### PR TITLE
feat: add Export Logs button for troubleshooting

### DIFF
--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, nativeTheme, BrowserWindow } from "electron";
+import { ipcMain, nativeTheme, BrowserWindow, shell, dialog } from "electron";
 import Store from "electron-store";
 import {
   type Config,
@@ -788,4 +788,52 @@ export function registerSettingsIpc(): void {
       }
     },
   );
+
+  // Export logs: zip the log directory and prompt the user to save
+  ipcMain.handle("settings:export-logs", async (): Promise<IpcResponse<void>> => {
+    try {
+      const { join } = await import("path");
+      const { readdirSync, mkdirSync } = await import("fs");
+      const { execFile } = await import("child_process");
+
+      const logDir = join(getDataDir(), "logs");
+      mkdirSync(logDir, { recursive: true });
+
+      const logFiles = readdirSync(logDir).filter((f) => f.endsWith(".log"));
+      if (logFiles.length === 0) {
+        return { success: false, error: "No log files found." };
+      }
+
+      const defaultName = `exo-logs-${new Date().toISOString().split("T")[0]}.zip`;
+      const { canceled, filePath } = await dialog.showSaveDialog({
+        title: "Export Logs",
+        defaultPath: defaultName,
+        filters: [{ name: "Zip Archive", extensions: ["zip"] }],
+      });
+
+      if (canceled || !filePath) {
+        return { success: true, data: undefined };
+      }
+
+      // Use macOS ditto to create a zip of the logs directory
+      await new Promise<void>((resolve, reject) => {
+        execFile(
+          "ditto",
+          ["-c", "-k", "--sequesterRsrc", logDir, filePath],
+          { timeout: 30_000 },
+          (error) => {
+            if (error) reject(error);
+            else resolve();
+          },
+        );
+      });
+
+      // Reveal the exported file in Finder
+      shell.showItemInFolder(filePath);
+
+      return { success: true, data: undefined };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : "Unknown error" };
+    }
+  });
 }

--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -792,6 +792,10 @@ export function registerSettingsIpc(): void {
   // Export logs: zip the log directory and prompt the user to save
   ipcMain.handle("settings:export-logs", async (): Promise<IpcResponse<void>> => {
     try {
+      if (process.platform !== "darwin") {
+        return { success: false, error: "Log export is currently only supported on macOS." };
+      }
+
       const { join } = await import("path");
       const { readdirSync, mkdirSync } = await import("fs");
       const { execFile } = await import("child_process");

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -229,6 +229,7 @@ const api = {
     getEA: (): Promise<unknown> => ipcRenderer.invoke("settings:get-ea"),
     setEA: (eaConfig: { enabled: boolean; email?: string; name?: string }): Promise<unknown> =>
       ipcRenderer.invoke("settings:set-ea", eaConfig),
+    exportLogs: (): Promise<unknown> => ipcRenderer.invoke("settings:export-logs"),
     validateGithubToken: (token: string): Promise<unknown> =>
       ipcRenderer.invoke("settings:validate-github-token", token),
     testOpenclawConnection: (): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1341,6 +1341,22 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 )}
               </div>
 
+              {/* Troubleshooting */}
+              <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-600">
+                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                  Troubleshooting
+                </h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                  Export log files to share with support. Email content is automatically redacted.
+                </p>
+                <button
+                  onClick={() => window.api.settings.exportLogs()}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+                >
+                  Export Logs
+                </button>
+              </div>
+
               {/* Save button */}
               <div className="flex justify-end">
                 <button

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -82,6 +82,8 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [enableSenderLookup, setEnableSenderLookup] = useState(true);
   const [modelConfig, setModelConfig] = useState<ModelConfig>(DEFAULT_MODEL_CONFIG);
   const [isSavingGeneral, setIsSavingGeneral] = useState(false);
+  const [isExportingLogs, setIsExportingLogs] = useState(false);
+  const [exportLogsError, setExportLogsError] = useState<string | null>(null);
   const [isDefaultMailApp, setIsDefaultMailApp] = useState(false);
   const [isDefaultMailAppLoading, setIsDefaultMailAppLoading] = useState(false);
   const [defaultMailAppError, setDefaultMailAppError] = useState("");
@@ -1350,11 +1352,29 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                   Export log files to share with support. Email content is automatically redacted.
                 </p>
                 <button
-                  onClick={() => window.api.settings.exportLogs()}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+                  onClick={async () => {
+                    setIsExportingLogs(true);
+                    setExportLogsError(null);
+                    try {
+                      const result = (await window.api.settings.exportLogs()) as {
+                        success: boolean;
+                        error?: string;
+                      };
+                      if (!result?.success && result?.error) {
+                        setExportLogsError(result.error);
+                      }
+                    } finally {
+                      setIsExportingLogs(false);
+                    }
+                  }}
+                  disabled={isExportingLogs}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors disabled:opacity-50"
                 >
-                  Export Logs
+                  {isExportingLogs ? "Exporting..." : "Export Logs"}
                 </button>
+                {exportLogsError && (
+                  <p className="text-sm text-red-600 dark:text-red-400 mt-2">{exportLogsError}</p>
+                )}
               </div>
 
               {/* Save button */}


### PR DESCRIPTION
## Summary
- Adds a "Troubleshooting" section to Settings > General with an "Export Logs" button
- Clicking the button zips the entire logs directory (`~/Library/Application Support/exo/logs/`) using macOS `ditto`, opens a native Save dialog, and reveals the saved file in Finder
- Email content is automatically redacted by the pino logger, so log files are safe to share

## Changes
- `src/main/ipc/settings.ipc.ts`: New `settings:export-logs` IPC handler (zip logs + save dialog + reveal in Finder)
- `src/preload/index.ts`: Expose `exportLogs()` in renderer API
- `src/renderer/components/SettingsPanel.tsx`: "Troubleshooting" section with Export Logs button in General tab

## Test plan
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`npm run format:check`)
- [x] All 1228 unit tests pass (`npm run test:unit`)
- [ ] Manual: click Export Logs in Settings > General, verify save dialog appears
- [ ] Manual: verify zip file contains .log files from the logs directory
- [ ] Manual: verify zip is revealed in Finder after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
