### PR TITLE
Enable auto-discovery for electron-devtools-testing skill

### DIFF
--- a/.claude/skills/electron-devtools-testing/SKILL.md
+++ b/.claude/skills/electron-devtools-testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: electron-devtools-testing
 description: Test the Electron app interactively using Chrome DevTools Protocol. Use when the user asks to test, verify, or interact with the running app via browser automation.
-disable-model-invocation: true
 ---
 
 Test the Exo Electron app interactively using Chrome DevTools Protocol (CDP) via the `chrome-devtools` MCP.


### PR DESCRIPTION
## Summary
- Removed `disable-model-invocation: true` from the electron-devtools-testing skill's SKILL.md frontmatter
- This flag was preventing Claude from automatically discovering and suggesting the skill when users ask to test the running Electron app
- Other skills like `review-code` don't have this flag and are discoverable — this brings electron-devtools-testing in line

## Changes
- `.claude/skills/electron-devtools-testing/SKILL.md`: Removed `disable-model-invocation: true` from frontmatter

## Test plan
- [ ] Start a new Claude Code session and ask to "test the app" — verify the skill appears in the available skills list and Claude suggests using it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
