### PR TITLE
docs: strengthen force push guard in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Generally i will give one git worktree one branch to work with and itll be clear
 
 ### Requires confirmation
 - `git push` — makes changes visible to others; always ask first
-- `git push --force` — never without explicit approval
+- `git push --force` — **never do this without explicitly asking the user first and getting approval**. Even if the situation seems to call for it, always check first.
 - `git reset --hard` — never without explicit approval
 - `git rebase` — never without explicit approval
 - `git clean -f`, `git checkout .`, `git restore .`, `git branch -D` — destructive, always ask first


### PR DESCRIPTION
## Summary
- Strengthened the `git push --force` instruction in CLAUDE.md to make it unambiguous that agents must explicitly ask the user and get approval before any force push
- Previous wording ("never without explicit approval") was ambiguous — new wording makes the ask-first requirement clear

## Changes
- Updated the `git push --force` line in the "Requires confirmation" section of CLAUDE.md

## Test plan
- [x] Verify the CLAUDE.md change reads correctly and is consistent with surrounding instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
