### PR TITLE
fix: guard SonicBoom writes to prevent destroyed error on startup

### DIFF
--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -14,6 +14,35 @@ import { type SonicBoom } from "sonic-boom";
 import { join } from "path";
 import { mkdirSync, readdirSync, unlinkSync, statSync } from "fs";
 import { tmpdir } from "os";
+import { Writable } from "stream";
+
+/**
+ * Wraps a SonicBoom destination so that writes to a destroyed stream are
+ * silently dropped instead of throwing "SonicBoom destroyed". This prevents
+ * logger errors from propagating up through IPC handlers during shutdown
+ * race conditions (see GitHub issue #67).
+ */
+function safeSonicBoomWrapper(dest: SonicBoom): Writable {
+  return new Writable({
+    write(chunk, _encoding, callback) {
+      try {
+        if (dest.destroyed) {
+          callback();
+          return;
+        }
+        dest.write(chunk);
+        callback();
+      } catch {
+        // Swallow write errors (e.g. "SonicBoom destroyed") — logging
+        // should never crash the app.
+        callback();
+      }
+    },
+    final(callback) {
+      callback();
+    },
+  });
+}
 
 // Lazy-require Electron modules so this file can be imported in tests
 // without Electron being available.
@@ -91,9 +120,10 @@ function initLogger(): Logger {
   const streams: pino.StreamEntry[] = [
     // Async writes — closeLogs() ends the SonicBoom destinations in before-quit,
     // deregistering pino's exit hook to prevent "sonic boom is not ready yet" crash.
+    // Wrapped in safeSonicBoomWrapper so writes after destroy are silently dropped.
     {
       level: "debug" as const,
-      stream: fileDest,
+      stream: safeSonicBoomWrapper(fileDest),
     },
   ];
 
@@ -112,7 +142,7 @@ function initLogger(): Logger {
       _destinations.push(stdoutDest);
       streams.push({
         level: "debug" as const,
-        stream: stdoutDest, // fd 1 = stdout
+        stream: safeSonicBoomWrapper(stdoutDest),
       });
     }
   }

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -38,6 +38,9 @@ function safeSonicBoomWrapper(dest: SonicBoom): Writable & { flushSync?: () => v
         callback();
       }
     },
+    // Intentionally does NOT forward end() to the underlying SonicBoom.
+    // closeLogs() calls dest.end() on the raw _destinations refs directly,
+    // which flushes SonicBoom's internal buffer before closing.
     final(callback) {
       callback();
     },

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -22,8 +22,8 @@ import { Writable } from "stream";
  * logger errors from propagating up through IPC handlers during shutdown
  * race conditions (see GitHub issue #67).
  */
-function safeSonicBoomWrapper(dest: SonicBoom): Writable {
-  return new Writable({
+function safeSonicBoomWrapper(dest: SonicBoom): Writable & { flushSync?: () => void } {
+  const wrapper = new Writable({
     write(chunk, _encoding, callback) {
       try {
         if (dest.destroyed) {
@@ -42,6 +42,16 @@ function safeSonicBoomWrapper(dest: SonicBoom): Writable {
       callback();
     },
   });
+  // Expose flushSync so pino's logger.flush() can still synchronously
+  // flush the underlying SonicBoom buffer to disk.
+  (wrapper as Writable & { flushSync: () => void }).flushSync = () => {
+    try {
+      if (!dest.destroyed) dest.flushSync();
+    } catch {
+      /* best effort */
+    }
+  };
+  return wrapper;
 }
 
 // Lazy-require Electron modules so this file can be imported in tests

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -26,7 +26,7 @@ function safeSonicBoomWrapper(dest: SonicBoom): Writable & { flushSync?: () => v
   const wrapper = new Writable({
     write(chunk, _encoding, callback) {
       try {
-        if (dest.destroyed) {
+        if ((dest as unknown as { destroyed: boolean }).destroyed) {
           callback();
           return;
         }
@@ -49,7 +49,7 @@ function safeSonicBoomWrapper(dest: SonicBoom): Writable & { flushSync?: () => v
   // flush the underlying SonicBoom buffer to disk.
   (wrapper as Writable & { flushSync: () => void }).flushSync = () => {
     try {
-      if (!dest.destroyed) dest.flushSync();
+      if (!(dest as unknown as { destroyed: boolean }).destroyed) dest.flushSync();
     } catch {
       /* best effort */
     }


### PR DESCRIPTION
## Summary

Fixes #67

- Wraps SonicBoom log destinations in a safe `Writable` stream that silently drops writes when the underlying stream is destroyed
- Prevents the race condition where IPC handlers hold child logger references that outlive the SonicBoom lifecycle during shutdown/hot-reload
- Logger errors no longer propagate as IPC failures to the renderer

## Changes

- `src/main/services/logger.ts`: Added `safeSonicBoomWrapper()` that checks `dest.destroyed` before writing and catches errors, applied to both file and stdout SonicBoom destinations

## Test plan

- [x] TypeScript type check passes
- [x] All 1333 unit tests pass
- [x] ESLint passes
- [ ] Manual: verify app starts without "SonicBoom destroyed" errors
- [ ] Manual: verify logs still write correctly during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
