### PR TITLE
Use backup OAuth credentials in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Build
         env:
-          MAIN_VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          MAIN_VITE_GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          MAIN_VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID_BACKUP }}
+          MAIN_VITE_GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET_BACKUP }}
           VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           VITE_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: npm run build


### PR DESCRIPTION
## Summary
- Switch release workflow to use `GOOGLE_CLIENT_ID_BACKUP` / `GOOGLE_CLIENT_SECRET_BACKUP` GitHub secrets
- These point to a separate GCP project ("Gmail Drafter Testing") that operates in testing mode
- The primary GCP project ("Gmail Drafter") is pending Google verification for restricted Gmail scopes (`gmail.send`, `gmail.modify`), which hard-blocks new users from authenticating

## Changes
- `.github/workflows/release.yml`: Updated `MAIN_VITE_GOOGLE_CLIENT_ID` and `MAIN_VITE_GOOGLE_CLIENT_SECRET` env vars to use `_BACKUP` secrets

## Context
Once the primary project's verification completes, swap back to `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.

## Test plan
- [ ] Verify backup secrets are set in GitHub (`GOOGLE_CLIENT_ID_BACKUP`, `GOOGLE_CLIENT_SECRET_BACKUP`)
- [ ] Test OAuth flow with the backup credentials locally
- [ ] Trigger a release build and verify the app can authenticate new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
