### PR TITLE
fix: stabilize flaky CLI tools persistence e2e test

### DIFF
--- a/tests/e2e/cli-tools-settings.spec.ts
+++ b/tests/e2e/cli-tools-settings.spec.ts
@@ -116,20 +116,21 @@ test.describe("Settings - CLI Tools", () => {
     // Save after removing
     const saveButton = page.locator("button:has-text('Save')").last();
     await saveButton.click();
-    await page.waitForTimeout(500);
+    await expect(page.locator("button:has-text('Saved')")).toBeVisible({ timeout: 3000 });
 
-    // Close settings
+    // Close settings with Escape (reliable — settings has priority in the handler)
     await page.keyboard.press("Escape");
-    await page.waitForTimeout(300);
+    await expect(page.locator("h1:has-text('Settings')")).toBeHidden({ timeout: 5000 });
 
-    // Reopen settings
-    await page.keyboard.press("ControlOrMeta+,");
+    // Reopen settings via button (keyboard shortcut Ctrl+, is unreliable on CI)
+    const settingsButton = page.locator("button[title='Settings']");
+    await settingsButton.click();
     await expect(page.locator("h1:has-text('Settings')")).toBeVisible({ timeout: 5000 });
 
     // Navigate back to Agents tab
     const agentsTab = page.locator("button:has-text('Agents')");
     await agentsTab.click();
-    await page.waitForTimeout(500);
+    await expect(agentsTab).toHaveAttribute("data-active", "true", { timeout: 3000 });
 
     await expect(page.locator("h4:has-text('CLI Tools')")).toBeVisible({ timeout: 5000 });
 


### PR DESCRIPTION
## Summary
- Fixed flaky e2e test `CLI tools persist after closing and reopening settings` that was failing intermittently on CI
- Replaced unreliable `ControlOrMeta+,` keyboard shortcut (swallowed by `isInputFocused()` guard in keyboard handler) with clicking the settings button
- Replaced all `waitForTimeout()` calls with proper Playwright assertions (`toBeHidden`, `toBeVisible`, `toHaveAttribute`) that wait for actual state transitions

## Changes
- `tests/e2e/cli-tools-settings.spec.ts`: Rewrote the persistence test to use click-based UI interactions and assertion-based waits instead of keyboard shortcuts and fixed timeouts

## Test plan
- [x] Ran the specific test 5 consecutive times locally — all passed
- [x] Ran full unit test suite (1168 passed)
- [x] Ran full e2e test suite (336 passed)
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
