### PR TITLE
feat: Add AI usage & cost tracking UI to Settings

### DIFF
--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -18,7 +18,7 @@ import {
 } from "../../shared/types";
 import { resetAnalyzer } from "./analysis.ipc";
 import { resetArchiveReadyAnalyzer } from "./archive-ready.ipc";
-import { resetClient } from "../services/anthropic-service";
+import { resetClient, getUsageStats, getCallHistory } from "../services/anthropic-service";
 import { prefetchService } from "../services/prefetch-service";
 import { agentCoordinator } from "../agents/agent-coordinator";
 import {
@@ -758,6 +758,32 @@ export function registerSettingsIpc(): void {
           success: false,
           error: error instanceof Error ? error.message : "Unknown error",
         };
+      }
+    },
+  );
+
+  // Usage / cost tracking
+  ipcMain.handle(
+    "settings:get-usage-stats",
+    async (): Promise<IpcResponse<ReturnType<typeof getUsageStats>>> => {
+      try {
+        return { success: true, data: getUsageStats() };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : "Unknown error" };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    "settings:get-call-history",
+    async (
+      _,
+      args?: { limit?: number },
+    ): Promise<IpcResponse<ReturnType<typeof getCallHistory>>> => {
+      try {
+        return { success: true, data: getCallHistory(args?.limit ?? 50) };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : "Unknown error" };
       }
     },
   );

