### PR TITLE
feat: add "Sent by Exo" branding signature with opt-out toggle

### DIFF
--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -58,6 +58,7 @@ function getStore(): Store<{ config: Config }> {
           theme: "system" as const,
           inboxDensity: "compact" as const,
           undoSendDelay: 5,
+          showExoBranding: true,
           autoDraft: {
             enabled: true,
             priorities: ["high", "medium", "low"],

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -152,6 +152,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [signatures, setSignatures] = useState<Signature[]>([]);
   const [editingSignature, setEditingSignature] = useState<Signature | null>(null);
   const [isSavingSignatures, setIsSavingSignatures] = useState(false);
+  const [showExoBranding, setShowExoBranding] = useState(true);
 
   // Fetch current prompts
   const { data: prompts, isLoading } = useQuery({
@@ -246,6 +247,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   useEffect(() => {
     if (generalConfig) {
       setSignatures(generalConfig.signatures ?? []);
+      setShowExoBranding(generalConfig.showExoBranding !== false);
     }
   }, [generalConfig]);
 
@@ -503,6 +505,12 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
     } finally {
       setIsSavingSignatures(false);
     }
+  };
+
+  const handleToggleExoBranding = async (enabled: boolean) => {
+    setShowExoBranding(enabled);
+    await window.api.settings.set({ showExoBranding: enabled });
+    queryClient.invalidateQueries({ queryKey: ["general-config"] });
   };
 
   const handleAddSignature = () => {
@@ -1600,6 +1608,30 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 Create and manage email signatures. The default signature is automatically appended
                 when composing new emails.
               </p>
+
+              {/* Exo branding toggle */}
+              <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4 mb-6">
+                <label className="flex items-center space-x-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={showExoBranding}
+                    onChange={(e) => handleToggleExoBranding(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                  />
+                  <div>
+                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                      Show &quot;Sent by Exo&quot; branding
+                    </span>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Appends a small &quot;Sent by{" "}
+                      <a href="https://exo.email" className="text-blue-500 hover:underline">
+                        Exo
+                      </a>
+                      &quot; line after your signature.
+                    </p>
+                  </div>
+                </label>
+              </div>
 
               {/* Signature list */}
               {!editingSignature && (

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -508,9 +508,13 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   };
 
   const handleToggleExoBranding = async (enabled: boolean) => {
-    setShowExoBranding(enabled);
-    await window.api.settings.set({ showExoBranding: enabled });
-    queryClient.invalidateQueries({ queryKey: ["general-config"] });
+    try {
+      await window.api.settings.set({ showExoBranding: enabled });
+      setShowExoBranding(enabled);
+      queryClient.invalidateQueries({ queryKey: ["general-config"] });
+    } catch {
+      // state stays at previous value; next config load will re-sync
+    }
   };
 
   const handleAddSignature = () => {

--- a/src/renderer/hooks/useSignature.ts
+++ b/src/renderer/hooks/useSignature.ts
@@ -6,7 +6,7 @@ export function useSignature(accountId: string) {
   const [activeSignatureId, setActiveSignatureId] = useState<string | null>(null);
   const [hasUserChosen, setHasUserChosen] = useState(false);
 
-  const { data: signatureConfig } = useQuery({
+  const { data: configData } = useQuery({
     queryKey: ["general-config"],
     queryFn: async () => {
       const result = (await window.api.settings.get()) as IpcResponse<Config>;
@@ -15,10 +15,10 @@ export function useSignature(accountId: string) {
       }
       return null;
     },
-    select: (config) => config?.signatures ?? [],
   });
 
-  const allSignatures = signatureConfig ?? [];
+  const allSignatures = configData?.signatures ?? [];
+  const showExoBranding = configData?.showExoBranding !== false;
 
   const availableSignatures = useMemo(
     () => allSignatures.filter((s: Signature) => !s.accountId || s.accountId === accountId),
@@ -45,9 +45,15 @@ export function useSignature(accountId: string) {
 
   const activeSignature = availableSignatures.find((s: Signature) => s.id === activeSignatureId);
 
-  const signatureHtml = activeSignature?.bodyHtml
-    ? `<div class="email-signature"><br><div>--</div>${activeSignature.bodyHtml}</div>`
+  const exoBrandingHtml = showExoBranding
+    ? `<div style="margin-top:12px;font-size:12px;color:#999;">Sent by <a href="https://exo.email" style="color:#999;">Exo</a></div>`
     : "";
+
+  const signatureHtml = activeSignature?.bodyHtml
+    ? `<div class="email-signature"><br><div>--</div>${activeSignature.bodyHtml}${exoBrandingHtml}</div>`
+    : exoBrandingHtml
+      ? `<div class="email-signature">${exoBrandingHtml}</div>`
+      : "";
 
   return {
     activeSignatureId,

--- a/src/renderer/hooks/useSignature.ts
+++ b/src/renderer/hooks/useSignature.ts
@@ -52,7 +52,7 @@ export function useSignature(accountId: string) {
   const signatureHtml = activeSignature?.bodyHtml
     ? `<div class="email-signature"><br><div>--</div>${activeSignature.bodyHtml}${exoBrandingLine}</div>`
     : exoBrandingLine
-      ? `<div class="email-signature"><br><div>--</div>${exoBrandingLine}</div>`
+      ? `<div class="email-signature"><br>${exoBrandingLine}</div>`
       : "";
 
   return {

--- a/src/renderer/hooks/useSignature.ts
+++ b/src/renderer/hooks/useSignature.ts
@@ -52,7 +52,7 @@ export function useSignature(accountId: string) {
   const signatureHtml = activeSignature?.bodyHtml
     ? `<div class="email-signature"><br><div>--</div>${activeSignature.bodyHtml}${exoBrandingLine}</div>`
     : exoBrandingLine
-      ? `<div class="email-signature"><br>${exoBrandingLine}</div>`
+      ? `<div class="email-signature"><br><div>--</div>${exoBrandingLine}</div>`
       : "";
 
   return {

--- a/src/renderer/hooks/useSignature.ts
+++ b/src/renderer/hooks/useSignature.ts
@@ -45,14 +45,14 @@ export function useSignature(accountId: string) {
 
   const activeSignature = availableSignatures.find((s: Signature) => s.id === activeSignatureId);
 
-  const exoBrandingHtml = showExoBranding
-    ? `<div style="margin-top:12px;font-size:12px;color:#999;"><div>--</div>Sent by <a href="https://exo.email" style="color:#999;">Exo</a></div>`
+  const exoBrandingLine = showExoBranding
+    ? `<div style="margin-top:12px;font-size:12px;color:#999;">Sent by <a href="https://exo.email" style="color:#999;">Exo</a></div>`
     : "";
 
   const signatureHtml = activeSignature?.bodyHtml
-    ? `<div class="email-signature"><br><div>--</div>${activeSignature.bodyHtml}${exoBrandingHtml}</div>`
-    : exoBrandingHtml
-      ? `<div class="email-signature">${exoBrandingHtml}</div>`
+    ? `<div class="email-signature"><br><div>--</div>${activeSignature.bodyHtml}${exoBrandingLine}</div>`
+    : exoBrandingLine
+      ? `<div class="email-signature"><br><div>--</div>${exoBrandingLine}</div>`
       : "";
 
   return {

--- a/src/renderer/hooks/useSignature.ts
+++ b/src/renderer/hooks/useSignature.ts
@@ -46,7 +46,7 @@ export function useSignature(accountId: string) {
   const activeSignature = availableSignatures.find((s: Signature) => s.id === activeSignatureId);
 
   const exoBrandingHtml = showExoBranding
-    ? `<div style="margin-top:12px;font-size:12px;color:#999;">Sent by <a href="https://exo.email" style="color:#999;">Exo</a></div>`
+    ? `<div style="margin-top:12px;font-size:12px;color:#999;"><div>--</div>Sent by <a href="https://exo.email" style="color:#999;">Exo</a></div>`
     : "";
 
   const signatureHtml = activeSignature?.bodyHtml

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -379,6 +379,7 @@ export const ConfigSchema = z.object({
   inboxDensity: z.enum(["default", "compact"]).default("compact"),
   undoSendDelay: z.number().min(0).max(30).default(5), // seconds; 0 = disabled
   signatures: z.array(SignatureSchema).optional(),
+  showExoBranding: z.boolean().default(true),
   stylePrompt: z.string().optional(),
   githubToken: z.string().optional(),
   allowPrereleaseUpdates: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Appends a "Sent by [Exo](https://exo.email)" line after the user's email signature on all outgoing emails, preceded by a `--` separator
- Enabled by default via `showExoBranding: boolean` config field (defaults to `true`)
- Adds a checkbox in **Settings → Signatures** to toggle the branding on/off, persisted immediately to config

## Changes
- `src/shared/types.ts`: Added `showExoBranding` field to `ConfigSchema` with `z.boolean().default(true)`
- `src/renderer/hooks/useSignature.ts`: Reads `showExoBranding` from config, appends branding HTML after user signature (or standalone with `--` separator if no signature)
- `src/renderer/components/SettingsPanel.tsx`: Added state, handler, and checkbox UI for the branding toggle at the top of the Signatures tab

## Test plan
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] All 1333 unit tests pass (`npm run test:unit`)
- [ ] Manual: compose email with signature → verify single `--` separator + branding line
- [ ] Manual: compose email without signature → verify `--` separator + branding line
- [ ] Manual: disable branding in Settings → Signatures → verify no branding in compose
- [ ] Manual: re-enable branding → verify it reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
