### PR TITLE
fix: resolve circular dependency crash in packaged app

### DIFF
--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -19,6 +19,7 @@ function getLogDir(): string {
   try {
     // Resolve the data directory inline to avoid a circular dependency
     // with data-dir.ts (which imports createLogger at module scope).
+    // NOTE: Keep this path logic in sync with getDataDir() in data-dir.ts.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { app } = require("electron");
     const dev = isDev();

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -17,9 +17,13 @@ import { mkdirSync, readdirSync, unlinkSync, statSync } from "fs";
 // without Electron being available.
 function getLogDir(): string {
   try {
+    // Resolve the data directory inline to avoid a circular dependency
+    // with data-dir.ts (which imports createLogger at module scope).
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { getDataDir } = require("../data-dir");
-    return join(getDataDir(), "logs");
+    const { app } = require("electron");
+    const dev = isDev();
+    const baseDir = dev ? join(app.getAppPath(), ".dev-data") : app.getPath("userData");
+    return join(baseDir, "logs");
   } catch {
     // Fallback for tests or non-Electron environments
     return join(process.cwd(), ".dev-data", "logs");


### PR DESCRIPTION
## Summary
- **Fixed a crash** on launch of the packaged (.dmg) macOS app: `Error: ENOENT: no such file or directory, mkdir '/.dev-data'`
- **Root cause**: Circular dependency between `data-dir.ts` and `logger.ts`. Logger lazy-required `getDataDir()` from data-dir, but data-dir imports `createLogger` at module scope. In the packaged app, the circular require returned an incomplete module, the catch fallback used `process.cwd()` (which is `/` on macOS when launched from Finder), and `mkdir("/.dev-data")` failed.
- **Fix**: Logger now resolves the data directory inline using Electron's `app` module directly (`app.getPath("userData")` for packaged, `app.getAppPath() + ".dev-data"` for dev), breaking the circular dependency.

## Changes
- `src/main/services/logger.ts`: Replaced `require("../data-dir").getDataDir()` with inline resolution via `require("electron").app`

## Test plan
- [ ] Install packaged app from .dmg and launch — should no longer show JavaScript error dialog
- [ ] Verify logs are written to `~/Library/Application Support/exo/logs/` in packaged app
- [ ] Verify `npm run dev` still writes logs to `.dev-data/logs/`
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