--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -781,7 +781,8 @@ export function registerSettingsIpc(): void {
       args?: { limit?: number },
     ): Promise<IpcResponse<ReturnType<typeof getCallHistory>>> => {
       try {
-        return { success: true, data: getCallHistory(args?.limit ?? 50) };
+        const limit = Math.min(Math.max(args?.limit ?? 50, 1), 500);
+        return { success: true, data: getCallHistory(limit) };
       } catch (error) {
         return { success: false, error: error instanceof Error ? error.message : "Unknown error" };
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1061,6 +1061,13 @@ const api = {
       ipcRenderer.removeAllListeners("outbox:auth-required");
     },
   },
+
+  // Usage / cost tracking
+  usage: {
+    getStats: (): Promise<unknown> => ipcRenderer.invoke("settings:get-usage-stats"),
+    getCallHistory: (limit?: number): Promise<unknown> =>
+      ipcRenderer.invoke("settings:get-call-history", { limit }),
+  },
 };
 
 // Expose API to renderer

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -3259,7 +3259,7 @@ function UsageCostSection() {
                 {history.map((row) => (
                   <tr key={row.id} className="border-b border-gray-50 dark:border-gray-700/50">
                     <td className="py-1.5 text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                      {new Date(row.created_at + "Z").toLocaleString()}
+                      {new Date(row.created_at.replace(" ", "T") + "Z").toLocaleString()}
                     </td>
                     <td className="py-1.5 text-gray-900 dark:text-gray-100">{row.caller}</td>
                     <td className="py-1.5 text-gray-700 dark:text-gray-300 font-mono">

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -3081,7 +3081,213 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 </li>
               </ul>
             </div>
+
+            {/* AI Usage & Costs */}
+            <UsageCostSection />
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- Usage / Cost Tracking ----
+
+interface UsageStats {
+  today: { totalCostCents: number; totalCalls: number };
+  thisWeek: { totalCostCents: number; totalCalls: number };
+  thisMonth: { totalCostCents: number; totalCalls: number };
+  byModel: Array<{ model: string; costCents: number; calls: number }>;
+  byCaller: Array<{ caller: string; costCents: number; calls: number }>;
+}
+
+interface LlmCallRecord {
+  id: string;
+  created_at: string;
+  model: string;
+  caller: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_create_tokens: number;
+  cost_cents: number;
+  duration_ms: number;
+  success: number;
+  error_message: string | null;
+}
+
+const formatCost = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+function UsageCostSection() {
+  const { data: statsResult } = useQuery({
+    queryKey: ["usage-stats"],
+    queryFn: () => window.api.usage.getStats() as Promise<{ success: boolean; data: UsageStats }>,
+    refetchOnWindowFocus: true,
+    staleTime: 30_000,
+  });
+
+  const { data: historyResult } = useQuery({
+    queryKey: ["call-history"],
+    queryFn: () =>
+      window.api.usage.getCallHistory(50) as Promise<{ success: boolean; data: LlmCallRecord[] }>,
+    refetchOnWindowFocus: true,
+    staleTime: 30_000,
+  });
+
+  const stats = statsResult?.success ? statsResult.data : null;
+  const history = historyResult?.success ? historyResult.data : null;
+
+  return (
+    <div className="space-y-6 mt-8 border-t border-gray-200 dark:border-gray-700 pt-6">
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+          AI Usage & Costs
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Token usage and estimated costs for Claude API calls (last 30 days).
+        </p>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-3 gap-4">
+        {(
+          [
+            ["Today", stats?.today],
+            ["This Week", stats?.thisWeek],
+            ["This Month", stats?.thisMonth],
+          ] as const
+        ).map(([label, bucket]) => (
+          <div
+            key={label}
+            className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4"
+          >
+            <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              {label}
+            </p>
+            <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">
+              {formatCost(bucket?.totalCostCents ?? 0)}
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {bucket?.totalCalls ?? 0} calls
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Breakdown by Caller */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">By Caller</h4>
+        {stats?.byCaller && stats.byCaller.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th className="pb-2 font-medium">Caller</th>
+                <th className="pb-2 font-medium text-right">Cost</th>
+                <th className="pb-2 font-medium text-right">Calls</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.byCaller.map((row) => (
+                <tr key={row.caller} className="border-b border-gray-50 dark:border-gray-700/50">
+                  <td className="py-1.5 text-gray-900 dark:text-gray-100">{row.caller}</td>
+                  <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                    {formatCost(row.costCents)}
+                  </td>
+                  <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                    {row.calls}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-sm text-gray-400 dark:text-gray-500">No usage data yet.</p>
+        )}
+      </div>
+
+      {/* Breakdown by Model */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">By Model</h4>
+        {stats?.byModel && stats.byModel.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th className="pb-2 font-medium">Model</th>
+                <th className="pb-2 font-medium text-right">Cost</th>
+                <th className="pb-2 font-medium text-right">Calls</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.byModel.map((row) => (
+                <tr key={row.model} className="border-b border-gray-50 dark:border-gray-700/50">
+                  <td className="py-1.5 text-gray-900 dark:text-gray-100 font-mono text-xs">
+                    {row.model}
+                  </td>
+                  <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                    {formatCost(row.costCents)}
+                  </td>
+                  <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                    {row.calls}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-sm text-gray-400 dark:text-gray-500">No usage data yet.</p>
+        )}
+      </div>
+
+      {/* Recent Calls */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">Recent Calls</h4>
+        {history && history.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                  <th className="pb-2 font-medium">Time</th>
+                  <th className="pb-2 font-medium">Caller</th>
+                  <th className="pb-2 font-medium">Model</th>
+                  <th className="pb-2 font-medium text-right">Tokens (in/out)</th>
+                  <th className="pb-2 font-medium text-right">Cost</th>
+                  <th className="pb-2 font-medium text-right">Duration</th>
+                  <th className="pb-2 font-medium text-center">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map((row) => (
+                  <tr key={row.id} className="border-b border-gray-50 dark:border-gray-700/50">
+                    <td className="py-1.5 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                      {new Date(row.created_at + "Z").toLocaleString()}
+                    </td>
+                    <td className="py-1.5 text-gray-900 dark:text-gray-100">{row.caller}</td>
+                    <td className="py-1.5 text-gray-700 dark:text-gray-300 font-mono">
+                      {row.model}
+                    </td>
+                    <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                      {row.input_tokens.toLocaleString()} / {row.output_tokens.toLocaleString()}
+                    </td>
+                    <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                      {formatCost(row.cost_cents)}
+                    </td>
+                    <td className="py-1.5 text-right text-gray-700 dark:text-gray-300">
+                      {(row.duration_ms / 1000).toFixed(1)}s
+                    </td>
+                    <td className="py-1.5 text-center">
+                      <span
+                        className={`inline-block w-2 h-2 rounded-full ${
+                          row.success ? "bg-green-500" : "bg-red-500"
+                        }`}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-400 dark:text-gray-500">No calls recorded yet.</p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Wire existing `getUsageStats()` and `getCallHistory()` from `AnthropicService` through IPC handlers to the renderer
- Add `usage` namespace to preload API
- Add "AI Usage & Costs" section to Settings → Analytics tab

## Changes

- **`src/main/ipc/settings.ipc.ts`** — Two new IPC handlers: `settings:get-usage-stats` and `settings:get-call-history`
- **`src/preload/index.ts`** — New `usage` namespace exposing `getStats()` and `getCallHistory()`
- **`src/renderer/components/SettingsPanel.tsx`** — New `UsageCostSection` component with:
  - Summary cards (Today / This Week / This Month) showing cost + call count
  - Breakdown by Caller table (last 30 days)
  - Breakdown by Model table (last 30 days)
  - Recent Calls table (last 50) with timestamp, caller, model, tokens, cost, duration, status
  - Dark mode support throughout
  - Empty state handling ($0.00 / "No usage data yet")

## Test plan

- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Format passes (`npm run format:check`)
- [ ] Unit tests pass (1228/1228)
- [ ] Settings → Analytics tab renders summary cards
- [ ] Breakdown tables populate with real usage data
- [ ] Recent calls table shows entries with correct formatting
- [ ] Empty state renders gracefully with no LLM calls
- [ ] Dark mode styling is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
