### PR TITLE
fix: guard against destroyed BrowserWindow in agent coordinator

### DIFF
--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -585,12 +585,17 @@ export class AgentCoordinator {
         this.handleNetFetchRequest(msg.requestId, msg.url, msg.options);
         break;
       case "confirmation_request":
-        this.sendToRenderer("agent:confirmation", {
-          toolCallId: msg.toolCallId,
-          toolName: msg.toolName,
-          input: msg.input,
-          description: msg.description,
-        });
+        if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+          this.sendToRenderer("agent:confirmation", {
+            toolCallId: msg.toolCallId,
+            toolName: msg.toolName,
+            input: msg.input,
+            description: msg.description,
+          });
+        } else {
+          // Window is gone — auto-decline so the agent task doesn't hang indefinitely
+          this.resolveConfirmation(msg.toolCallId, false);
+        }
         break;
       case "providers_list":
         this.sendToRenderer("agent:providers", {

--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -177,6 +177,11 @@ export class AgentCoordinator {
     // Worker is spawned lazily on first use via ensureWorker()
   }
 
+  /** Update the window reference when macOS re-creates the window on activate. */
+  setMainWindow(mainWindow: BrowserWindow): void {
+    this.mainWindow = mainWindow;
+  }
+
   private spawnWorker(): void {
     // Worker lives in out/worker/, one level up from out/main/ where __dirname points
     const workerPath = path.join(__dirname, "..", "worker", "agent-worker.cjs");
@@ -361,13 +366,6 @@ export class AgentCoordinator {
 
     // Forward events from port1 to the renderer via IPC
     port1.on("message", (event) => {
-      // If the window was destroyed (user quit), cancel all running tasks
-      // immediately rather than continuing to process events to nowhere.
-      if (this.mainWindow?.isDestroyed()) {
-        this.cancelAll();
-        return;
-      }
-
       const agentEvent = event.data as ScopedAgentEvent;
       this.sendToRenderer("agent:event", {
         taskId,

--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -159,6 +159,17 @@ export class AgentCoordinator {
     ) => generateForwardForEmail({ emailId, accountId, instructions, to, cc, bcc }),
   } as const;
 
+  /**
+   * Safely send an IPC message to the renderer, guarding against
+   * the BrowserWindow having been destroyed (e.g. user quit the app
+   * while an agent task was still running).
+   */
+  private sendToRenderer(channel: string, ...args: unknown[]): void {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send(channel, ...args);
+    }
+  }
+
   start(mainWindow: BrowserWindow): void {
     if (this.started) return;
     this.mainWindow = mainWindow;
@@ -351,7 +362,7 @@ export class AgentCoordinator {
     // Forward events from port1 to the renderer via IPC
     port1.on("message", (event) => {
       const agentEvent = event.data as ScopedAgentEvent;
-      this.mainWindow?.webContents.send("agent:event", {
+      this.sendToRenderer("agent:event", {
         taskId,
         event: agentEvent,
       });
@@ -569,7 +580,7 @@ export class AgentCoordinator {
         this.handleNetFetchRequest(msg.requestId, msg.url, msg.options);
         break;
       case "confirmation_request":
-        this.mainWindow?.webContents.send("agent:confirmation", {
+        this.sendToRenderer("agent:confirmation", {
           toolCallId: msg.toolCallId,
           toolName: msg.toolName,
           input: msg.input,
@@ -577,7 +588,7 @@ export class AgentCoordinator {
         });
         break;
       case "providers_list":
-        this.mainWindow?.webContents.send("agent:providers", {
+        this.sendToRenderer("agent:providers", {
           providers: msg.providers,
         });
         break;
@@ -663,7 +674,7 @@ export class AgentCoordinator {
         method === "saveDraft"
           ? (args[4] as { cc?: string[]; bcc?: string[] } | undefined)
           : { cc: args[3] as string[] | undefined, bcc: args[4] as string[] | undefined };
-      this.mainWindow?.webContents.send("agent:draft-saved", {
+      this.sendToRenderer("agent:draft-saved", {
         emailId,
         draft: {
           body: draftBody,
@@ -678,7 +689,7 @@ export class AgentCoordinator {
     if (method === "generateDraft" && result && typeof result === "object" && "body" in result) {
       const emailId = args[0] as string;
       const genResult = result as { body: string; cc?: string[]; bcc?: string[] };
-      this.mainWindow?.webContents.send("agent:draft-saved", {
+      this.sendToRenderer("agent:draft-saved", {
         emailId,
         draft: {
           body: genResult.body,
@@ -691,7 +702,7 @@ export class AgentCoordinator {
     }
     if (method === "saveLocalDraft" && args.length >= 1) {
       const draft = args[0] as Record<string, unknown>;
-      this.mainWindow?.webContents.send("agent:local-draft-saved", { draft });
+      this.sendToRenderer("agent:local-draft-saved", { draft });
     }
     // generateForward now saves via saveDraftAndSync (same as generateDraft) —
     // notify the renderer so the inline draft appears on the email
@@ -701,7 +712,7 @@ export class AgentCoordinator {
       const forwardCc = (args.length >= 5 ? args[4] : undefined) as string[] | undefined;
       const forwardBcc = (args.length >= 6 ? args[5] : undefined) as string[] | undefined;
       const genResult = result as { body: string };
-      this.mainWindow?.webContents.send("agent:draft-saved", {
+      this.sendToRenderer("agent:draft-saved", {
         emailId,
         draft: {
           body: genResult.body,

--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -361,6 +361,13 @@ export class AgentCoordinator {
 
     // Forward events from port1 to the renderer via IPC
     port1.on("message", (event) => {
+      // If the window was destroyed (user quit), cancel all running tasks
+      // immediately rather than continuing to process events to nowhere.
+      if (this.mainWindow?.isDestroyed()) {
+        this.cancelAll();
+        return;
+      }
+
       const agentEvent = event.data as ScopedAgentEvent;
       this.sendToRenderer("agent:event", {
         taskId,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -223,7 +223,8 @@ function handleMailtoUrl(url: string): void {
     pendingMailtoUrl = url;
     // On macOS the app can be running with no windows; create one so the URL gets consumed
     if (app.isReady()) {
-      createWindow();
+      const newWindow = createWindow();
+      agentCoordinator.setMainWindow(newWindow);
     }
     return;
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -485,7 +485,10 @@ app.whenReady().then(async () => {
 
   app.on("activate", function () {
     // On macOS re-create a window when dock icon is clicked and no windows are open
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    if (BrowserWindow.getAllWindows().length === 0) {
+      const newWindow = createWindow();
+      agentCoordinator.setMainWindow(newWindow);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Object has been destroyed` crash that floods error dialogs when the user closes the app while an agent task is running
- Agent tasks now survive macOS window close (Cmd+W) — they keep running in the utility process and reconnect when the window reopens
- Added `sendToRenderer()` helper that checks `isDestroyed()` before all IPC sends to the renderer
- Added `setMainWindow()` so the coordinator reconnects when macOS re-creates the window on dock click

## Changes

- `src/main/agents/agent-coordinator.ts`: Replace all 7 `mainWindow?.webContents.send()` calls with `sendToRenderer()` guard that checks `isDestroyed()`. Add `setMainWindow()` for window reconnection. Remove overly aggressive `cancelAll()` on window destruction.
- `src/main/index.ts`: Call `agentCoordinator.setMainWindow(newWindow)` in the `activate` handler so agent events resume flowing to the new window.

## Root cause

The `MessagePortMain` handler in `AgentCoordinator` fires on every agent event (streaming tokens, tool calls, state changes). When the `BrowserWindow` is destroyed, `this.mainWindow` is still a non-null reference but its internal Electron resources are freed. Optional chaining (`?.`) only guards against null/undefined, not a destroyed Electron object — so `webContents.send()` throws `TypeError: Object has been destroyed` for every event, causing a flood of native error dialogs.

## Test plan

- [x] Manually reproduced on pre-fix code: select email → Cmd+J → start agent task → Cmd+Q → error dialog flood
- [x] Verified fix: same repro steps → clean exit, no error dialogs
- [x] Verified macOS window re-create: close window → reopen from dock → agent tasks not marked as failed
- [x] Type check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
