### PR TITLE
Replace all mail-client references with mail-app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ tests/screenshots/
 # Dev mode data directory (isolated from production)
 .dev-data/
 
-# Private extensions and agents (copied in at build time by mail-client)
+# Private extensions and agents (copied in at build time by mail-app)
 src/extensions-private/
 src/agents-private/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Generally i will give one git worktree one branch to work with and itll be clear
 - When starting work in a new worktree, copy over any gitignored files needed from the main worktree (environment variables, local config, credentials, etc.).
 - Do NOT copy `.claude/` directory contents or `CLAUDE.md` — those are tracked by git and will already be in the worktree.
 - Do NOT use `git -C <path>` or `git -c` flags unnecessarily — you are already working inside the worktree, so just run git commands directly from the current directory.
-- **Worktree dev setup for this project**: The main worktree is at `/Users/ankit/src/mail-client/`. To run `npm run dev` with real accounts, copy these files from the main worktree:
+- **Worktree dev setup for this project**: The main worktree is at `/Users/ankit/src/mail-app/`. To run `npm run dev` with real accounts, copy these files from the main worktree:
   1. `.env` → needed at build time for `MAIN_VITE_GOOGLE_CLIENT_ID` / `MAIN_VITE_GOOGLE_CLIENT_SECRET` and `ANTHROPIC_API_KEY`
   2. `.dev-data/tokens*.json` → per-account OAuth tokens
   3. `.dev-data/exo-config.json` → app config (API keys, settings)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Automated email draft generator using Claude AI and Gmail",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ankitvgupta/mail-client.git"
+    "url": "https://github.com/ankitvgupta/mail-app.git"
   },
   "type": "module",
   "main": "./out/main/index.js",
@@ -135,7 +135,7 @@
     "publish": {
       "provider": "github",
       "owner": "ankitvgupta",
-      "repo": "mail-client",
+      "repo": "mail-app",
       "private": true
     },
     "directories": {

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -96,7 +96,7 @@ if (hasMainEntry) {
       `--outfile="${join(buildDir, "dist/main.js")}" ` +
       `--external:electron --external:better-sqlite3 ` +
       // Extension types are provided by the host app at runtime
-      `--alias:@mail-client/extension-types=@mail-client/extension-types ` +
+      `--alias:@mail-app/extension-types=@mail-app/extension-types ` +
       `--define:process.env.NODE_ENV='"production"'`,
       { stdio: "inherit", cwd: extPath }
     );

--- a/src/main/agents/providers/claude-agent-provider.ts
+++ b/src/main/agents/providers/claude-agent-provider.ts
@@ -63,7 +63,7 @@ export class ClaudeAgentProvider implements AgentProvider {
 
     // Create in-process MCP server with our tools
     const mcpServer = createSdkMcpServer({
-      name: "mail-client-tools",
+      name: "mail-app-tools",
       version: "1.0.0",
       tools: mcpTools,
     });
@@ -84,9 +84,9 @@ export class ClaudeAgentProvider implements AgentProvider {
     // Build MCP server map — always include our tool server,
     // conditionally include Chrome DevTools for browser automation
     const mcpServerMap: Record<string, McpServerConfig> = {
-      "mail-client-tools": mcpServer,
+      "mail-app-tools": mcpServer,
     };
-    const allowedToolPatterns = tools.map((t) => `mcp__mail-client-tools__${t.name}`);
+    const allowedToolPatterns = tools.map((t) => `mcp__mail-app-tools__${t.name}`);
 
     const browserConfig = this.frameworkConfig.browserConfig;
     if (browserConfig?.enabled) {
@@ -101,7 +101,7 @@ export class ClaudeAgentProvider implements AgentProvider {
     }
 
     // Add user-configured custom MCP servers
-    const reservedNames = new Set(["mail-client-tools", "chrome-devtools"]);
+    const reservedNames = new Set(["mail-app-tools", "chrome-devtools"]);
     // Prevent user env vars from overriding security-sensitive keys
     const protectedEnvKeys = new Set([
       "ANTHROPIC_API_KEY", "CLAUDECODE",
@@ -385,7 +385,7 @@ function buildMcpToolWithTracking(
 
 /**
  * Strip the MCP server prefix from a tool name.
- * "mcp__mail-client-tools__read_email" → "read_email"
+ * "mcp__mail-app-tools__read_email" → "read_email"
  */
 function baseToolName(name: string): string {
   if (name.startsWith("mcp__")) {

--- a/src/main/services/auto-updater.ts
+++ b/src/main/services/auto-updater.ts
@@ -99,7 +99,7 @@ class AutoUpdateService extends EventEmitter {
       autoUpdater.setFeedURL({
         provider: "github",
         owner: "ankitvgupta",
-        repo: "mail-client",
+        repo: "mail-app",
         private: true,
         token: process.env.GH_TOKEN || undefined,
       });

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -2282,7 +2282,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                           servers = obj;
                         }
 
-                        const reservedNames = new Set(["mail-client-tools", "chrome-devtools"]);
+                        const reservedNames = new Set(["mail-app-tools", "chrome-devtools"]);
                         const validated: Record<string, McpServerConfig> = {};
 
                         for (const [name, config] of Object.entries(servers)) {

--- a/tests/unit/db-isolation.spec.ts
+++ b/tests/unit/db-isolation.spec.ts
@@ -73,7 +73,7 @@ test.describe("Database isolation between demo and production modes", () => {
   });
 
   test.beforeAll(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "mail-client-db-test-"));
+    tmpDir = mkdtempSync(join(tmpdir(), "mail-app-db-test-"));
     prodDbPath = join(tmpDir, "exo.db");
     demoDbPath = join(tmpDir, "exo-demo.db");
   });

--- a/tests/workflow-tests.md
+++ b/tests/workflow-tests.md
@@ -3,7 +3,7 @@
 **Date**: 2026-02-10
 **App**: Exo (Electron + React + TypeScript)
 **Mode**: Demo mode (`EXO_DEMO_MODE=true`)
-**Branch**: `mail-client-testing`
+**Branch**: `mail-app-testing`
 
 ## Summary
 


### PR DESCRIPTION
## Summary
- The repo was renamed from `mail-client` to `mail-app` but references throughout the codebase still pointed to the old name
- This caused 404s on auto-update checks (`releases.atom` endpoint) and other GitHub API calls
- Replaced all `mail-client` references with `mail-app` across 9 files

## Changes
- **package.json**: repository URL and electron-builder publish config → `mail-app`
- **auto-updater.ts**: GitHub release feed URL repo → `mail-app`
- **claude-agent-provider.ts**: MCP server name `mail-client-tools` → `mail-app-tools` (5 occurrences)
- **SettingsPanel.tsx**: reserved MCP server name check → `mail-app-tools`
- **build-extension.mjs**: `@mail-client/extension-types` → `@mail-app/extension-types`
- **CLAUDE.md**: worktree path docs
- **.gitignore**: comment
- **tests/workflow-tests.md**: branch name reference
- **tests/unit/db-isolation.spec.ts**: temp dir prefix

Note: `gmail-client` references (module/file names for the Gmail API client wrapper) were intentionally left unchanged — they describe functionality, not the repo.

## Test plan
- [ ] Verify auto-updater no longer 404s by checking `releases.atom` endpoint resolves
- [ ] Verify MCP tool names use `mail-app-tools` prefix in agent sessions
- [ ] Verify extension build script resolves `@mail-app/extension-types` alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
