### PR TITLE
OpenClaw provider + update demo names

### DIFF
--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -182,6 +182,13 @@ export class AgentCoordinator {
         chromeProfilePath: browser.chromeProfilePath,
       } : undefined,
       mcpServers: appConfig.mcpServers,
+      providers: {
+        "openclaw-agent": {
+          enabled: appConfig.openclaw?.enabled ?? false,
+          gatewayUrl: appConfig.openclaw?.gatewayUrl ?? "",
+          gatewayToken: appConfig.openclaw?.gatewayToken ?? "",
+        },
+      },
     };
     this.workerReady = populatePrivateProviderConfig(baseConfig).then(
       (enrichedConfig) => { this.initWorker(enrichedConfig); },

--- a/src/main/agents/orchestrator.ts
+++ b/src/main/agents/orchestrator.ts
@@ -64,8 +64,8 @@ export class AgentOrchestrator {
     this.providerRegistry.register(
       new OpenClawAgentProvider({
         enabled: ocSettings?.enabled ?? false,
-        gatewayUrl: (ocSettings?.gatewayUrl as string) ?? "",
-        gatewayToken: (ocSettings?.gatewayToken as string) ?? "",
+        gatewayUrl: ocSettings?.gatewayUrl ?? "",
+        gatewayToken: ocSettings?.gatewayToken ?? "",
       }),
     );
 

--- a/src/main/agents/orchestrator.ts
+++ b/src/main/agents/orchestrator.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types";
 import { AgentProviderRegistry } from "./providers/registry";
 import { ClaudeAgentProvider } from "./providers/claude-agent-provider";
+import { OpenClawAgentProvider } from "./providers/openclaw/openclaw-agent-provider";
 import { PermissionGate } from "./permission-gate";
 import type { ToolRegistry } from "./tools/registry";
 import type { ProxyContext } from "./tools/types";
@@ -56,6 +57,16 @@ export class AgentOrchestrator {
     // Register the Claude provider by default
     this.providerRegistry.register(
       new ClaudeAgentProvider(deps.config),
+    );
+
+    // Register the OpenClaw provider
+    const ocSettings = deps.config.providers?.["openclaw-agent"];
+    this.providerRegistry.register(
+      new OpenClawAgentProvider({
+        enabled: ocSettings?.enabled ?? false,
+        gatewayUrl: (ocSettings?.gatewayUrl as string) ?? "",
+        gatewayToken: (ocSettings?.gatewayToken as string) ?? "",
+      }),
     );
 
     // Register any auto-discovered private providers

--- a/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
+++ b/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
@@ -12,7 +12,7 @@ import type {
 import type { OpenClawProviderConfig, OpenClawAgentResponse } from "./types";
 
 function isDemoMode(): boolean {
-  return process.env.GMAIL_DRAFTER_DEMO_MODE === "true";
+  return process.env.EXO_DEMO_MODE === "true";
 }
 
 const TIMEOUT_MS = 300_000;

--- a/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
+++ b/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
@@ -15,8 +15,8 @@ function isDemoMode(): boolean {
   return process.env.GMAIL_DRAFTER_DEMO_MODE === "true";
 }
 
-const TIMEOUT_MS = 60_000;
-const SLOW_WARNING_MS = 15_000;
+const TIMEOUT_MS = 300_000;
+const SLOW_WARNING_MS = 30_000;
 
 /**
  * Demo mode canned responses, rotated by a hash of the query string.

--- a/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
+++ b/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
@@ -9,7 +9,8 @@ import type {
   AgentEvent,
   SubAgentToolConfig,
 } from "../../types";
-import type { OpenClawProviderConfig, OpenClawAgentResponse } from "./types";
+import type { OpenClawProviderConfig } from "./types";
+import { OpenClawAgentResponseSchema } from "./types";
 
 function isDemoMode(): boolean {
   return process.env.EXO_DEMO_MODE === "true";
@@ -99,24 +100,27 @@ export function execOpenClaw(
         }
 
         // Parse JSON output to extract the response text
-        try {
-          const data = JSON.parse(stdout) as OpenClawAgentResponse;
-          if (data.status !== "ok") {
-            reject(new Error(`OpenClaw: Agent returned status "${data.status}" — ${data.summary ?? "unknown error"}`));
-            return;
-          }
-          const text = data.result?.payloads
-            ?.map((p) => p.text)
-            .filter(Boolean)
-            .join("\n");
-          if (text) {
-            resolve(text);
-          } else {
-            resolve(stdout);
-          }
-        } catch {
-          // If not JSON, return raw stdout (might be plain text response)
+        const parsed = OpenClawAgentResponseSchema.safeParse(
+          (() => { try { return JSON.parse(stdout); } catch { return null; } })(),
+        );
+        if (!parsed.success) {
+          // Not valid JSON or doesn't match schema — return raw stdout
           resolve(stdout.trim() || "No response from OpenClaw");
+          return;
+        }
+        const data = parsed.data;
+        if (data.status !== "ok") {
+          reject(new Error(`OpenClaw: Agent returned status "${data.status}" — ${data.summary ?? "unknown error"}`));
+          return;
+        }
+        const text = data.result?.payloads
+          ?.map((p) => p.text)
+          .filter(Boolean)
+          .join("\n");
+        if (text) {
+          resolve(text);
+        } else {
+          resolve(stdout);
         }
       },
     );
@@ -180,7 +184,7 @@ export class OpenClawAgentProvider implements AgentProvider {
     params.signal.addEventListener("abort", onParentAbort, { once: true });
 
     try {
-      // Race a 15s slow-warning timer against the CLI call so the warning
+      // Race a 30s slow-warning timer against the CLI call so the warning
       // is yielded while the CLI is still running (not after it finishes).
       const slowWarning = Symbol("slow");
       const cliPromise = this.queryOpenClaw(params.prompt, controller.signal);

--- a/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
+++ b/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
@@ -60,12 +60,21 @@ export function execOpenClaw(
       slowTimer = setTimeout(onSlow, SLOW_WARNING_MS);
     }
 
-    const child = execFile(
+    // Define onAbort early so execFile callback can remove it on completion
+    let child: ReturnType<typeof execFile>;
+    const onAbort = () => {
+      if (slowTimer) clearTimeout(slowTimer);
+      child?.kill("SIGTERM");
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    child = execFile(
       "openclaw",
       ["agent", "--agent", "main", "--message", message, "--json"],
       { timeout: TIMEOUT_MS, env: { ...process.env, NO_COLOR: "1", ...extraEnv } },
       (error, stdout, stderr) => {
         if (slowTimer) clearTimeout(slowTimer);
+        signal.removeEventListener("abort", onAbort);
 
         if (signal.aborted) {
           reject(new Error("Request cancelled"));
@@ -82,7 +91,7 @@ export function execOpenClaw(
             return;
           }
           if (error.killed || combined.includes("ETIMEDOUT")) {
-            reject(new Error("OpenClaw: Request timed out after 60s"));
+            reject(new Error("OpenClaw: Request timed out after 5m"));
             return;
           }
           reject(new Error(`OpenClaw: ${error.message}`));
@@ -111,13 +120,6 @@ export function execOpenClaw(
         }
       },
     );
-
-    // Kill child process on abort
-    const onAbort = () => {
-      if (slowTimer) clearTimeout(slowTimer);
-      child.kill("SIGTERM");
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
   });
 }
 

--- a/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
+++ b/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
@@ -120,7 +120,7 @@ export function execOpenClaw(
         if (text) {
           resolve(text);
         } else {
-          resolve(stdout);
+          resolve(data.summary || stdout.trim() || "No response from OpenClaw");
         }
       },
     );

--- a/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
+++ b/src/main/agents/providers/openclaw/openclaw-agent-provider.ts
@@ -1,0 +1,274 @@
+import { z } from "zod";
+import { execFile } from "node:child_process";
+import type {
+  AgentFrameworkConfig,
+  AgentProvider,
+  AgentProviderConfig,
+  AgentRunParams,
+  AgentRunResult,
+  AgentEvent,
+  SubAgentToolConfig,
+} from "../../types";
+import type { OpenClawProviderConfig, OpenClawAgentResponse } from "./types";
+
+function isDemoMode(): boolean {
+  return process.env.GMAIL_DRAFTER_DEMO_MODE === "true";
+}
+
+const TIMEOUT_MS = 60_000;
+const SLOW_WARNING_MS = 15_000;
+
+/**
+ * Demo mode canned responses, rotated by a hash of the query string.
+ */
+const DEMO_RESPONSES = [
+  `Sarah Chen is a General Partner at Sequoia Capital, where she's been since 2021. She led their Series A investment in Retool and sits on the boards of Notion and Linear. Previously, she was VP of Product at Stripe (2016-2021) where she built Stripe Atlas. Stanford CS undergrad, Harvard MBA. She's been actively tweeting about AI infrastructure plays and spoke at the All-In Summit last month about "why developer tools are underpriced." Her fund just closed a new $2.5B early-stage vehicle. She typically responds within 24 hours and prefers concise, data-driven pitches.`,
+
+  `Marcus Rodriguez is the co-founder and CEO of Athena Labs, a Series B climate tech startup ($45M raised, led by a16z). They're building carbon capture monitoring software used by 12 Fortune 500 companies. He was previously a senior engineer at SpaceX (propulsion team, 2015-2020) and holds 3 patents in sensor fusion. Athena was in YC W21. Their last quarterly revenue was ~$3.2M ARR, growing 15% month-over-month. He's hiring aggressively — 8 open engineering roles. He's known for extremely detailed technical emails and expects the same in replies.`,
+
+  `Jennifer Park is the CTO of Meridian Health Systems, a $4B healthcare company with 15,000 employees across 200 locations. She joined from Google Cloud (VP of Healthcare & Life Sciences) in 2023. Her current focus is migrating Meridian's EHR infrastructure to a hybrid cloud setup — they're evaluating vendors now with a Q3 decision deadline. She reports to CEO David Kim and manages a 400-person engineering org. She's methodical, prefers structured proposals with timelines, and typically involves her VP of Infrastructure (Tom Walsh) in technical decisions.`,
+
+  `Alex Nakamura is a Staff Engineer at Vercel, working on the Edge Runtime team. He previously built internal developer tools at Netflix (2018-2022) and contributed to several popular open source projects including SWR and Turbopack. He maintains a well-read technical blog (alexnak.dev) where his recent post on "Edge Computing Tradeoffs in 2026" got significant traction on Hacker News. He's based in San Francisco, active in the local TypeScript meetup scene, and known for giving thoughtful, detailed code reviews. He usually responds to emails within a few days.`,
+];
+
+export function getDemoResponse(query: string): string {
+  let hash = 0;
+  for (let i = 0; i < query.length; i++) {
+    hash = ((hash << 5) - hash + query.charCodeAt(i)) | 0;
+  }
+  return DEMO_RESPONSES[Math.abs(hash) % DEMO_RESPONSES.length];
+}
+
+/**
+ * Execute `openclaw agent` CLI and return the response text.
+ * OpenClaw's gateway is WebSocket-based, so we shell out to the CLI
+ * which handles the WS protocol and returns JSON with --json flag.
+ *
+ * Calls `onSlow` after SLOW_WARNING_MS if the response hasn't arrived yet,
+ * so the caller can yield a "taking longer than expected" event.
+ */
+export function execOpenClaw(
+  message: string,
+  signal: AbortSignal,
+  onSlow?: () => void,
+  extraEnv?: Record<string, string>,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let slowTimer: ReturnType<typeof setTimeout> | null = null;
+
+    if (onSlow) {
+      slowTimer = setTimeout(onSlow, SLOW_WARNING_MS);
+    }
+
+    const child = execFile(
+      "openclaw",
+      ["agent", "--agent", "main", "--message", message, "--json"],
+      { timeout: TIMEOUT_MS, env: { ...process.env, NO_COLOR: "1", ...extraEnv } },
+      (error, stdout, stderr) => {
+        if (slowTimer) clearTimeout(slowTimer);
+
+        if (signal.aborted) {
+          reject(new Error("Request cancelled"));
+          return;
+        }
+        if (error) {
+          const combined = (stderr || "") + (stdout || "");
+          if (combined.includes("No API key")) {
+            reject(new Error("OpenClaw: No API key configured — run `openclaw configure` to set up credentials"));
+            return;
+          }
+          if (combined.includes("ECONNREFUSED") || combined.includes("not reachable") || combined.includes("gateway")) {
+            reject(new Error("OpenClaw: Gateway not running — start it with `openclaw gateway run`"));
+            return;
+          }
+          if (error.killed || combined.includes("ETIMEDOUT")) {
+            reject(new Error("OpenClaw: Request timed out after 60s"));
+            return;
+          }
+          reject(new Error(`OpenClaw: ${error.message}`));
+          return;
+        }
+
+        // Parse JSON output to extract the response text
+        try {
+          const data = JSON.parse(stdout) as OpenClawAgentResponse;
+          if (data.status !== "ok") {
+            reject(new Error(`OpenClaw: Agent returned status "${data.status}" — ${data.summary ?? "unknown error"}`));
+            return;
+          }
+          const text = data.result?.payloads
+            ?.map((p) => p.text)
+            .filter(Boolean)
+            .join("\n");
+          if (text) {
+            resolve(text);
+          } else {
+            resolve(stdout);
+          }
+        } catch {
+          // If not JSON, return raw stdout (might be plain text response)
+          resolve(stdout.trim() || "No response from OpenClaw");
+        }
+      },
+    );
+
+    // Kill child process on abort
+    const onAbort = () => {
+      if (slowTimer) clearTimeout(slowTimer);
+      child.kill("SIGTERM");
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * OpenClaw Agent Provider — connects to a local OpenClaw instance.
+ *
+ * OpenClaw's gateway uses WebSocket, not HTTP REST. This provider shells
+ * out to `openclaw agent --message "..." --json` which handles the WS
+ * protocol and returns structured JSON.
+ *
+ * The user enables OpenClaw in Settings → Integrations. The actual queries
+ * go through the CLI which reads its own config from ~/.openclaw/.
+ *
+ * The installed OpenClaw is local, not connected to the public internet,
+ * and has no tools or file access — it's just a chatbot.
+ */
+export class OpenClawAgentProvider implements AgentProvider {
+  readonly config: AgentProviderConfig = {
+    id: "openclaw-agent",
+    name: "OpenClaw Agent",
+    description: "Local OpenClaw agent for enrichment and context",
+    auth: { type: "api_key", configKey: "OPENCLAW_AUTH_TOKEN" },
+  };
+
+  private enabled: boolean;
+  private gatewayUrl: string;
+  private gatewayToken: string;
+  private inFlight = new Map<string, AbortController>();
+
+  constructor(cfg: OpenClawProviderConfig) {
+    this.enabled = cfg.enabled;
+    this.gatewayUrl = cfg.gatewayUrl ?? "";
+    this.gatewayToken = cfg.gatewayToken ?? "";
+  }
+
+  updateConfig(config: Partial<AgentFrameworkConfig>): void {
+    const oc = config.providers?.["openclaw-agent"];
+    if (oc) {
+      if ("enabled" in oc) this.enabled = Boolean(oc.enabled);
+      if ("gatewayUrl" in oc) this.gatewayUrl = String(oc.gatewayUrl ?? "");
+      if ("gatewayToken" in oc) this.gatewayToken = String(oc.gatewayToken ?? "");
+    }
+  }
+
+  async *run(params: AgentRunParams): AsyncGenerator<AgentEvent, AgentRunResult, void> {
+    if (!this.enabled && !isDemoMode()) {
+      yield { type: "error", message: "OPENCLAW_NOT_CONFIGURED" };
+      return { state: "failed" };
+    }
+
+    yield { type: "state", state: "running" };
+
+    // Create our own controller so cancel() can abort the CLI process.
+    // Also listen to the caller's signal so external cancellation works too.
+    const controller = new AbortController();
+    this.inFlight.set(params.taskId, controller);
+    const onParentAbort = () => controller.abort();
+    params.signal.addEventListener("abort", onParentAbort, { once: true });
+
+    try {
+      // Race a 15s slow-warning timer against the CLI call so the warning
+      // is yielded while the CLI is still running (not after it finishes).
+      const slowWarning = Symbol("slow");
+      const cliPromise = this.queryOpenClaw(params.prompt, controller.signal);
+      const timerPromise = new Promise<typeof slowWarning>((resolve) => {
+        const id = setTimeout(() => resolve(slowWarning), SLOW_WARNING_MS);
+        // If CLI finishes first (success or failure), cancel the timer.
+        // Use .then(fn, fn) instead of .finally() to avoid dangling unhandled rejections.
+        cliPromise.then(() => clearTimeout(id), () => clearTimeout(id));
+      });
+
+      let response: string;
+      const first = await Promise.race([cliPromise, timerPromise]);
+      if (first === slowWarning) {
+        yield { type: "text_delta", text: "\n⏳ OpenClaw is taking longer than expected...\n" };
+        response = await cliPromise;
+      } else {
+        response = first;
+      }
+
+      yield { type: "text_delta", text: response };
+      yield { type: "done", summary: "OpenClaw query completed" };
+      return { state: "completed" };
+    } catch (err) {
+      if (controller.signal.aborted || params.signal.aborted) {
+        yield { type: "state", state: "cancelled" };
+        return { state: "cancelled" };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      yield { type: "error", message: msg };
+      return { state: "failed" };
+    } finally {
+      params.signal.removeEventListener("abort", onParentAbort);
+      this.inFlight.delete(params.taskId);
+    }
+  }
+
+  cancel(taskId: string): void {
+    const controller = this.inFlight.get(taskId);
+    if (controller) {
+      controller.abort();
+      this.inFlight.delete(taskId);
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (isDemoMode()) return true;
+    return this.enabled;
+  }
+
+  asSubAgentTool(): SubAgentToolConfig | null {
+    if (!this.enabled && !isDemoMode()) return null;
+
+    return {
+      name: "ask_openclaw",
+      description:
+        "Query your local OpenClaw agent for context about a person, company, or topic. OpenClaw is a local AI assistant — it draws on its own knowledge to answer. Use this when you need more information about an email sender or topic to write a better response.",
+      systemPromptGuidance: `You have access to the ask_openclaw tool which queries a local OpenClaw agent. OpenClaw is a standalone AI chatbot running locally — it has no internet access or tools, so it answers from its own knowledge. Use it when:
+- You need background on an email sender (role, company, recent activity)
+- You want context about a company or organization mentioned in an email
+- The user asks you to look something up or get more context
+- You're drafting a reply and would benefit from knowing more about the recipient
+
+Pass a natural language question as the 'query' parameter. Be specific about what you want to know. Note that OpenClaw's knowledge may not be current — it's useful for general context but treat specific claims as approximate.`,
+      inputSchema: z.object({
+        query: z.string().describe("The question to ask OpenClaw"),
+        conversation_id: z
+          .string()
+          .optional()
+          .describe("Not used by OpenClaw — included for interface compatibility"),
+      }),
+    };
+  }
+
+  // --- Private ---
+
+  private async queryOpenClaw(
+    query: string,
+    signal: AbortSignal,
+  ): Promise<string> {
+    // Use canned responses only in demo mode when OpenClaw is NOT enabled.
+    // When the user has explicitly enabled OpenClaw, always use the real CLI
+    // even in demo mode — this allows testing the real integration with mock Gmail data.
+    if (isDemoMode() && !this.enabled) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      return getDemoResponse(query);
+    }
+
+    const env: Record<string, string> = {};
+    if (this.gatewayUrl) env.OPENCLAW_GATEWAY_URL = this.gatewayUrl;
+    if (this.gatewayToken) env.OPENCLAW_GATEWAY_TOKEN = this.gatewayToken;
+    return execOpenClaw(query, signal, undefined, env);
+  }
+}

--- a/src/main/agents/providers/openclaw/types.ts
+++ b/src/main/agents/providers/openclaw/types.ts
@@ -5,6 +5,8 @@
  * These types model both the provider configuration and the CLI output shape.
  */
 
+import { z } from "zod";
+
 // --- Provider configuration (passed from settings) ---
 
 export interface OpenClawProviderConfig {
@@ -15,30 +17,32 @@ export interface OpenClawProviderConfig {
 
 // --- CLI response shape (`openclaw agent --json`) ---
 
-export interface OpenClawAgentPayload {
-  text: string | null;
-  mediaUrl: string | null;
-}
+const OpenClawAgentPayloadSchema = z.object({
+  text: z.string().nullable(),
+  mediaUrl: z.string().nullable(),
+});
 
-export interface OpenClawAgentResult {
-  payloads?: OpenClawAgentPayload[];
-  meta?: {
-    durationMs: number;
-    agentMeta?: {
-      sessionId: string;
-      provider: string;
-      model: string;
-      usage?: {
-        input: number;
-        output: number;
-      };
-    };
-  };
-}
+const OpenClawAgentResultSchema = z.object({
+  payloads: z.array(OpenClawAgentPayloadSchema).optional(),
+  meta: z.object({
+    durationMs: z.number(),
+    agentMeta: z.object({
+      sessionId: z.string(),
+      provider: z.string(),
+      model: z.string(),
+      usage: z.object({
+        input: z.number(),
+        output: z.number(),
+      }).optional(),
+    }).optional(),
+  }).optional(),
+});
 
-export interface OpenClawAgentResponse {
-  runId: string;
-  status: "ok" | "error" | string;
-  summary: string;
-  result?: OpenClawAgentResult;
-}
+export const OpenClawAgentResponseSchema = z.object({
+  runId: z.string(),
+  status: z.string(),
+  summary: z.string(),
+  result: OpenClawAgentResultSchema.optional(),
+});
+
+export type OpenClawAgentResponse = z.infer<typeof OpenClawAgentResponseSchema>;

--- a/src/main/agents/providers/openclaw/types.ts
+++ b/src/main/agents/providers/openclaw/types.ts
@@ -1,0 +1,44 @@
+/**
+ * OpenClaw agent provider types.
+ *
+ * OpenClaw CLI (`openclaw agent --json`) returns a structured JSON response.
+ * These types model both the provider configuration and the CLI output shape.
+ */
+
+// --- Provider configuration (passed from settings) ---
+
+export interface OpenClawProviderConfig {
+  enabled: boolean;
+  gatewayUrl?: string;
+  gatewayToken?: string;
+}
+
+// --- CLI response shape (`openclaw agent --json`) ---
+
+export interface OpenClawAgentPayload {
+  text: string | null;
+  mediaUrl: string | null;
+}
+
+export interface OpenClawAgentResult {
+  payloads?: OpenClawAgentPayload[];
+  meta?: {
+    durationMs: number;
+    agentMeta?: {
+      sessionId: string;
+      provider: string;
+      model: string;
+      usage?: {
+        input: number;
+        output: number;
+      };
+    };
+  };
+}
+
+export interface OpenClawAgentResponse {
+  runId: string;
+  status: "ok" | "error" | string;
+  summary: string;
+  result?: OpenClawAgentResult;
+}

--- a/src/main/demo/fake-inbox.ts
+++ b/src/main/demo/fake-inbox.ts
@@ -50,7 +50,7 @@ const RICH_HTML_EMAIL_BODY = `<html>
 
     <div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid #ddd;">
       <p style="margin: 0;">Best regards,</p>
-      <p style="margin: 4px 0; font-weight: bold;">Emily Watson</p>
+      <p style="margin: 4px 0; font-weight: bold;">Garry Tan</p>
       <p style="margin: 0; color: #666; font-size: 12px;">Head of Analytics | TechCorp Inc.</p>
       <img src="https://via.placeholder.com/100x30?text=TechCorp" alt="TechCorp Logo" style="margin-top: 8px;">
     </div>
@@ -81,7 +81,7 @@ const INLINE_IMAGE_EMAIL_BODY = `<html>
 
     <div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid #ddd;">
       <p style="margin: 0;">Cheers,</p>
-      <p style="margin: 4px 0; font-weight: bold;">Rachel Lee</p>
+      <p style="margin: 4px 0; font-weight: bold;">Surbhi Sarna</p>
       <p style="margin: 0; color: #666; font-size: 12px;">Senior Designer | CreativeStudio</p>
     </div>
   </div>
@@ -94,7 +94,7 @@ export const DEMO_INBOX_EMAILS: Email[] = [
     id: "demo-html-001",
     threadId: "thread-html-report",
     subject: "Q3 Quarterly Report - Action Required",
-    from: "Emily Watson <emily.watson@techcorp.com>",
+    from: "Garry Tan <garry.tan@techcorp.com>",
     to: "me@example.com",
     date: new Date(now - 15 * 60 * 1000).toISOString(), // 15 mins ago (shows first)
     body: RICH_HTML_EMAIL_BODY,
@@ -129,7 +129,7 @@ export const DEMO_INBOX_EMAILS: Email[] = [
     id: "demo-001",
     threadId: "thread-project-alpha",
     subject: "Project Alpha - Timeline Discussion",
-    from: "Sarah Chen <sarah.chen@acmecorp.com>",
+    from: "Jared Friedman <jared.friedman@acmecorp.com>",
     to: "me@example.com",
     date: new Date(now - 2 * day).toISOString(),
     body: `Hi,
@@ -144,42 +144,42 @@ Key milestones:
 Can you review and let me know if this aligns with your expectations?
 
 Thanks,
-Sarah`,
+Jared`,
     snippet: "I wanted to kick off the discussion about Project Alpha's timeline...",
   },
   {
     id: "demo-002",
     threadId: "thread-project-alpha",
     subject: "Re: Project Alpha - Timeline Discussion",
-    from: "Mike Johnson <mike.j@acmecorp.com>",
-    to: "me@example.com, sarah.chen@acmecorp.com",
+    from: "Michael Seibel <michael.s@acmecorp.com>",
+    to: "me@example.com, jared.friedman@acmecorp.com",
     cc: "engineering-leads@acmecorp.com",
     date: new Date(now - 1.5 * day).toISOString(),
-    body: `Sarah, team,
+    body: `Jared, team,
 
 The timeline looks reasonable. I'd suggest we add a buffer week for unexpected issues - we've learned from past projects that 6 weeks often turns into 7-8.
 
 Also, should we schedule a kickoff meeting for Monday?
 
-Mike`,
+Michael`,
     snippet: "The timeline looks reasonable. I'd suggest we add a buffer week...",
   },
   {
     id: "demo-003",
     threadId: "thread-project-alpha",
     subject: "Re: Project Alpha - Timeline Discussion",
-    from: "Sarah Chen <sarah.chen@acmecorp.com>",
-    to: "me@example.com, mike.j@acmecorp.com",
+    from: "Jared Friedman <jared.friedman@acmecorp.com>",
+    to: "me@example.com, michael.s@acmecorp.com",
     cc: "engineering-leads@acmecorp.com, product-team@acmecorp.com",
     date: new Date(now - 1 * hour).toISOString(),
-    body: `Good point Mike. Let's plan for 7 weeks then.
+    body: `Good point Michael. Let's plan for 7 weeks then.
 
 @me - can you confirm your availability for a Monday kickoff? I'm thinking 10am PT works for everyone.
 
 Also, we'll need your input on the technical architecture decisions before we finalize the design phase.
 
-Sarah`,
-    snippet: "Good point Mike. Let's plan for 7 weeks then. Can you confirm your availability...",
+Jared`,
+    snippet: "Good point Michael. Let's plan for 7 weeks then. Can you confirm your availability...",
   },
 
   // Thread 2: API question (single email, needs reply)
@@ -187,7 +187,7 @@ Sarah`,
     id: "demo-004",
     threadId: "thread-api-question",
     subject: "Quick question about API rate limits",
-    from: "Alex Rodriguez <alex.r@startup.io>",
+    from: "Gustaf Alströmer <gustaf.a@startup.io>",
     to: "me@example.com",
     date: new Date(now - 3 * hour).toISOString(),
     body: `Hey!
@@ -202,7 +202,7 @@ Questions:
 We're planning to go live next week, so any guidance would be super helpful!
 
 Thanks,
-Alex`,
+Gustaf`,
     snippet: "We're integrating with your API and running into rate limiting issues...",
   },
 
@@ -211,7 +211,7 @@ Alex`,
     id: "demo-005",
     threadId: "thread-q4-planning",
     subject: "Meeting Follow-up: Q4 Planning - Action Items",
-    from: "Jennifer Park <j.park@techcorp.com>",
+    from: "Diana Hu <d.hu@techcorp.com>",
     to: "me@example.com",
     date: new Date(now - 30 * 60 * 1000).toISOString(), // 30 mins ago
     body: `Hi,
@@ -228,7 +228,7 @@ I've attached the spreadsheet with the detailed breakdown. Let me know if you ha
 Can we schedule a quick sync tomorrow to finalize before the exec review?
 
 Best,
-Jennifer`,
+Diana`,
     snippet: "Great discussion in today's Q4 planning meeting! Action items for you...",
   },
 
@@ -367,7 +367,7 @@ HR Team`,
     id: "demo-010",
     threadId: "thread-lunch",
     subject: "Lunch this week?",
-    from: "David Kim <david.kim@gmail.com>",
+    from: "Tom Blomfield <tom.blomfield@gmail.com>",
     to: "me@example.com",
     date: new Date(now - 1 * day).toISOString(),
     body: `Hey!
@@ -377,7 +377,7 @@ It's been a while since we caught up. Want to grab lunch this week? I'm free Thu
 There's a new ramen place downtown that got great reviews - we could check it out.
 
 Let me know!
-David`,
+Tom`,
     snippet: "It's been a while since we caught up. Want to grab lunch this week?",
   },
 
@@ -389,15 +389,15 @@ David`,
     from: "Google Calendar <calendar-notification@google.com>",
     to: "me@example.com",
     date: new Date(now - 12 * hour).toISOString(),
-    body: `Sarah Chen has accepted this invitation.
+    body: `Jared Friedman has accepted this invitation.
 
 Weekly Team Sync
 When: Monday, January 27, 2025 10:00am - 11:00am PT
 Where: Conference Room A / Zoom
 
-Going: sarah.chen@acmecorp.com
-Awaiting: mike.j@acmecorp.com, you`,
-    snippet: "Sarah Chen has accepted this invitation. Weekly Team Sync...",
+Going: jared.friedman@acmecorp.com
+Awaiting: michael.s@acmecorp.com, you`,
+    snippet: "Jared Friedman has accepted this invitation. Weekly Team Sync...",
   },
 
   // Thread 5: Bug report (needs reply, high priority)
@@ -436,7 +436,7 @@ On-Call Team`,
     id: "demo-meeting",
     threadId: "thread-meeting-request",
     subject: "Coffee chat to discuss partnership opportunity",
-    from: "Lisa Thompson <lisa.t@partnerco.com>",
+    from: "Kat Mañalac <kat.m@partnerco.com>",
     to: "me@example.com",
     date: new Date(now - 4 * hour).toISOString(),
     body: `Hi,
@@ -450,7 +450,7 @@ Would you have 30 minutes sometime next week for a quick call? I'm flexible with
 Looking forward to connecting!
 
 Best regards,
-Lisa Thompson
+Kat Mañalac
 Head of Business Development
 PartnerCo`,
     snippet: "I'd love to schedule a call to discuss potential partnership opportunities...",
@@ -461,7 +461,7 @@ PartnerCo`,
     id: "demo-inline-images",
     threadId: "thread-inline-images",
     subject: "Landing Page Mockups - Inline Images",
-    from: "Rachel Lee <rachel.lee@creativestudio.com>",
+    from: "Surbhi Sarna <surbhi.sarna@creativestudio.com>",
     to: "me@example.com",
     date: new Date(now - 3 * hour).toISOString(),
     body: INLINE_IMAGE_EMAIL_BODY,
@@ -474,9 +474,9 @@ PartnerCo`,
     threadId: "thread-project-alpha",
     subject: "Re: Project Alpha - Timeline Discussion",
     from: "me@example.com",
-    to: "sarah.chen@acmecorp.com, mike.j@acmecorp.com",
+    to: "jared.friedman@acmecorp.com, michael.s@acmecorp.com",
     date: new Date(now - 25 * 60 * 1000).toISOString(), // 25 mins ago
-    body: `Sarah, Mike,
+    body: `Jared, Michael,
 
 Monday at 10am PT works perfectly for the kickoff. I'll have my calendar blocked.
 
@@ -492,28 +492,28 @@ Talk soon!`,
     labelIds: ["SENT"],
   },
 
-  // === STYLE TESTING: Casual contact (Jake Torres) ===
-  // Inbox email from Jake that needs a reply
+  // === STYLE TESTING: Casual contact (Dalton Caldwell) ===
+  // Inbox email from Dalton that needs a reply
   {
     id: "demo-casual-inbox",
-    threadId: "thread-casual-jake-11",
+    threadId: "thread-casual-dalton-11",
     subject: "friday?",
-    from: "Jake Torres <jake.torres@gmail.com>",
+    from: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     to: "me@example.com",
     date: new Date(now - 2 * hour).toISOString(),
     body: `yo you free friday? was thinking we grab tacos at that new spot on valencia
 
-jake`,
+dalton`,
     snippet: "yo you free friday? was thinking we grab tacos...",
   },
 
-  // === STYLE TESTING: Formal contact (Dr. Margaret Chen) ===
-  // Inbox email from Dr. Chen that needs a reply
+  // === STYLE TESTING: Formal contact (Dr. Geoff Ralston) ===
+  // Inbox email from Dr. Ralston that needs a reply
   {
     id: "demo-formal-inbox",
-    threadId: "thread-formal-margaret-11",
+    threadId: "thread-formal-geoff-11",
     subject: "Request for Strategic Advisory Input - FY2026 Planning",
-    from: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    from: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     to: "me@example.com",
     date: new Date(now - 3 * hour).toISOString(),
     body: `Dear Colleague,
@@ -531,7 +531,7 @@ I have attached a preliminary briefing document for your review. I would be most
 Please do not hesitate to reach out if you require any additional context or supporting documentation.
 
 With kind regards,
-Dr. Margaret Chen
+Dr. Geoff Ralston
 Managing Partner
 Whitfield & Partners`,
     snippet: "I am writing to request your input on several strategic matters...",
@@ -542,7 +542,7 @@ Whitfield & Partners`,
     id: "demo-multi-001",
     threadId: "thread-multi-sender",
     subject: "Launch Readiness Review - v2.0 Release",
-    from: "Priya Sharma <priya.sharma@acmecorp.com>",
+    from: "Nicolas Dessaigne <nicolas.d@acmecorp.com>",
     to: "me@example.com, team@acmecorp.com",
     date: new Date(now - 3 * day).toISOString(),
     body: `Hi everyone,
@@ -556,31 +556,31 @@ I'd like to kick off the launch readiness review for v2.0. Here's what we need t
 Can each of you confirm your area is on track?
 
 Thanks,
-Priya`,
+Nicolas`,
     snippet: "I'd like to kick off the launch readiness review for v2.0...",
   },
   {
     id: "demo-multi-002",
     threadId: "thread-multi-sender",
     subject: "Re: Launch Readiness Review - v2.0 Release",
-    from: "Carlos Mendez <carlos.mendez@acmecorp.com>",
-    to: "me@example.com, priya.sharma@acmecorp.com, team@acmecorp.com",
+    from: "Pete Koomen <pete.koomen@acmecorp.com>",
+    to: "me@example.com, nicolas.d@acmecorp.com, team@acmecorp.com",
     date: new Date(now - 2.8 * day).toISOString(),
-    body: `Priya,
+    body: `Nicolas,
 
 Backend is in good shape. All API endpoints are finalized and load-tested. One concern: the new search indexing needs another round of performance tuning before we can handle production traffic.
 
 I'll have an update by Thursday.
 
-Carlos`,
+Pete`,
     snippet: "Backend is in good shape. All API endpoints are finalized...",
   },
   {
     id: "demo-multi-003",
     threadId: "thread-multi-sender",
     subject: "Re: Launch Readiness Review - v2.0 Release",
-    from: "Nina Okafor <nina.okafor@acmecorp.com>",
-    to: "me@example.com, priya.sharma@acmecorp.com, team@acmecorp.com",
+    from: "Aaron Epstein <aaron.epstein@acmecorp.com>",
+    to: "me@example.com, nicolas.d@acmecorp.com, team@acmecorp.com",
     date: new Date(now - 2.5 * day).toISOString(),
     body: `Team,
 
@@ -588,33 +588,33 @@ Design is ready. All screens have been finalized and handed off to engineering. 
 
 One thing to flag: we still need final copy for the onboarding tooltips. @me - can you review the draft copy I sent last week?
 
-Nina`,
+Aaron`,
     snippet: "Design is ready. All screens have been finalized...",
   },
   {
     id: "demo-multi-004",
     threadId: "thread-multi-sender",
     subject: "Re: Launch Readiness Review - v2.0 Release",
-    from: "Tom Bradley <tom.bradley@acmecorp.com>",
-    to: "me@example.com, priya.sharma@acmecorp.com, team@acmecorp.com",
+    from: "Brad Flora <brad.flora@acmecorp.com>",
+    to: "me@example.com, nicolas.d@acmecorp.com, team@acmecorp.com",
     date: new Date(now - 2 * day).toISOString(),
     body: `All,
 
-QA is tracking 3 P1 bugs and 12 P2s. The P1s are all in the checkout flow - Carlos, can you prioritize those?
+QA is tracking 3 P1 bugs and 12 P2s. The P1s are all in the checkout flow - Pete, can you prioritize those?
 
 Test coverage is at 87% which is above our 85% threshold. Automated regression suite passes on staging.
 
 I'll share the full QA report tomorrow.
 
-Tom`,
+Brad`,
     snippet: "QA is tracking 3 P1 bugs and 12 P2s...",
   },
   {
     id: "demo-multi-005",
     threadId: "thread-multi-sender",
     subject: "Re: Launch Readiness Review - v2.0 Release",
-    from: "Aisha Patel <aisha.patel@acmecorp.com>",
-    to: "me@example.com, priya.sharma@acmecorp.com, team@acmecorp.com",
+    from: "Harj Taggar <harj.taggar@acmecorp.com>",
+    to: "me@example.com, nicolas.d@acmecorp.com, team@acmecorp.com",
     date: new Date(now - 1.5 * day).toISOString(),
     body: `Hi all,
 
@@ -623,27 +623,27 @@ Marketing is almost there. Press release is drafted, social media campaign is sc
 We need the final release notes from engineering to complete the changelog page. @me - also wanted to confirm: are we doing the launch webinar on Thursday or Friday?
 
 Best,
-Aisha`,
+Harj`,
     snippet: "Marketing is almost there. Press release is drafted...",
   },
   {
     id: "demo-multi-006",
     threadId: "thread-multi-sender",
     subject: "Re: Launch Readiness Review - v2.0 Release",
-    from: "Priya Sharma <priya.sharma@acmecorp.com>",
+    from: "Nicolas Dessaigne <nicolas.d@acmecorp.com>",
     to: "me@example.com, team@acmecorp.com",
     date: new Date(now - 6 * hour).toISOString(),
     body: `Team,
 
 Thanks for the updates. Quick summary:
-- Backend: on track, search perf needs work (Carlos)
-- Design: done, waiting on tooltip copy (Nina)
-- QA: 3 P1s to fix, overall good (Tom)
-- Marketing: nearly ready, needs release notes (Aisha)
+- Backend: on track, search perf needs work (Pete)
+- Design: done, waiting on tooltip copy (Aaron)
+- QA: 3 P1s to fix, overall good (Brad)
+- Marketing: nearly ready, needs release notes (Harj)
 
 @me - we need your input on the tooltip copy, release notes, and webinar date. Can you respond by EOD?
 
-Priya`,
+Nicolas`,
     snippet: "Thanks for the updates. We need your input on tooltip copy...",
   },
 
@@ -711,7 +711,7 @@ Priya`,
     id: "demo-ea-sched-001",
     threadId: "thread-ea-scheduling",
     subject: "Meeting to discuss partnership — finding a time",
-    from: "Tom Nguyen <tom.nguyen@partnerco.io>",
+    from: "David Lieb <david.lieb@partnerco.io>",
     to: "Ankit <ankit@example.com>",
     date: new Date(now - 2 * day - 4 * hour).toISOString(),
     body: `Hi Ankit,
@@ -721,7 +721,7 @@ Great chatting at the conference last week! I'd love to set up a 30-minute call 
 Do you have any availability next week? Happy to work around your schedule.
 
 Best,
-Tom`,
+David`,
     snippet: "Great chatting at the conference! I'd love to set up a 30-minute call...",
   },
   // User replies and CC's EA Claire
@@ -730,10 +730,10 @@ Tom`,
     threadId: "thread-ea-scheduling",
     subject: "Re: Meeting to discuss partnership — finding a time",
     from: "Ankit <ankit@example.com>",
-    to: "Tom Nguyen <tom.nguyen@partnerco.io>",
+    to: "David Lieb <david.lieb@partnerco.io>",
     cc: "Claire <testea@ycombinator.com>",
     date: new Date(now - 2 * day - 3 * hour).toISOString(),
-    body: `Hi Tom,
+    body: `Hi David,
 
 Great meeting you too! I'd be happy to chat.
 
@@ -746,16 +746,16 @@ Ankit`,
     snippet: "I've CC'd Claire, my assistant, who can help coordinate scheduling...",
     labelIds: ["SENT"],
   },
-  // EA Claire coordinates with Tom — user is CC'd
+  // EA Claire coordinates with David — user is CC'd
   {
     id: "demo-ea-sched-003",
     threadId: "thread-ea-scheduling",
     subject: "Re: Meeting to discuss partnership — finding a time",
     from: "Claire <testea@ycombinator.com>",
-    to: "Tom Nguyen <tom.nguyen@partnerco.io>",
+    to: "David Lieb <david.lieb@partnerco.io>",
     cc: "Ankit <ankit@example.com>",
     date: new Date(now - 2 * day - 2 * hour).toISOString(),
-    body: `Hi Tom,
+    body: `Hi David,
 
 Thanks for your interest in connecting with Ankit! I'd be happy to help find a time.
 
@@ -770,12 +770,12 @@ Best,
 Claire`,
     snippet: "Here are a few slots available next week: Tuesday 2:00–2:30 PM PT...",
   },
-  // Tom replies to Claire — user still CC'd. This is the latest email user sees.
+  // David replies to Claire — user still CC'd. This is the latest email user sees.
   {
     id: "demo-ea-sched-004",
     threadId: "thread-ea-scheduling",
     subject: "Re: Meeting to discuss partnership — finding a time",
-    from: "Tom Nguyen <tom.nguyen@partnerco.io>",
+    from: "David Lieb <david.lieb@partnerco.io>",
     to: "Claire <testea@ycombinator.com>",
     cc: "Ankit <ankit@example.com>",
     date: new Date(now - 1 * day - 5 * hour).toISOString(),
@@ -786,7 +786,7 @@ Wednesday at 10am PT works perfectly! Could we do it over Zoom?
 Thanks for coordinating.
 
 Best,
-Tom`,
+David`,
     snippet: "Wednesday at 10am PT works perfectly! Could we do it over Zoom?",
   },
 
@@ -795,7 +795,7 @@ Tom`,
     id: "demo-ea-direct-001",
     threadId: "thread-ea-direct",
     subject: "Partnership technical requirements — need your input",
-    from: "Tom Nguyen <tom.nguyen@partnerco.io>",
+    from: "David Lieb <david.lieb@partnerco.io>",
     to: "Ankit <ankit@example.com>",
     cc: "Claire <testea@ycombinator.com>",
     date: new Date(now - 6 * hour).toISOString(),
@@ -810,30 +810,56 @@ Before our meeting on Wednesday, I wanted to get your thoughts on a couple of te
 These will help me prepare the right materials for our discussion.
 
 Thanks,
-Tom`,
+David`,
     snippet: "Before our meeting, I wanted to get your thoughts on technical questions...",
+  },
+
+  // Intro request — YC partner asking for 5 intros to other YC people
+  {
+    id: "demo-intro-request",
+    threadId: "thread-intro-request",
+    subject: "Can you intro me to a few folks?",
+    from: "Gustaf Alströmer <gustaf.a@startup.io>",
+    to: "Ankit <ankit@example.com>",
+    date: new Date(now - 1.5 * hour).toISOString(),
+    body: `Hey Ankit,
+
+Hope you're doing well! I'm working on a growth-focused AI project and I'd love to get connected with a few people in your network who I think could be really helpful.
+
+Could you intro me to:
+
+1. Garry Tan — I'd love to get his perspective on the market landscape and how he's thinking about AI-native products
+2. Jared Friedman — heard he's been diving deep into developer tools, and I have some ideas I'd love to bounce off him
+3. Diana Hu — she has incredible insight into the technical side of scaling AI systems
+
+No rush on all three at once — happy to take them one at a time if that's easier. And of course, only if you think each one makes sense.
+
+Thanks so much!
+
+Gustaf`,
+    snippet: "Could you intro me to Garry, Jared, and Diana?",
   },
 
   // Introduction email — someone connecting two people
   {
     id: "demo-intro",
     threadId: "thread-intro",
-    subject: "Intro: Ankit <> Maya Patel (AI infrastructure)",
-    from: "Rachel Kim <rachel.kim@venturefirm.com>",
-    to: "Ankit <ankit@example.com>, Maya Patel <maya.patel@aistack.dev>",
+    subject: "Intro: Ankit <> Tim Brady (AI infrastructure)",
+    from: "Kevin Hale <kevin.hale@venturefirm.com>",
+    to: "Ankit <ankit@example.com>, Tim Brady <tim.brady@aistack.dev>",
     date: new Date(now - 3 * hour).toISOString(),
-    body: `Hi Ankit and Maya,
+    body: `Hi Ankit and Tim,
 
 I wanted to connect the two of you! I think there could be a great fit here.
 
-Ankit — Maya is the CTO at AIStack and is building some really impressive infrastructure for serving large language models at scale. She's looking for design partners who are building AI-powered products.
+Ankit — Tim is the CTO at AIStack and is building some really impressive infrastructure for serving large language models at scale. He's looking for design partners who are building AI-powered products.
 
-Maya — Ankit is building a next-gen email client with deep AI integration. He's exactly the kind of builder who would benefit from your platform, and could give you valuable feedback on the developer experience.
+Tim — Ankit is building a next-gen email client with deep AI integration. He's exactly the kind of builder who would benefit from your platform, and could give you valuable feedback on the developer experience.
 
 I'll let the two of you take it from here!
 
 Best,
-Rachel`,
+Kevin`,
     snippet: "I wanted to connect the two of you! I think there could be a great fit here...",
   },
 ];
@@ -856,19 +882,20 @@ export const DEMO_EXPECTED_ANALYSIS: Record<string, { needsReply: boolean; prior
   "demo-inline-images": { needsReply: true, priority: "medium", reason: "Design review request requiring feedback" },
   "demo-sent-reply-001": { needsReply: false, reason: "Sent by user - no reply needed" },
   "demo-multi-001": { needsReply: false, reason: "Initial kickoff email, already has follow-ups" },
-  "demo-multi-002": { needsReply: false, reason: "Status update from Carlos, not directly addressed to user" },
-  "demo-multi-003": { needsReply: false, reason: "Status update from Nina, copy review request addressed in later email" },
-  "demo-multi-004": { needsReply: false, reason: "QA status update from Tom" },
+  "demo-multi-002": { needsReply: false, reason: "Status update from Pete, not directly addressed to user" },
+  "demo-multi-003": { needsReply: false, reason: "Status update from Aaron, copy review request addressed in later email" },
+  "demo-multi-004": { needsReply: false, reason: "QA status update from Brad" },
   "demo-multi-005": { needsReply: false, reason: "Marketing status, webinar question addressed in later email" },
   "demo-multi-006": { needsReply: true, priority: "high", reason: "Direct request for tooltip copy, release notes, and webinar date by EOD" },
   "demo-html-email": { needsReply: false, reason: "Product update newsletter, no action required" },
   "demo-casual-inbox": { needsReply: true, priority: "low", reason: "Casual friend asking about weekend plans" },
   "demo-formal-inbox": { needsReply: true, priority: "medium", reason: "Strategic advisory request with deadline from managing partner" },
-  "demo-intro": { needsReply: true, priority: "high", reason: "Introduction email — should reply to Maya and BCC Rachel (the introducer) to move her to BCC" },
+  "demo-intro-request": { needsReply: true, priority: "high", reason: "Direct request for 3 introductions — requires drafting individual intro emails to Garry, Jared, and Diana" },
+  "demo-intro": { needsReply: true, priority: "high", reason: "Introduction email — should reply to Tim and BCC Kevin (the introducer) to move him to BCC" },
   "demo-ea-sched-001": { needsReply: false, reason: "Initial scheduling request, already replied in thread" },
   "demo-ea-sched-002": { needsReply: false, reason: "Sent by user — no reply needed" },
   "demo-ea-sched-003": { needsReply: false, reason: "Sent by EA Claire coordinating scheduling — no user action needed" },
-  "demo-ea-sched-004": { needsReply: true, priority: "medium", reason: "Tom confirmed a time — but Claire (EA) is handling scheduling, user is just CC'd" },
+  "demo-ea-sched-004": { needsReply: true, priority: "medium", reason: "David confirmed a time — but Claire (EA) is handling scheduling, user is just CC'd" },
   "demo-ea-direct-001": { needsReply: true, priority: "high", reason: "Direct technical questions addressed to user requiring personal expertise" },
 };
 
@@ -876,9 +903,9 @@ export const DEMO_EXPECTED_ANALYSIS: Record<string, { needsReply: boolean; prior
 export const DEMO_SENT_EMAILS: SentEmail[] = [
   {
     id: "sent-demo-001",
-    toAddress: "sarah.chen@acmecorp.com",
+    toAddress: "jared.friedman@acmecorp.com",
     subject: "Re: Project Alpha - Initial thoughts",
-    body: `Sarah,
+    body: `Jared,
 
 Thanks for putting this together. A few thoughts:
 
@@ -891,9 +918,9 @@ Happy to discuss further.`,
   },
   {
     id: "sent-demo-002",
-    toAddress: "alex.r@startup.io",
+    toAddress: "gustaf.a@startup.io",
     subject: "Re: API Integration Help",
-    body: `Hey Alex,
+    body: `Hey Gustaf,
 
 Good questions! Here's what I'd recommend:
 
@@ -908,9 +935,9 @@ Best,`,
   },
   {
     id: "sent-demo-003",
-    toAddress: "j.park@techcorp.com",
+    toAddress: "d.hu@techcorp.com",
     subject: "Re: Q3 Review",
-    body: `Jennifer,
+    body: `Diana,
 
 Thanks for the summary. I reviewed the numbers and have a few comments:
 
@@ -927,7 +954,7 @@ Thanks,`,
 
 // Mock draft responses for demo mode
 export const DEMO_DRAFT_RESPONSES: Record<string, string> = {
-  "demo-003": `Hi Sarah,
+  "demo-003": `Hi Jared,
 
 Monday at 10am PT works for me. I'll have my calendar blocked.
 
@@ -940,7 +967,7 @@ I'll share a doc before the meeting so we can hit the ground running.
 
 See you Monday!`,
 
-  "demo-004": `Hey Alex,
+  "demo-004": `Hey Gustaf,
 
 Happy to help! Here are answers to your questions:
 
@@ -952,7 +979,7 @@ Happy to help! Here are answers to your questions:
 
 Let me know if you need anything else before your launch!`,
 
-  "demo-005": `Hi Jennifer,
+  "demo-005": `Hi Diana,
 
 Thanks for capturing these. Quick responses:
 
@@ -975,7 +1002,7 @@ For the interview, I'll focus on:
 
 Thanks!`,
 
-  "demo-010": `Hey David!
+  "demo-010": `Hey Tom!
 
 Lunch sounds great - I'm free Friday. The ramen place sounds perfect.
 
@@ -992,7 +1019,7 @@ First steps I'd recommend:
 
 Hopping on Zoom now.`,
 
-  "demo-meeting": `Hi Lisa,
+  "demo-meeting": `Hi Kat,
 
 Thanks for reaching out! I'd be happy to discuss partnership opportunities with PartnerCo.
 
@@ -1000,9 +1027,11 @@ I've copied my assistant who can help coordinate scheduling. They have access to
 
 Looking forward to the conversation!`,
 
-  "demo-intro": `Hi Maya,
+  "demo-intro-request": `yup i'm on it`,
 
-Great to e-meet you! Rachel has told me great things about what you're building at AIStack.
+  "demo-intro": `Hi Tim,
+
+Great to e-meet you! Kevin has told me great things about what you're building at AIStack.
 
 I'm indeed building an AI-powered email client and we're doing a lot of LLM inference — both for email analysis and draft generation. Would love to learn more about your infrastructure and how it might help us scale.
 
@@ -1011,7 +1040,7 @@ Are you free for a 30-minute call sometime next week? Happy to work around your 
 Best,
 Ankit`,
 
-  "demo-ea-direct-001": `Hi Tom,
+  "demo-ea-direct-001": `Hi David,
 
 Great questions — here's a quick rundown:
 
@@ -1027,13 +1056,13 @@ Ankit`,
 
 // Sent emails seeded into DB for style profiling (not shown in inbox)
 export const DEMO_STYLE_SEED_EMAILS: Email[] = [
-  // 10 casual sent emails to Jake — all lowercase, ~10 words, minimal punctuation
+  // 10 casual sent emails to Dalton — all lowercase, ~10 words, minimal punctuation
   {
     id: "demo-sent-casual-01",
-    threadId: "thread-casual-jake-01",
+    threadId: "thread-casual-dalton-01",
     subject: "Re: weekend",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 3 * day).toISOString(),
     body: "yeah sounds good lets do saturday",
     snippet: "yeah sounds good lets do saturday",
@@ -1041,10 +1070,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-02",
-    threadId: "thread-casual-jake-02",
+    threadId: "thread-casual-dalton-02",
     subject: "Re: that new show",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 5 * day).toISOString(),
     body: "haha nice ill check it out tonight",
     snippet: "haha nice ill check it out tonight",
@@ -1052,10 +1081,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-03",
-    threadId: "thread-casual-jake-03",
+    threadId: "thread-casual-dalton-03",
     subject: "Re: dinner tonight",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 8 * day).toISOString(),
     body: "hey running late be there in 10",
     snippet: "hey running late be there in 10",
@@ -1063,10 +1092,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-04",
-    threadId: "thread-casual-jake-04",
+    threadId: "thread-casual-dalton-04",
     subject: "Re: extra ticket",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 12 * day).toISOString(),
     body: "nah im good thanks tho",
     snippet: "nah im good thanks tho",
@@ -1074,10 +1103,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-05",
-    threadId: "thread-casual-jake-05",
+    threadId: "thread-casual-dalton-05",
     subject: "Re: last night",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 15 * day).toISOString(),
     body: "lol yeah that was wild",
     snippet: "lol yeah that was wild",
@@ -1085,10 +1114,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-06",
-    threadId: "thread-casual-jake-06",
+    threadId: "thread-casual-dalton-06",
     subject: "Re: meetup",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 20 * day).toISOString(),
     body: "cool cool see you there",
     snippet: "cool cool see you there",
@@ -1096,10 +1125,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-07",
-    threadId: "thread-casual-jake-07",
+    threadId: "thread-casual-dalton-07",
     subject: "Re: article",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 25 * day).toISOString(),
     body: "hey can you send me that link again",
     snippet: "hey can you send me that link again",
@@ -1107,10 +1136,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-08",
-    threadId: "thread-casual-jake-08",
+    threadId: "thread-casual-dalton-08",
     subject: "Re: yo",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 30 * day).toISOString(),
     body: "yeah just got home whats up",
     snippet: "yeah just got home whats up",
@@ -1118,10 +1147,10 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-09",
-    threadId: "thread-casual-jake-09",
+    threadId: "thread-casual-dalton-09",
     subject: "Re: bbq",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 38 * day).toISOString(),
     body: "nice one ill bring the stuff tomorrow",
     snippet: "nice one ill bring the stuff tomorrow",
@@ -1129,25 +1158,25 @@ export const DEMO_STYLE_SEED_EMAILS: Email[] = [
   },
   {
     id: "demo-sent-casual-10",
-    threadId: "thread-casual-jake-10",
+    threadId: "thread-casual-dalton-10",
     subject: "Re: road trip idea",
     from: "me@example.com",
-    to: "Jake Torres <jake.torres@gmail.com>",
+    to: "Dalton Caldwell <dalton.caldwell@gmail.com>",
     date: new Date(now - 45 * day).toISOString(),
     body: "haha for real tho we should do that",
     snippet: "haha for real tho we should do that",
     labelIds: ["SENT"],
   },
 
-  // 10 formal sent emails to Dr. Margaret Chen — proper capitalization, structured, "Dear/Regards"
+  // 10 formal sent emails to Dr. Geoff Ralston — proper capitalization, structured, "Dear/Regards"
   {
     id: "demo-sent-formal-01",
-    threadId: "thread-formal-margaret-01",
+    threadId: "thread-formal-geoff-01",
     subject: "Re: Q4 Strategic Review - Preliminary Analysis",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 4 * day).toISOString(),
-    body: `Dear Dr. Chen,
+    body: `Dear Dr. Ralston,
 
 Thank you for sharing the preliminary analysis. I have reviewed the documentation thoroughly and would like to offer the following observations:
 
@@ -1163,12 +1192,12 @@ Best regards`,
   },
   {
     id: "demo-sent-formal-02",
-    threadId: "thread-formal-margaret-02",
+    threadId: "thread-formal-geoff-02",
     subject: "Re: Board Meeting Preparation - Agenda Review",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 9 * day).toISOString(),
-    body: `Dear Margaret,
+    body: `Dear Geoff,
 
 Thank you for circulating the proposed agenda for the upcoming board meeting. I have reviewed each item carefully and have the following recommendations:
 
@@ -1184,12 +1213,12 @@ Regards`,
   },
   {
     id: "demo-sent-formal-03",
-    threadId: "thread-formal-margaret-03",
+    threadId: "thread-formal-geoff-03",
     subject: "Re: Due Diligence Report - Confidential",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 14 * day).toISOString(),
-    body: `Dear Dr. Chen,
+    body: `Dear Dr. Ralston,
 
 I appreciate you sharing the due diligence findings. After a thorough review of the materials, I would like to highlight several areas that warrant further examination:
 
@@ -1205,12 +1234,12 @@ Best regards`,
   },
   {
     id: "demo-sent-formal-04",
-    threadId: "thread-formal-margaret-04",
+    threadId: "thread-formal-geoff-04",
     subject: "Re: Partnership Framework Discussion",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 18 * day).toISOString(),
-    body: `Dear Margaret,
+    body: `Dear Geoff,
 
 Thank you for the productive discussion regarding the partnership framework. I wanted to follow up with a summary of the key points we agreed upon:
 
@@ -1226,12 +1255,12 @@ Best regards`,
   },
   {
     id: "demo-sent-formal-05",
-    threadId: "thread-formal-margaret-05",
+    threadId: "thread-formal-geoff-05",
     subject: "Re: Annual Compliance Review",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 22 * day).toISOString(),
-    body: `Dear Dr. Chen,
+    body: `Dear Dr. Ralston,
 
 Thank you for initiating the annual compliance review process. I have completed my assessment of the areas under my purview and would like to report the following:
 
@@ -1247,12 +1276,12 @@ Regards`,
   },
   {
     id: "demo-sent-formal-06",
-    threadId: "thread-formal-margaret-06",
+    threadId: "thread-formal-geoff-06",
     subject: "Re: Investment Committee Briefing Materials",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 28 * day).toISOString(),
-    body: `Dear Margaret,
+    body: `Dear Geoff,
 
 I have reviewed the investment committee briefing materials and prepared my analysis of the three proposed opportunities:
 
@@ -1268,12 +1297,12 @@ Best regards`,
   },
   {
     id: "demo-sent-formal-07",
-    threadId: "thread-formal-margaret-07",
+    threadId: "thread-formal-geoff-07",
     subject: "Re: Governance Policy Updates",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 33 * day).toISOString(),
-    body: `Dear Dr. Chen,
+    body: `Dear Dr. Ralston,
 
 Thank you for sharing the proposed governance policy updates. I have reviewed the revisions carefully and offer the following feedback:
 
@@ -1289,12 +1318,12 @@ Regards`,
   },
   {
     id: "demo-sent-formal-08",
-    threadId: "thread-formal-margaret-08",
+    threadId: "thread-formal-geoff-08",
     subject: "Re: Risk Assessment Findings",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 40 * day).toISOString(),
-    body: `Dear Margaret,
+    body: `Dear Geoff,
 
 I have completed my review of the risk assessment findings and concur with the overall conclusions. I would like to add the following observations:
 
@@ -1310,12 +1339,12 @@ Best regards`,
   },
   {
     id: "demo-sent-formal-09",
-    threadId: "thread-formal-margaret-09",
+    threadId: "thread-formal-geoff-09",
     subject: "Re: Quarterly Stakeholder Report",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 48 * day).toISOString(),
-    body: `Dear Dr. Chen,
+    body: `Dear Dr. Ralston,
 
 Thank you for the opportunity to contribute to the quarterly stakeholder report. Please find below my section on technology and innovation developments:
 
@@ -1331,12 +1360,12 @@ Regards`,
   },
   {
     id: "demo-sent-formal-10",
-    threadId: "thread-formal-margaret-10",
+    threadId: "thread-formal-geoff-10",
     subject: "Re: Strategic Advisory Engagement Proposal",
     from: "me@example.com",
-    to: "Dr. Margaret Chen <m.chen@whitfield-partners.com>",
+    to: "Dr. Geoff Ralston <g.ralston@whitfield-partners.com>",
     date: new Date(now - 55 * day).toISOString(),
-    body: `Dear Margaret,
+    body: `Dear Geoff,
 
 I have reviewed the strategic advisory engagement proposal with great interest. The scope of work is well-defined and the proposed methodology is sound. I would like to offer several suggestions:
 

--- a/src/main/demo/fake-inbox.ts
+++ b/src/main/demo/fake-inbox.ts
@@ -236,24 +236,25 @@ Diana`,
   {
     id: "demo-006",
     threadId: "thread-github-ci",
-    subject: "[myorg/myrepo] CI workflow failed on main",
+    subject: "[ankitvgupta/mail-app] CI workflow failed on main",
     from: "GitHub <noreply@github.com>",
     to: "me@example.com",
     date: new Date(now - 4 * hour).toISOString(),
-    body: `The workflow "CI" in repository myorg/myrepo has failed.
+    body: `The workflow "Build & Test" in repository ankitvgupta/mail-app has failed.
 
-Commit: abc123def456
-Message: Update dependencies
-Author: dependabot[bot]
+Commit: 4d96857a3f
+Message: Replace all mail-client references with mail-app (#5)
+Author: ankitvgupta
 
 Failed jobs:
-- test (ubuntu-latest)
+- test-e2e (ubuntu-latest)
+  Error: better-sqlite3 ABI mismatch — rebuilt for system Node but running under Electron
 
-View the workflow run: https://github.com/myorg/myrepo/actions/runs/12345
+View the workflow run: https://github.com/ankitvgupta/mail-app/actions/runs/14738291
 
 ---
 You are receiving this because you are subscribed to this repository.`,
-    snippet: "The workflow CI in repository myorg/myrepo has failed...",
+    snippet: "The workflow Build & Test in repository ankitvgupta/mail-app has failed...",
   },
 
   // Newsletter (skip)

--- a/src/main/ipc/sync.ipc.ts
+++ b/src/main/ipc/sync.ipc.ts
@@ -646,9 +646,9 @@ export function registerSyncIpc(): void {
 
       // Seed correspondent profiles for style testing contacts
       saveCorrespondentProfile({
-        email: "jake.torres@gmail.com",
+        email: "dalton.caldwell@gmail.com",
         accountId: "default",
-        displayName: "Jake Torres",
+        displayName: "Dalton Caldwell",
         emailCount: 10,
         avgWordCount: 7,
         dominantGreeting: "hey",
@@ -657,9 +657,9 @@ export function registerSyncIpc(): void {
         lastComputedAt: Date.now(),
       });
       saveCorrespondentProfile({
-        email: "m.chen@whitfield-partners.com",
+        email: "g.ralston@whitfield-partners.com",
         accountId: "default",
-        displayName: "Dr. Margaret Chen",
+        displayName: "Dr. Geoff Ralston",
         emailCount: 10,
         avgWordCount: 120,
         dominantGreeting: "dear",

--- a/src/main/services/email-analyzer.ts
+++ b/src/main/services/email-analyzer.ts
@@ -99,8 +99,8 @@ Email Body: "Great news! Your order #123-4567890-1234567 is on its way. Track yo
 Output: {"needs_reply": false, "reason": "Automated shipping notification from e-commerce"}
 
 Example 8 - Personal introduction (reply needed):
-Email Subject: "Introduction from Sarah Chen"
-Email Body: "Hi! I hope this email finds you well. Sarah Chen mentioned that you're working on some interesting AI-powered productivity tools, and I'd love to learn more about your work. I'm currently leading product at a startup in the same space, and it seems like there could be some interesting synergies. Would you be open to a brief call sometime next week? No rush on this - just wanted to reach out and introduce myself."
+Email Subject: "Introduction from Jared Friedman"
+Email Body: "Hi! I hope this email finds you well. Jared Friedman mentioned that you're working on some interesting AI-powered productivity tools, and I'd love to learn more about your work. I'm currently leading product at a startup in the same space, and it seems like there could be some interesting synergies. Would you be open to a brief call sometime next week? No rush on this - just wanted to reach out and introduce myself."
 Output: {"needs_reply": true, "reason": "Personal introduction from mutual connection requesting networking call", "priority": "low"}
 
 Example 9 - LinkedIn notification (no reply needed):

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,9 +172,7 @@ Steps:
 3. Search for prior email conversations with this sender if it would help provide better context
 4. Call generateDraft with any additional context you gathered as instructions
 
-Pass relevant research findings to generateDraft in the instructions parameter — for example, who the sender is, their role, and any important history. Keep research proportional to the email's complexity: a simple question doesn't need extensive background research.
-
-INTRODUCTIONS: If the email asks you to make introductions, search the inbox (using search_emails or list_emails) to find recent emails from the people being introduced. Use that context to write warm, personalized intros — mention what each person has been working on or recently discussed. For each intro, use compose_new_email to draft a separate introduction email.`;
+Pass relevant research findings to generateDraft in the instructions parameter — for example, who the sender is, their role, and any important history. Keep research proportional to the email's complexity: a simple question doesn't need extensive background research.`;
 
 // The user-editable archive-ready prompt contains only the behavioral rules.
 // The JSON output format is appended automatically by ArchiveReadyAnalyzer.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,7 +172,9 @@ Steps:
 3. Search for prior email conversations with this sender if it would help provide better context
 4. Call generateDraft with any additional context you gathered as instructions
 
-Pass relevant research findings to generateDraft in the instructions parameter — for example, who the sender is, their role, and any important history. Keep research proportional to the email's complexity: a simple question doesn't need extensive background research.`;
+Pass relevant research findings to generateDraft in the instructions parameter — for example, who the sender is, their role, and any important history. Keep research proportional to the email's complexity: a simple question doesn't need extensive background research.
+
+INTRODUCTIONS: If the email asks you to make introductions, search the inbox (using search_emails or list_emails) to find recent emails from the people being introduced. Use that context to write warm, personalized intros — mention what each person has been working on or recently discussed. For each intro, use compose_new_email to draft a separate introduction email.`;
 
 // The user-editable archive-ready prompt contains only the behavioral rules.
 // The JSON output format is appended automatically by ArchiveReadyAnalyzer.

--- a/tests/e2e/action-buttons.spec.ts
+++ b/tests/e2e/action-buttons.spec.ts
@@ -57,8 +57,8 @@ test.describe("Email Action Buttons", () => {
   });
 
   test("action buttons are visible in thread header when email is selected", async () => {
-    // Select an email (Emily Watson's Q3 report — not snoozed in demo mode)
-    await selectEmail(page, "Emily");
+    // Select an email (Garry Tan's Q3 report — not snoozed in demo mode)
+    await selectEmail(page, "Garry");
 
     // Verify all action buttons are present by their title attributes
     await expect(page.locator("button[title='Archive']")).toBeVisible();
@@ -80,7 +80,7 @@ test.describe("Email Action Buttons", () => {
   test("star button toggles between star and unstar", async () => {
     // Ensure we're viewing an email
     await ensureInList(page);
-    await selectEmail(page, "Emily");
+    await selectEmail(page, "Garry");
 
     // The initial state should be "Star" (unstarred)
     const starButton = page.locator("button[title='Star']");
@@ -215,9 +215,9 @@ test.describe("Email Action Buttons", () => {
     await ensureInList(page);
 
     // Select any remaining email
-    const anyEmail = page.locator("button").filter({ hasText: "Emily" }).first();
+    const anyEmail = page.locator("button").filter({ hasText: "Garry" }).first();
     if (await anyEmail.isVisible().catch(() => false)) {
-      await selectEmail(page, "Emily");
+      await selectEmail(page, "Garry");
 
       // Verify the buttons area is rendered (action + compose buttons visible)
       await expect(page.locator("button[title='Archive']")).toBeVisible();

--- a/tests/e2e/compose.spec.ts
+++ b/tests/e2e/compose.spec.ts
@@ -216,7 +216,7 @@ test.describe("Compose - Reply", () => {
     await page.waitForTimeout(1000);
 
     // Find an email in the list
-    const emailButton = page.locator("button").filter({ hasText: "Sarah" }).first();
+    const emailButton = page.locator("button").filter({ hasText: "Garry" }).first();
     if (await emailButton.isVisible()) {
       await emailButton.click();
       await page.waitForTimeout(800);
@@ -307,7 +307,7 @@ test.describe("Compose - Forward", () => {
     await page.waitForTimeout(1000);
 
     // Select an email
-    const emailButton = page.locator("button").filter({ hasText: "Sarah" }).first();
+    const emailButton = page.locator("button").filter({ hasText: "Garry" }).first();
     if (await emailButton.isVisible()) {
       await emailButton.click();
       await page.waitForTimeout(800);

--- a/tests/e2e/dark-mode.spec.ts
+++ b/tests/e2e/dark-mode.spec.ts
@@ -155,7 +155,7 @@ test.describe("Dark Mode", () => {
   test("inbox email list renders with dark colors", async () => {
     // Verify the inbox area has dark-themed elements
     // Check that at least one email row exists and has appropriate dark styling
-    const emailButtons = page.locator("button").filter({ hasText: /Lisa|HR Team|Amazon|GitHub|Product Team/ });
+    const emailButtons = page.locator("button").filter({ hasText: /Garry|HR Team|Amazon|GitHub|Product Team/ });
     const count = await emailButtons.count();
     expect(count).toBeGreaterThan(0);
 

--- a/tests/e2e/draft-persistence.spec.ts
+++ b/tests/e2e/draft-persistence.spec.ts
@@ -21,7 +21,7 @@ async function openFirstEmailInFullView(page: Page): Promise<void> {
   const firstEmail = page.locator("[data-testid='email-list-item']").first();
   const emailButton = (await firstEmail.isVisible().catch(() => false))
     ? firstEmail
-    : page.locator("button").filter({ hasText: "Sarah" }).first();
+    : page.locator("button").filter({ hasText: "Garry" }).first();
 
   await emailButton.click();
   await page.waitForTimeout(500);
@@ -50,7 +50,7 @@ async function reopenFirstEmail(page: Page): Promise<void> {
   const firstEmail = page.locator("[data-testid='email-list-item']").first();
   const emailButton = (await firstEmail.isVisible().catch(() => false))
     ? firstEmail
-    : page.locator("button").filter({ hasText: "Sarah" }).first();
+    : page.locator("button").filter({ hasText: "Garry" }).first();
 
   await emailButton.click();
   await page.waitForTimeout(500);

--- a/tests/e2e/draft-persistence.spec.ts
+++ b/tests/e2e/draft-persistence.spec.ts
@@ -93,12 +93,14 @@ test.describe("Draft persistence across navigation", () => {
     const inlineCompose = page.locator("[data-testid='inline-compose']");
     await expect(inlineCompose).toBeVisible({ timeout: 5000 });
 
-    // Capture the current editor content (may include pre-existing draft)
+    // Type some content into the editor so we can verify it persists
     const editor = inlineCompose.locator(".ProseMirror");
     await editor.click();
     await page.waitForTimeout(300);
+    await editor.pressSequentially("Draft persistence test content");
+    await page.waitForTimeout(300);
     const originalText = await editor.textContent();
-    expect(originalText).toBeTruthy(); // Should have some content
+    expect(originalText).toBeTruthy();
 
     // Navigate away — Esc blurs editor, then Esc navigates back
     await navigateBackToInbox(page);

--- a/tests/e2e/email-body.spec.ts
+++ b/tests/e2e/email-body.spec.ts
@@ -36,7 +36,7 @@ test.describe("Email Body Rendering", () => {
 
   test("renders plain text email correctly", async () => {
     // Wait for email list to populate (use senders known to not be pre-snoozed)
-    const emailItem = page.locator("button").filter({ hasText: /Lisa|HR Team|Product Team|Amazon/i }).first();
+    const emailItem = page.locator("button").filter({ hasText: /Garry|HR Team|Product Team|Amazon/i }).first();
     await expect(emailItem).toBeVisible({ timeout: 15000 });
 
     // Click on an email to show detail in split view

--- a/tests/e2e/image-loading.spec.ts
+++ b/tests/e2e/image-loading.spec.ts
@@ -37,7 +37,7 @@ test.describe("Image Loading in Emails", () => {
   test("images load in HTML emails", async () => {
     // Wait for app and emails to load
     await page.waitForSelector("text=Exo", { timeout: 15000 });
-    await page.locator("button").filter({ hasText: /Lisa|HR Team|Product Team/ }).first().waitFor({ timeout: 10000 });
+    await page.locator("button").filter({ hasText: /Garry|HR Team|Product Team/ }).first().waitFor({ timeout: 10000 });
 
     // Find an HTML email — Product Team newsletter is always visible (not snoozed)
     const htmlEmail = page.locator("button").filter({ hasText: "Weekly Product Update" }).first();

--- a/tests/e2e/inbox.spec.ts
+++ b/tests/e2e/inbox.spec.ts
@@ -106,7 +106,7 @@ test.describe("Exo E2E - Email Detail", () => {
 
   test("shows email content when selected", async () => {
     // Click on any visible email in the list (senders may be snoozed from prior runs)
-    const candidates = ["Lisa", "HR Team", "Jennifer", "David", "Emily", "Mike"];
+    const candidates = ["Garry", "HR Team", "Jared", "Diana", "Gustaf", "Michael"];
     let clicked = false;
     for (const name of candidates) {
       const btn = page.locator("button").filter({ hasText: name }).first();

--- a/tests/e2e/inline-images.spec.ts
+++ b/tests/e2e/inline-images.spec.ts
@@ -40,7 +40,7 @@ test.describe("Inline Images - Reading", () => {
 
   test("email with inline images displays images correctly", async () => {
     // Find and click the email with inline images
-    const emailItem = page.locator("button").filter({ hasText: /Rachel|Landing Page Mockups/i }).first();
+    const emailItem = page.locator("button").filter({ hasText: /Surbhi|Landing Page Mockups/i }).first();
     await expect(emailItem).toBeVisible({ timeout: 10000 });
     await emailItem.click();
     await page.waitForTimeout(1500);
@@ -83,7 +83,7 @@ test.describe("Inline Images - Reading", () => {
     await page.waitForTimeout(500);
 
     // Click the Q3 report email which has an external image (https://via.placeholder.com)
-    const emailItem = page.locator("button").filter({ hasText: /Emily|Q3 Quarterly/i }).first();
+    const emailItem = page.locator("button").filter({ hasText: /Garry|Q3 Quarterly/i }).first();
     await expect(emailItem).toBeVisible({ timeout: 10000 });
     await emailItem.click();
     await page.waitForTimeout(1500);

--- a/tests/e2e/keyboard-flow.spec.ts
+++ b/tests/e2e/keyboard-flow.spec.ts
@@ -139,11 +139,14 @@ test.describe("Keyboard Navigation - Enter and Escape", () => {
 
   test("Enter opens email in full view", async () => {
     await expect(page.locator("text=Inbox").first()).toBeVisible({ timeout: 10000 });
+    // Wait for email list to fully render before keyboard nav
+    await page.locator("[data-testid='email-list-item'], button").filter({ hasText: /Garry|HR Team/ }).first().waitFor({ timeout: 10000 });
+    await page.waitForTimeout(500);
 
     // Select first thread
     await page.keyboard.press("j");
     // Wait for selection before pressing Enter
-    await expect(page.locator("div[data-thread-id][data-selected='true']")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("div[data-thread-id][data-selected='true']")).toBeVisible({ timeout: 10000 });
 
     // Open full view
     await page.keyboard.press("Enter");

--- a/tests/e2e/reply-forward.spec.ts
+++ b/tests/e2e/reply-forward.spec.ts
@@ -28,7 +28,7 @@ async function openFirstEmailInFullView(page: Page): Promise<void> {
   // If email list items don't have a test ID, fall back to finding buttons in the list
   const emailButton = (await firstEmail.isVisible().catch(() => false))
     ? firstEmail
-    : page.locator("button").filter({ hasText: "Sarah" }).first();
+    : page.locator("button").filter({ hasText: "Garry" }).first();
 
   await emailButton.click();
   await page.waitForTimeout(500);

--- a/tests/e2e/screenshot-reply-buttons.spec.ts
+++ b/tests/e2e/screenshot-reply-buttons.spec.ts
@@ -17,8 +17,8 @@ test.describe("Thread Reply Buttons Screenshot", () => {
   });
 
   test("capture reply buttons in multi-message thread", async () => {
-    // Click on Sarah Chen's Project Alpha thread (has 4 messages)
-    const emailButton = page.locator("button").filter({ hasText: "Sarah Chen" }).first();
+    // Click on Jared Friedman's Project Alpha thread (has 4 messages)
+    const emailButton = page.locator("button").filter({ hasText: "Jared Friedman" }).first();
     await expect(emailButton).toBeVisible({ timeout: 5000 });
     await emailButton.click();
     await page.waitForTimeout(2000);
@@ -27,15 +27,15 @@ test.describe("Thread Reply Buttons Screenshot", () => {
     await expect(page.locator("button[title='Archive']")).toBeVisible({ timeout: 5000 });
 
     // Expand collapsed messages by clicking on them
-    // Click on the first Sarah Chen collapsed message header
-    const firstCollapsed = page.locator("text=Sarah Chen").filter({ hasText: "I wanted to kick off" }).first();
+    // Click on the first Jared Friedman collapsed message header
+    const firstCollapsed = page.locator("text=Jared Friedman").filter({ hasText: "I wanted to kick off" }).first();
     if (await firstCollapsed.isVisible().catch(() => false)) {
       await firstCollapsed.click();
       await page.waitForTimeout(500);
     }
 
-    // Click on Mike Johnson collapsed message
-    const mikeCollapsed = page.locator("text=Mike Johnson").first();
+    // Click on Michael Seibel collapsed message
+    const mikeCollapsed = page.locator("text=Michael Seibel").first();
     if (await mikeCollapsed.isVisible().catch(() => false)) {
       await mikeCollapsed.click();
       await page.waitForTimeout(500);

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -46,17 +46,17 @@ test.describe("Sender Profile - Display", () => {
     // Sender name should be visible in the detail view
     // Demo emails have known senders
     const senderNames = [
-      "Sarah Johnson",
-      "Michael Chen",
-      "GitHub Actions",
+      "Garry Tan",
+      "Jared Friedman",
+      "Michael Seibel",
+      "GitHub",
       "Tech Weekly",
-      "Alex Rodriguez",
       "Amazon",
-      "Lisa",
-      "Jennifer",
-      "David",
-      "Emily",
-      "Mike",
+      "Gustaf",
+      "Diana",
+      "Tom Blomfield",
+      "Nicolas",
+      "Dalton",
     ];
 
     let foundSender = false;
@@ -241,7 +241,7 @@ test.describe("Sender Profile - Full View", () => {
     expect(bodyText).toBeTruthy();
 
     // At least one known demo sender should be visible
-    const knownSenders = ["Sarah", "Michael", "GitHub", "Alex", "Lisa", "Jennifer", "David", "Emily", "Mike"];
+    const knownSenders = ["Garry", "Jared", "Michael", "GitHub", "Gustaf", "Diana", "Tom", "Nicolas", "Dalton"];
     let found = false;
     for (const sender of knownSenders) {
       if (bodyText?.includes(sender)) {

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -301,7 +301,7 @@ test.describe("Settings Panel - Undo Send Delay", () => {
   });
 
   test("can set undo send to Off", async () => {
-    const offButton = page.locator("button:has-text('Off')");
+    const offButton = page.getByTestId("settings-panel").locator("button:has-text('Off')");
     await offButton.click();
     await page.waitForTimeout(300);
 

--- a/tests/e2e/sidebar-focused-email.spec.ts
+++ b/tests/e2e/sidebar-focused-email.spec.ts
@@ -11,12 +11,12 @@ import { launchElectronApp } from "./launch-helpers";
 
 // The multi-sender thread senders in chronological order.
 const THREAD_SENDERS = [
-  { id: "demo-multi-001", name: "Priya Sharma", email: "priya.sharma@acmecorp.com" },
-  { id: "demo-multi-002", name: "Carlos Mendez", email: "carlos.mendez@acmecorp.com" },
-  { id: "demo-multi-003", name: "Nina Okafor", email: "nina.okafor@acmecorp.com" },
-  { id: "demo-multi-004", name: "Tom Bradley", email: "tom.bradley@acmecorp.com" },
-  { id: "demo-multi-005", name: "Aisha Patel", email: "aisha.patel@acmecorp.com" },
-  { id: "demo-multi-006", name: "Priya Sharma", email: "priya.sharma@acmecorp.com" },
+  { id: "demo-multi-001", name: "Nicolas Dessaigne", email: "nicolas.d@acmecorp.com" },
+  { id: "demo-multi-002", name: "Pete Koomen", email: "pete.koomen@acmecorp.com" },
+  { id: "demo-multi-003", name: "Aaron Epstein", email: "aaron.epstein@acmecorp.com" },
+  { id: "demo-multi-004", name: "Brad Flora", email: "brad.flora@acmecorp.com" },
+  { id: "demo-multi-005", name: "Harj Taggar", email: "harj.taggar@acmecorp.com" },
+  { id: "demo-multi-006", name: "Nicolas Dessaigne", email: "nicolas.d@acmecorp.com" },
 ];
 
 test.describe("Sidebar reflects focused email in thread", () => {

--- a/tests/e2e/snooze.spec.ts
+++ b/tests/e2e/snooze.spec.ts
@@ -153,7 +153,7 @@ test.describe("Snooze Feature — Natural Language Input", () => {
     page = result.page;
 
     // Wait for email list to populate
-    await page.locator("button").filter({ hasText: /High|Medium|Low|Emily|HR Team|Product Team/ }).first().waitFor({ timeout: 15000 });
+    await page.locator("button").filter({ hasText: /High|Medium|Low|Garry|HR Team|Product Team/ }).first().waitFor({ timeout: 15000 });
   });
 
   test.afterAll(async () => {
@@ -164,9 +164,9 @@ test.describe("Snooze Feature — Natural Language Input", () => {
 
   test("parses natural language time in text input", async () => {
     // Select an email — use a sender that exists in demo data and is not snoozed
-    const emailButton = page.locator("button").filter({ hasText: "Emily" }).first();
+    const emailButton = page.locator("button").filter({ hasText: "Garry" }).first();
     if (!(await emailButton.isVisible())) return;
-    await selectAndOpenEmail(page, "Emily");
+    await selectAndOpenEmail(page, "Garry");
 
     // Open snooze menu
     const snoozeButton = page.locator("button[title='Snooze (h)'], button[title='Snoozed']").first();
@@ -190,9 +190,9 @@ test.describe("Snooze Feature — Natural Language Input", () => {
 
   test("shows error for unparseable input", async () => {
     // Select an email
-    const emailButton = page.locator("button").filter({ hasText: "Emily" }).first();
+    const emailButton = page.locator("button").filter({ hasText: "Garry" }).first();
     if (!(await emailButton.isVisible())) return;
-    await selectAndOpenEmail(page, "Emily");
+    await selectAndOpenEmail(page, "Garry");
 
     // Open snooze menu
     const snoozeButton = page.locator("button[title='Snooze (h)'], button[title='Snoozed']").first();
@@ -211,9 +211,9 @@ test.describe("Snooze Feature — Natural Language Input", () => {
 
   test("can snooze with Enter key after typing time", async () => {
     // Select an email
-    const emailButton = page.locator("button").filter({ hasText: "Emily" }).first();
+    const emailButton = page.locator("button").filter({ hasText: "Garry" }).first();
     if (!(await emailButton.isVisible())) return;
-    await selectAndOpenEmail(page, "Emily");
+    await selectAndOpenEmail(page, "Garry");
 
     // Open snooze menu
     const snoozeButton = page.locator("button[title='Snooze (h)'], button[title='Snoozed']").first();
@@ -295,10 +295,10 @@ test.describe("Snooze Feature — Snooze Banner & Unsnooze", () => {
   });
 
   test("snooze button turns amber when thread is snoozed", async () => {
-    // Snooze an email (Mike is not snoozed in demo mode)
-    const emailButton = page.locator("button").filter({ hasText: "Mike" }).first();
+    // Snooze an email (Gustaf is not snoozed in demo mode)
+    const emailButton = page.locator("button").filter({ hasText: "Gustaf" }).first();
     if (!(await emailButton.isVisible())) return;
-    await selectAndOpenEmail(page, "Mike");
+    await selectAndOpenEmail(page, "Gustaf");
 
     const snoozeButton = page.locator("button[title='Snooze (h)'], button[title='Snoozed']").first();
     await snoozeButton.click();
@@ -314,7 +314,7 @@ test.describe("Snooze Feature — Snooze Banner & Unsnooze", () => {
       await snoozedTab.click();
       await page.waitForTimeout(300);
 
-      const snoozedEmail = page.locator("button").filter({ hasText: "Mike" }).first();
+      const snoozedEmail = page.locator("button").filter({ hasText: "Gustaf" }).first();
       if (await snoozedEmail.isVisible()) {
         await snoozedEmail.click();
         await page.waitForTimeout(500);

--- a/tests/e2e/undo-send.spec.ts
+++ b/tests/e2e/undo-send.spec.ts
@@ -100,7 +100,7 @@ test.describe("Undo Send - Inline Reply", () => {
   test("app loads with inbox emails", async () => {
     await expect(page.locator("text=Exo")).toBeVisible();
     await expect(page.locator("text=Inbox").first()).toBeVisible();
-    await expect(page.locator("button").filter({ hasText: "Sarah Chen" }).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("button").filter({ hasText: "Garry Tan" }).first()).toBeVisible({ timeout: 5000 });
 
     await takeScreenshot(electronApp, page, "undo-send-01-app-loaded");
   });
@@ -108,8 +108,8 @@ test.describe("Undo Send - Inline Reply", () => {
   test("inline reply shows undo toast with Undo button on send", async () => {
     await page.waitForTimeout(500);
 
-    // Select Sarah Chen's email
-    const emailItem = page.locator("button").filter({ hasText: "Sarah Chen" }).first();
+    // Select Garry Tan's email
+    const emailItem = page.locator("button").filter({ hasText: "Garry Tan" }).first();
     await emailItem.click();
     await page.waitForTimeout(800);
 
@@ -129,7 +129,7 @@ test.describe("Undo Send - Inline Reply", () => {
 
     // Type some reply text
     await editor.click();
-    await editor.type("Thanks for the update, Sarah. I will review the project status.", { delay: 10 });
+    await editor.type("Thanks for the update, Garry. I will review the quarterly report.", { delay: 10 });
 
     await takeScreenshot(electronApp, page, "undo-send-04-reply-typed");
 
@@ -190,8 +190,8 @@ test.describe("Undo Send - Inline Reply Undo Action", () => {
   test("clicking Undo restores the draft with content", async () => {
     await page.waitForTimeout(500);
 
-    // Select Sarah Chen's email
-    const emailItem = page.locator("button").filter({ hasText: "Sarah Chen" }).first();
+    // Select Garry Tan's email
+    const emailItem = page.locator("button").filter({ hasText: "Garry Tan" }).first();
     await expect(emailItem).toBeVisible({ timeout: 5000 });
     await emailItem.click();
     await page.waitForTimeout(1000);
@@ -404,7 +404,7 @@ test.describe("Undo Send - Forward", () => {
   test("forward with undo-send shows toast and Undo button", async () => {
     await page.waitForTimeout(500);
 
-    const emailItem = page.locator("button").filter({ hasText: "Sarah Chen" }).first();
+    const emailItem = page.locator("button").filter({ hasText: "Garry Tan" }).first();
     await expect(emailItem).toBeVisible({ timeout: 5000 });
     await emailItem.click();
     await page.waitForTimeout(800);


### PR DESCRIPTION
## Summary

- Update the agent drafter prompt to search the inbox for context when drafting intro emails
- Move the OpenClaw agent provider from `agents-private` (gitignored) to a checked-in provider at `src/main/agents/providers/openclaw/`, registered alongside the Claude provider in the orchestrator

## Test plan
- [ ] Run app in demo mode (`EXO_DEMO_MODE=true npm run dev`) and verify YC partner names appear
- [ ] Click Gustaf's intro request email and verify the draft says "yup i'm on it"
- [ ] Verify OpenClaw agent is available as a sub-agent tool when enabled in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
