### PR TITLE
Add Cloclo as agent provider

### DIFF
--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -188,6 +188,11 @@ export class AgentCoordinator {
           gatewayUrl: appConfig.openclaw?.gatewayUrl ?? "",
           gatewayToken: appConfig.openclaw?.gatewayToken ?? "",
         },
+        "cloclo-agent": {
+          enabled: appConfig.cloclo?.enabled ?? false,
+          model: appConfig.cloclo?.model,
+          extraFlags: appConfig.cloclo?.extraFlags,
+        },
       },
     };
     this.workerReady = populatePrivateProviderConfig(baseConfig).then(

--- a/src/main/agents/orchestrator.ts
+++ b/src/main/agents/orchestrator.ts
@@ -14,6 +14,7 @@ import type {
 import { AgentProviderRegistry } from "./providers/registry";
 import { ClaudeAgentProvider } from "./providers/claude-agent-provider";
 import { OpenClawAgentProvider } from "./providers/openclaw/openclaw-agent-provider";
+import { ClocloAgentProvider } from "./providers/cloclo/cloclo-agent-provider";
 import { PermissionGate } from "./permission-gate";
 import type { ToolRegistry } from "./tools/registry";
 import type { ProxyContext } from "./tools/types";
@@ -66,6 +67,16 @@ export class AgentOrchestrator {
         enabled: ocSettings?.enabled ?? false,
         gatewayUrl: ocSettings?.gatewayUrl ?? "",
         gatewayToken: ocSettings?.gatewayToken ?? "",
+      }),
+    );
+
+    // Register the Cloclo provider
+    const clocloSettings = deps.config.providers?.["cloclo-agent"];
+    this.providerRegistry.register(
+      new ClocloAgentProvider({
+        enabled: clocloSettings?.enabled ?? false,
+        model: clocloSettings?.model,
+        extraFlags: clocloSettings?.extraFlags,
       }),
     );
 

