### PR TITLE
Simplify OAuth permissions text in setup wizard

### DIFF
--- a/src/renderer/components/SetupWizard.tsx
+++ b/src/renderer/components/SetupWizard.tsx
@@ -409,7 +409,8 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 
               <div className="bg-yellow-50 dark:bg-yellow-900/30 p-4 rounded-lg mb-6">
                 <p className="text-sm text-yellow-800 dark:text-yellow-300">
-                  We&apos;ll request access to view and edit your emails and view your calendar events.
+                  We&apos;ll request access to view and edit your emails and view your calendar
+                  events.
                 </p>
               </div>
 

--- a/src/renderer/components/SetupWizard.tsx
+++ b/src/renderer/components/SetupWizard.tsx
@@ -408,14 +408,9 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
               </p>
 
               <div className="bg-yellow-50 dark:bg-yellow-900/30 p-4 rounded-lg mb-6">
-                <h3 className="font-semibold text-yellow-900 dark:text-yellow-200 mb-2">
-                  Permissions requested:
-                </h3>
-                <ul className="text-sm text-yellow-800 dark:text-yellow-300 space-y-1 list-disc list-inside">
-                  <li>Read your emails (gmail.readonly)</li>
-                  <li>Create draft emails (gmail.compose)</li>
-                  <li>View your calendar events (calendar.readonly)</li>
-                </ul>
+                <p className="text-sm text-yellow-800 dark:text-yellow-300">
+                  We&apos;ll request access to view and edit your emails and calendar events.
+                </p>
               </div>
 
               {error && (

--- a/src/renderer/components/SetupWizard.tsx
+++ b/src/renderer/components/SetupWizard.tsx
@@ -409,7 +409,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 
               <div className="bg-yellow-50 dark:bg-yellow-900/30 p-4 rounded-lg mb-6">
                 <p className="text-sm text-yellow-800 dark:text-yellow-300">
-                  We&apos;ll request access to view and edit your emails and calendar events.
+                  We&apos;ll request access to view and edit your emails and view your calendar events.
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
- Replace the detailed OAuth scopes list (gmail.readonly, gmail.compose, calendar.readonly) with a single human-readable sentence
- The setup wizard now says "We'll request access to view and edit your emails and calendar events" instead of listing individual API scopes

## Changes
- `src/renderer/components/SetupWizard.tsx`: Replaced the `<h3>` + `<ul>` scopes list with a single `<p>` element

## Test plan
- [ ] Verify the setup wizard OAuth step shows the simplified text
- [ ] Verify dark mode styling is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
