### PR TITLE
fix: add cancel button during Gmail OAuth authorization

### DIFF
--- a/src/main/ipc/gmail.ipc.ts
+++ b/src/main/ipc/gmail.ipc.ts
@@ -14,6 +14,9 @@ const useFakeData = isTestMode || isDemoMode;
 
 const gmailClients = new Map<string, GmailClient>();
 
+// Track the client used during initial OAuth so it can be cancelled
+let pendingOAuthClient: GmailClient | null = null;
+
 function resolveTargetAccountId(accountId?: string): string {
   const trimmedAccountId = accountId?.trim();
   const accounts = getAccounts();
@@ -118,7 +121,13 @@ export function registerGmailIpc(): void {
     try {
       // Reset clients to force re-auth
       gmailClients.clear();
-      const client = await getClient("default");
+
+      // Create the client manually so we can track it for cancellation
+      const client = new GmailClient("default");
+      pendingOAuthClient = client;
+      await client.connect();
+      gmailClients.set("default", client);
+      pendingOAuthClient = null;
 
       // Get the user's profile to save the account
       const profile = await client.getProfile();
@@ -139,10 +148,19 @@ export function registerGmailIpc(): void {
 
       return { success: true, data: undefined };
     } catch (error) {
+      pendingOAuthClient = null;
       return {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
       };
+    }
+  });
+
+  // Cancel an in-progress initial OAuth flow
+  ipcMain.handle("gmail:cancel-oauth", async (): Promise<void> => {
+    if (pendingOAuthClient) {
+      pendingOAuthClient.abortOAuth();
+      pendingOAuthClient = null;
     }
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,7 @@ const api = {
     saveCredentials: (clientId: string, clientSecret: string): Promise<unknown> =>
       ipcRenderer.invoke("gmail:save-credentials", { clientId, clientSecret }),
     startOAuth: (): Promise<unknown> => ipcRenderer.invoke("gmail:start-oauth"),
+    cancelOAuth: (): Promise<void> => ipcRenderer.invoke("gmail:cancel-oauth"),
   },
 
   // Analysis operations

--- a/src/renderer/components/SetupWizard.tsx
+++ b/src/renderer/components/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import type { IpcResponse } from "../../shared/types";
 import { reconfigurePostHog } from "../services/posthog";
 
@@ -34,11 +34,8 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const [extensionAuths, setExtensionAuths] = useState<ExtensionAuthInfo[]>([]);
   const [authenticatingExtension, setAuthenticatingExtension] = useState<string | null>(null);
 
-  // Analytics opt-in (default ON - session replay is bundled under analytics)
+  // Analytics opt-in (default ON — session replay is bundled under analytics)
   const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
-
-  // Track if user cancelled OAuth so the pending promise does not advance wizard
-  const oauthCancelledRef = useRef(false);
 
   // Check what's already configured and skip to the right step.
   useEffect(() => {
@@ -151,30 +148,36 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   };
 
   const handleStartOAuth = async () => {
-    oauthCancelledRef.current = false;
     setIsLoading(true);
     setError(null);
 
     try {
       const result = await window.api.gmail.startOAuth();
-      if (oauthCancelledRef.current) {
-        oauthCancelledRef.current = false;
-        return;
-      }
       if (result.success) {
         await enterExtensionsStep();
       } else {
+        if (result.error === "Authorization cancelled") {
+          // User cancelled — don't show as an error, just reset
+          setIsLoading(false);
+          return;
+        }
         setError(result.error);
         setIsLoading(false);
       }
     } catch (err) {
-      if (oauthCancelledRef.current) {
-        oauthCancelledRef.current = false;
+      const msg = err instanceof Error ? err.message : "Authorization failed. Please try again.";
+      if (msg === "Authorization cancelled") {
+        setIsLoading(false);
         return;
       }
-      setError(err instanceof Error ? err.message : "Authorization failed. Please try again.");
+      setError(msg);
       setIsLoading(false);
     }
+  };
+
+  const handleCancelOAuth = async () => {
+    await window.api.gmail.cancelOAuth();
+    setIsLoading(false);
   };
 
   const enterExtensionsStep = useCallback(async () => {
@@ -442,11 +445,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 
               {isLoading && (
                 <button
-                  onClick={() => {
-                    oauthCancelledRef.current = true;
-                    setIsLoading(false);
-                    setError("Authorization was cancelled. You can try again when ready.");
-                  }}
+                  onClick={handleCancelOAuth}
                   className="w-full mt-2 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
                 >
                   Cancel


### PR DESCRIPTION
## Problem

When user clicks "Authorize with Google" in the setup wizard, the button changes to "Authorizing..." and there is no way to cancel or go back. If the OAuth browser window opens in wrong Chrome profile or user just changes their mind, they are completely stuck on the authorizing screen with no exit.

The issue reporter describes this exact scenario - opened in wrong profile and couldnt do anything.

## Fix

Added a "Cancel" button that appears below the "Authorizing..." button while the OAuth flow is in progress:

```tsx
{isLoading && (
  <button onClick={() => {
    setIsLoading(false);
    setError("Authorization was cancelled. You can try again when ready.");
  }}>
    Cancel
  </button>
)}
```

When clicked:
1. Resets `isLoading` to false so the "Authorize with Google" button becomes clickable again
2. Shows a message explaining the authorization was cancelled and they can retry

The cancel button is styled as subtle text (not a primary button) so it doesnt compete visually with the main authorize button. It only appears during the loading state.

## What about the pending OAuth callback?

The OAuth flow runs server-side via IPC (`window.api.gmail.startOAuth()`). If user cancels on the UI side, the IPC call is still pending but when it eventually resolves or rejects, the component will just update state normally. The error case already has a catch handler. If user retries OAuth after cancelling, a new flow starts cleanly.

Closes #39
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