--- a/src/main/agents/providers/cloclo/cloclo-agent-provider.ts
+++ b/src/main/agents/providers/cloclo/cloclo-agent-provider.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+import { execFile } from "node:child_process";
+import type {
+  AgentFrameworkConfig,
+  AgentProvider,
+  AgentProviderConfig,
+  AgentRunParams,
+  AgentRunResult,
+  AgentEvent,
+  SubAgentToolConfig,
+} from "../../types";
+import type { ClocloProviderConfig } from "./types";
+import { ClocloResponseSchema } from "./types";
+
+const TIMEOUT_MS = 300_000;
+const SLOW_WARNING_MS = 30_000;
+
+/** Flags that must not be overridden by user-supplied extraFlags. */
+const RESERVED_FLAGS = new Set(["-p", "--print", "--json", "-m", "--model"]);
+
+/**
+ * Execute `cloclo` CLI and return the response text.
+ * Cloclo outputs structured JSON via `--json` flag.
+ */
+function execCloclo(
+  message: string,
+  signal: AbortSignal,
+  model?: string,
+  extraFlags?: string[],
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof execFile>;
+    const onAbort = () => {
+      child?.kill("SIGTERM");
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    const args = ["-p", message, "--json"];
+    if (model) args.push("-m", model);
+    if (extraFlags) {
+      const safe = extraFlags.filter((f) => !RESERVED_FLAGS.has(f.split("=")[0]));
+      args.push(...safe);
+    }
+
+    child = execFile(
+      "cloclo",
+      args,
+      { timeout: TIMEOUT_MS, env: { ...process.env, NO_COLOR: "1" } },
+      (error, stdout, stderr) => {
+        signal.removeEventListener("abort", onAbort);
+
+        if (signal.aborted) {
+          reject(new Error("Request cancelled"));
+          return;
+        }
+        if (error) {
+          const combined = (stderr || "") + (stdout || "");
+          if (combined.includes("No API key") || combined.includes("Auth failure")) {
+            reject(new Error("Cloclo: No API key configured — set ANTHROPIC_API_KEY or run `cloclo --login`"));
+            return;
+          }
+          if (error.killed || combined.includes("ETIMEDOUT")) {
+            reject(new Error("Cloclo: Request timed out after 5m"));
+            return;
+          }
+          reject(new Error(`Cloclo: ${error.message}`));
+          return;
+        }
+
+        const parsed = ClocloResponseSchema.safeParse(
+          (() => { try { return JSON.parse(stdout); } catch { return null; } })(),
+        );
+        if (!parsed.success) {
+          resolve(stdout.trim() || "No response from Cloclo");
+          return;
+        }
+        resolve(parsed.data.content);
+      },
+    );
+  });
+}
+
+/**
+ * Cloclo Agent Provider — connects to a local Cloclo instance.
+ *
+ * Cloclo is an open-source, provider-agnostic CLI for AI agents.
+ * It supports 13 LLM providers (Anthropic, OpenAI, Gemini, DeepSeek,
+ * Mistral, Groq, Ollama, LM Studio, etc.) and comes with built-in
+ * tools for file processing (PDF, DOCX, XLSX), browser automation,
+ * code execution, and more.
+ *
+ * Unlike OpenClaw (which is a chatbot with no tools), Cloclo can
+ * actually process email attachments, run code, browse the web,
+ * and execute multi-step workflows — making it useful for tasks
+ * like invoice processing, data extraction, and research.
+ *
+ * Install: npm install -g cloclo
+ * Repo: https://github.com/SeifBenayed/claude-code-sdk
+ */
+export class ClocloAgentProvider implements AgentProvider {
+  readonly config: AgentProviderConfig = {
+    id: "cloclo-agent",
+    name: "Cloclo Agent",
+    description: "Provider-agnostic AI agent with built-in tools (PDF, XLSX, browser, code execution)",
+    auth: { type: "none" },
+  };
+
+  private enabled: boolean;
+  private model: string | undefined;
+  private extraFlags: string[];
+  private inFlight = new Map<string, AbortController>();
+
+  constructor(cfg: ClocloProviderConfig) {
+    this.enabled = cfg.enabled;
+    this.model = cfg.model;
+    this.extraFlags = cfg.extraFlags ?? [];
+  }
+
+  updateConfig(config: Partial<AgentFrameworkConfig>): void {
+    const cc = config.providers?.["cloclo-agent"];
+    if (cc) {
+      if ("enabled" in cc) this.enabled = Boolean(cc.enabled);
+      if ("model" in cc) this.model = cc.model;
+      if ("extraFlags" in cc) this.extraFlags = Array.isArray(cc.extraFlags) ? cc.extraFlags : [];
+    }
+  }
+
+  async *run(params: AgentRunParams): AsyncGenerator<AgentEvent, AgentRunResult, void> {
+    if (!this.enabled) {
+      yield { type: "error", message: "CLOCLO_NOT_CONFIGURED" };
+      return { state: "failed" };
+    }
+
+    yield { type: "state", state: "running" };
+
+    const controller = new AbortController();
+    this.inFlight.set(params.taskId, controller);
+    const onParentAbort = () => controller.abort();
+    params.signal.addEventListener("abort", onParentAbort, { once: true });
+
+    try {
+      const slowWarning = Symbol("slow");
+      const cliPromise = execCloclo(
+        params.prompt,
+        controller.signal,
+        this.model,
+        this.extraFlags,
+      );
+      const timerPromise = new Promise<typeof slowWarning>((resolve) => {
+        const id = setTimeout(() => resolve(slowWarning), SLOW_WARNING_MS);
+        cliPromise.then(() => clearTimeout(id), () => clearTimeout(id));
+      });
+
+      let response: string;
+      const first = await Promise.race([cliPromise, timerPromise]);
+      if (first === slowWarning) {
+        yield { type: "text_delta", text: "\n⏳ Cloclo is processing...\n" };
+        response = await cliPromise;
+      } else {
+        response = first;
+      }
+
+      yield { type: "text_delta", text: response };
+      yield { type: "done", summary: "Cloclo query completed" };
+      return { state: "completed" };
+    } catch (err) {
+      if (controller.signal.aborted || params.signal.aborted) {
+        yield { type: "state", state: "cancelled" };
+        return { state: "cancelled" };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      yield { type: "error", message: msg };
+      return { state: "failed" };
+    } finally {
+      params.signal.removeEventListener("abort", onParentAbort);
+      this.inFlight.delete(params.taskId);
+    }
+  }
+
+  cancel(taskId: string): void {
+    const controller = this.inFlight.get(taskId);
+    if (controller) {
+      controller.abort();
+      this.inFlight.delete(taskId);
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.enabled;
+  }
+
+  asSubAgentTool(): SubAgentToolConfig | null {
+    if (!this.enabled) return null;
+
+    return {
+      name: "ask_cloclo",
+      description:
+        "Query a local Cloclo agent for tasks that require tools — processing attachments (PDF, XLSX, DOCX), running code, browsing the web, or executing multi-step workflows. Cloclo is provider-agnostic and can use any LLM backend.",
+      systemPromptGuidance: `You have access to the ask_cloclo tool which queries a local Cloclo agent. Cloclo is a provider-agnostic CLI with built-in tools for file processing, code execution, and web browsing. Use it when:
+- An email has attachments that need processing (invoices, spreadsheets, documents)
+- You need to run code or scripts to answer a question
+- You need to browse a URL mentioned in an email for context
+- A task requires multiple steps (extract data from PDF, compute totals, draft response)
+- You want to use a different LLM provider than Claude for a specific sub-task
+
+Pass a natural language instruction as the 'query' parameter. Be specific about what you want done and what output you expect.`,
+      inputSchema: z.object({
+        query: z.string().describe("The task or question for Cloclo to handle"),
+        conversation_id: z
+          .string()
+          .optional()
+          .describe("Not used by Cloclo — included for interface compatibility"),
+      }),
+    };
+  }
+}

--- a/src/main/agents/providers/cloclo/types.ts
+++ b/src/main/agents/providers/cloclo/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Cloclo agent provider types.
+ *
+ * Cloclo CLI (`cloclo -p "..." --json`) returns structured JSON output.
+ * These types model both the provider configuration and the CLI output shape.
+ */
+
+import { z } from "zod";
+
+// --- Provider configuration (passed from settings) ---
+
+export interface ClocloProviderConfig {
+  enabled: boolean;
+  /** Override the model used by cloclo (e.g. "claude-sonnet", "gpt-5", "ollama/llama3") */
+  model?: string;
+  /** Extra CLI flags passed to cloclo */
+  extraFlags?: string[];
+}
+
+// --- CLI response shape (`cloclo -p "..." --json`) ---
+
+export const ClocloResponseSchema = z.object({
+  role: z.string(),
+  content: z.string(),
+  model: z.string().optional(),
+  usage: z.object({
+    input_tokens: z.number(),
+    output_tokens: z.number(),
+  }).optional(),
+  cost_usd: z.number().optional(),
+});
+
+export type ClocloResponse = z.infer<typeof ClocloResponseSchema>;

--- a/src/main/agents/types.ts
+++ b/src/main/agents/types.ts
@@ -163,6 +163,10 @@ export interface ProviderSettings {
   apiKey?: string;
   gatewayUrl?: string;
   gatewayToken?: string;
+  /** Model override for providers that support it (e.g. Cloclo). */
+  model?: string;
+  /** Extra CLI flags for providers that shell out to a CLI (e.g. Cloclo). */
+  extraFlags?: string[];
 }
 
 // --- IPC message types (utility process <-> main process) ---


### PR DESCRIPTION
Adds [Cloclo](https://github.com/SeifBenayed/claude-code-sdk) as an agent provider, following the same pattern as OpenClaw.

**What Cloclo brings to Exo:** provider-agnostic CLI with built-in tools — PDF, XLSX, DOCX extraction, browser automation, code execution, 13 LLM providers. Useful for processing email attachments, running code, and multi-step workflows.

**Changes:**
- `src/main/agents/providers/cloclo/` — provider + types (same architecture as OpenClaw)
- `src/main/agents/orchestrator.ts` — registered in provider registry

**Install:** `npm install -g cloclo`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
