### PR TITLE
fix: eliminate main-thread blocking during sender profile enrichment

### DIFF
--- a/src/main/extensions/extension-host.ts
+++ b/src/main/extensions/extension-host.ts
@@ -365,6 +365,11 @@ export class ExtensionHost {
     );
 
     for (const provider of sortedProviders) {
+      // Yield between providers so sync DB cache checks don't pile up
+      // and starve the event loop when multiple enrichEmail calls resolve
+      // near-simultaneously from a Promise.all batch.
+      await new Promise((resolve) => setImmediate(resolve));
+
       // Get extension ID from the enrichment data (more reliable than parsing provider.id)
       const extensionId = this.getExtensionIdForProvider(provider);
 

--- a/src/main/extensions/extension-host.ts
+++ b/src/main/extensions/extension-host.ts
@@ -350,6 +350,8 @@ export class ExtensionHost {
    */
   async enrichEmail(
     email: DashboardEmail,
+    /** Thread emails for provider context. May be empty when allowNewLookups
+     *  is false (cache-hit path) since providers are not called. */
     threadEmails: DashboardEmail[],
     options: { allowNewLookups?: boolean } = {},
   ): Promise<ExtensionEnrichmentResult[]> {

--- a/src/main/services/prefetch-service.ts
+++ b/src/main/services/prefetch-service.ts
@@ -547,7 +547,12 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
     const CONCURRENCY: Record<PrefetchTask["type"], number> = {
       analysis: 10,
       "archive-ready": 10,
-      "sender-profile": 10,
+      // Sender-profile tasks make Claude API calls then do synchronous DB
+      // reads/writes on resolution. With 10 concurrent tasks resolving near-
+      // simultaneously, the sync DB bursts pile up and block the main thread
+      // for seconds (observed 7.8s event-loop lag). Cap at 3 so at most 3
+      // bursts of sync work can land back-to-back.
+      "sender-profile": 3,
       "agent-draft": 1,
     };
 
@@ -683,7 +688,14 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
   private async processAnalysis(emailId: string): Promise<void> {
     if (this.processedAnalysis.has(emailId)) return;
 
+    const tGet = performance.now();
     const email = getEmail(emailId);
+    const getTime = performance.now() - tGet;
+    if (getTime > 5) {
+      log.info(
+        `[PERF:processAnalysis] getEmail(${emailId.slice(0, 12)}) took ${getTime.toFixed(1)}ms`,
+      );
+    }
     if (!email) {
       this.processedAnalysis.add(emailId);
       return;
@@ -924,7 +936,9 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
       this.processedCounts.extensionEnrichment++;
 
       // Now trigger enrichment for all other emails waiting for this sender
-      // These will be cache hits - each extension handles its own caching
+      // These will be cache hits - each extension handles its own caching.
+      // Yield between each to avoid blocking the event loop with back-to-back
+      // sync DB reads (getEmail + getEmailsByThread + enrichment cache checks).
       const waitingEmails = this.pendingSenderLookups.get(senderEmail) || [];
       if (waitingEmails.length > 1) {
         let cachedCount = 0;
@@ -933,14 +947,17 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
             waitingEmailId !== emailId &&
             !this.processedExtensionEnrichments.has(waitingEmailId)
           ) {
+            // Yield with a brief delay so IPC handlers, UI updates, and
+            // incremental GC can run. setImmediate alone isn't enough — the
+            // rapid object allocation from cache-hit processing causes major
+            // GC pauses (~1s) when V8 defers collection too long.
+            await new Promise((resolve) => setTimeout(resolve, 5));
             const waitingEmail = getEmail(waitingEmailId);
             if (waitingEmail) {
-              const waitingThreadEmails = getEmailsByThread(
-                waitingEmail.threadId,
-                waitingEmail.accountId,
-              );
-              // allowNewLookups: false - these should all be cache hits
-              await extensionHost.enrichEmail(waitingEmail, waitingThreadEmails, {
+              // allowNewLookups: false means these are cache hits — threadEmails
+              // are only used by provider.enrich() which won't be called.
+              // Pass empty array to avoid loading full email bodies into memory.
+              await extensionHost.enrichEmail(waitingEmail, [], {
                 allowNewLookups: false,
               });
               this.processedExtensionEnrichments.add(waitingEmailId);
@@ -1040,7 +1057,14 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
       return;
     }
 
+    const tGetEmail = performance.now();
     const email = getEmail(emailId);
+    const getEmailTime = performance.now() - tGetEmail;
+    if (getEmailTime > 5) {
+      log.info(
+        `[PERF:processAgentDraft] getEmail(${emailId.slice(0, 12)}) took ${getEmailTime.toFixed(1)}ms`,
+      );
+    }
     if (!email || email.draft) {
       this.processedDrafts.add(emailId);
       this.markAgentDraftDone(emailId, "completed");

--- a/src/main/services/prefetch-service.ts
+++ b/src/main/services/prefetch-service.ts
@@ -688,14 +688,7 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
   private async processAnalysis(emailId: string): Promise<void> {
     if (this.processedAnalysis.has(emailId)) return;
 
-    const tGet = performance.now();
     const email = getEmail(emailId);
-    const getTime = performance.now() - tGet;
-    if (getTime > 5) {
-      log.info(
-        `[PERF:processAnalysis] getEmail(${emailId.slice(0, 12)}) took ${getTime.toFixed(1)}ms`,
-      );
-    }
     if (!email) {
       this.processedAnalysis.add(emailId);
       return;
@@ -1057,14 +1050,7 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
       return;
     }
 
-    const tGetEmail = performance.now();
     const email = getEmail(emailId);
-    const getEmailTime = performance.now() - tGetEmail;
-    if (getEmailTime > 5) {
-      log.info(
-        `[PERF:processAgentDraft] getEmail(${emailId.slice(0, 12)}) took ${getEmailTime.toFixed(1)}ms`,
-      );
-    }
     if (!email || email.draft) {
       this.processedDrafts.add(emailId);
       this.markAgentDraftDone(emailId, "completed");


### PR DESCRIPTION
## Summary

- **Root cause identified:** Sender-profile enrichment (not agent draft spawning as originally suspected) was blocking the main Electron thread for up to 7.8 seconds, causing the macOS beach ball. 10 concurrent Claude API calls with `web_search` would resolve near-simultaneously, each triggering synchronous SQLite reads/writes (enrichment cache checks, thread email loading, result persistence) that pile up with no yielding.
- **Reduced sender-profile concurrency** from 10 to 3, so at most 3 sync DB bursts can land back-to-back
- **Added event loop yields** (`setImmediate`/`setTimeout`) between enrichment providers and dedup cache-hit iterations
- **Eliminated unnecessary memory allocation** by skipping `getEmailsByThread()` for cache-hit dedup (thread emails are only used by `provider.enrich()` which isn't called for cache hits)

## Measured improvement

| Metric | Before | After |
|--------|--------|-------|
| Worst event loop lag | 7,803ms | 873ms |
| Lag events >1s | 5 | 0 |
| Lag events >200ms | 17 | 5 |
| Peak heap during enrichment | 952MB | reduced (skipping thread body loading) |

## Changes

- `src/main/services/prefetch-service.ts`: Sender-profile concurrency 10→3, yield in dedup loop, skip thread loading for cache hits
- `src/main/extensions/extension-host.ts`: Yield between enrichment providers in `enrichEmail()`

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] 1333 unit tests pass
- [x] Manual testing on real inbox (738 emails, 261 sender profiles) — no beach ball

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
