### PR TITLE
fix: replace window.prompt() with inline link popover in compose editor

### DIFF
--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -94,14 +94,9 @@ function LinkPopover({
       if (anchorRef.current?.contains(target)) return;
       onClose();
     };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
     document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleEscape);
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscape);
     };
   }, [onClose, anchorRef]);
 
@@ -117,6 +112,12 @@ function LinkPopover({
   return (
     <div
       ref={popoverRef}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.nativeEvent.stopImmediatePropagation();
+          onClose();
+        }
+      }}
       className="absolute top-full left-0 mt-1 z-50 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-2 flex items-center gap-1.5"
     >
       <input
@@ -125,6 +126,11 @@ function LinkPopover({
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.stopPropagation();
+            e.nativeEvent.stopImmediatePropagation();
+            onClose();
+          }
           if (e.key === "Enter") {
             e.preventDefault();
             apply();

--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -340,11 +340,7 @@ function Toolbar({ editor }: { editor: Editor | null }) {
           </svg>
         </ToolbarButton>
         {showLinkPopover && (
-          <LinkPopover
-            editor={editor}
-            onClose={closeLinkPopover}
-            anchorRef={linkButtonRef}
-          />
+          <LinkPopover editor={editor} onClose={closeLinkPopover} anchorRef={linkButtonRef} />
         )}
       </div>
 

--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -71,9 +71,11 @@ function readFileAsDataUrl(file: File): Promise<string> {
 function LinkPopover({
   editor,
   onClose,
+  anchorRef,
 }: {
   editor: Editor;
   onClose: () => void;
+  anchorRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const previousUrl = editor.getAttributes("link").href;
   const [url, setUrl] = useState(previousUrl || "https://");
@@ -86,9 +88,11 @@ function LinkPopover({
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        onClose();
-      }
+      const target = e.target as Node;
+      // Ignore clicks on the popover itself or the anchor button (toggle handles that)
+      if (popoverRef.current?.contains(target)) return;
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
     };
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -99,7 +103,7 @@ function LinkPopover({
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEscape);
     };
-  }, [onClose]);
+  }, [onClose, anchorRef]);
 
   const apply = () => {
     if (url.trim() === "") {
@@ -156,6 +160,7 @@ function LinkPopover({
 function Toolbar({ editor }: { editor: Editor | null }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showLinkPopover, setShowLinkPopover] = useState(false);
+  const linkButtonRef = useRef<HTMLDivElement>(null);
 
   const toggleLinkPopover = useCallback(() => {
     setShowLinkPopover((prev) => !prev);
@@ -309,8 +314,12 @@ function Toolbar({ editor }: { editor: Editor | null }) {
       </ToolbarButton>
 
       {/* Link */}
-      <div className="relative">
-        <ToolbarButton onClick={toggleLinkPopover} active={editor.isActive("link")} title="Insert link">
+      <div className="relative" ref={linkButtonRef}>
+        <ToolbarButton
+          onClick={toggleLinkPopover}
+          active={editor.isActive("link")}
+          title="Insert link"
+        >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
@@ -321,7 +330,11 @@ function Toolbar({ editor }: { editor: Editor | null }) {
           </svg>
         </ToolbarButton>
         {showLinkPopover && (
-          <LinkPopover editor={editor} onClose={() => setShowLinkPopover(false)} />
+          <LinkPopover
+            editor={editor}
+            onClose={() => setShowLinkPopover(false)}
+            anchorRef={linkButtonRef}
+          />
         )}
       </div>
 

--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -166,6 +166,10 @@ function Toolbar({ editor }: { editor: Editor | null }) {
     setShowLinkPopover((prev) => !prev);
   }, []);
 
+  const closeLinkPopover = useCallback(() => {
+    setShowLinkPopover(false);
+  }, []);
+
   const insertImage = useCallback(() => {
     fileInputRef.current?.click();
   }, []);
@@ -332,7 +336,7 @@ function Toolbar({ editor }: { editor: Editor | null }) {
         {showLinkPopover && (
           <LinkPopover
             editor={editor}
-            onClose={() => setShowLinkPopover(false)}
+            onClose={closeLinkPopover}
             anchorRef={linkButtonRef}
           />
         )}

--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -8,7 +8,7 @@ import Link from "@tiptap/extension-link";
 import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
 import TextAlign from "@tiptap/extension-text-align";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../store";
 import { ContactMention } from "./MentionSuggestion";
 
@@ -67,24 +67,99 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
+// Inline popover for entering a link URL
+function LinkPopover({
+  editor,
+  onClose,
+}: {
+  editor: Editor;
+  onClose: () => void;
+}) {
+  const previousUrl = editor.getAttributes("link").href;
+  const [url, setUrl] = useState(previousUrl || "https://");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onClose]);
+
+  const apply = () => {
+    if (url.trim() === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+    } else {
+      editor.chain().focus().extendMarkRange("link").setLink({ href: url.trim() }).run();
+    }
+    onClose();
+  };
+
+  return (
+    <div
+      ref={popoverRef}
+      className="absolute top-full left-0 mt-1 z-50 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-2 flex items-center gap-1.5"
+    >
+      <input
+        ref={inputRef}
+        type="url"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            apply();
+          }
+        }}
+        placeholder="https://example.com"
+        className="w-56 px-2 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      />
+      <button
+        type="button"
+        onClick={apply}
+        className="px-2 py-1 text-sm rounded bg-blue-600 text-white hover:bg-blue-700"
+      >
+        Apply
+      </button>
+      {previousUrl && (
+        <button
+          type="button"
+          onClick={() => {
+            editor.chain().focus().extendMarkRange("link").unsetLink().run();
+            onClose();
+          }}
+          className="px-2 py-1 text-sm rounded text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
+        >
+          Remove
+        </button>
+      )}
+    </div>
+  );
+}
+
 // Toolbar component
 function Toolbar({ editor }: { editor: Editor | null }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showLinkPopover, setShowLinkPopover] = useState(false);
 
-  const setLink = useCallback(() => {
-    if (!editor) return;
-    const previousUrl = editor.getAttributes("link").href;
-    const url = window.prompt("Enter URL:", previousUrl || "https://");
-
-    if (url === null) return;
-
-    if (url === "") {
-      editor.chain().focus().extendMarkRange("link").unsetLink().run();
-      return;
-    }
-
-    editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
-  }, [editor]);
+  const toggleLinkPopover = useCallback(() => {
+    setShowLinkPopover((prev) => !prev);
+  }, []);
 
   const insertImage = useCallback(() => {
     fileInputRef.current?.click();
@@ -234,16 +309,21 @@ function Toolbar({ editor }: { editor: Editor | null }) {
       </ToolbarButton>
 
       {/* Link */}
-      <ToolbarButton onClick={setLink} active={editor.isActive("link")} title="Insert link">
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-          />
-        </svg>
-      </ToolbarButton>
+      <div className="relative">
+        <ToolbarButton onClick={toggleLinkPopover} active={editor.isActive("link")} title="Insert link">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            />
+          </svg>
+        </ToolbarButton>
+        {showLinkPopover && (
+          <LinkPopover editor={editor} onClose={() => setShowLinkPopover(false)} />
+        )}
+      </div>
 
       <div className="w-px h-5 bg-gray-300 dark:bg-gray-600 mx-1" />
 

--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -422,6 +422,7 @@ export function ComposeEditor({
       StarterKit.configure({
         heading: false,
         codeBlock: false,
+        link: false, // Link is configured explicitly below
       }),
       Link.configure({
         openOnClick: false,

--- a/tests/e2e/link-popover.spec.ts
+++ b/tests/e2e/link-popover.spec.ts
@@ -64,7 +64,7 @@ test.describe("Link Popover", () => {
     // Default value should be https://
     await expect(urlInput).toHaveValue("https://");
 
-    // Close by toggling the button (not Escape, which would close compose view)
+    // Close by toggling the button
     await linkButton.click();
     await page.waitForTimeout(200);
     await expect(urlInput).not.toBeVisible();
@@ -220,7 +220,6 @@ test.describe("Link Popover", () => {
     await linkButton.click();
     await page.waitForTimeout(500);
 
-    // Close via toggle (not Escape)
     await linkButton.click();
     await page.waitForTimeout(200);
 

--- a/tests/e2e/link-popover.spec.ts
+++ b/tests/e2e/link-popover.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect, Page, ElectronApplication } from "@playwright/test";
+import { launchElectronApp, closeApp } from "./launch-helpers";
+
+/**
+ * E2E Tests for Link Popover in Compose Editor
+ *
+ * Verifies the fix for #66: window.prompt() replaced with inline popover.
+ * Tests that clicking the link button opens a popover (not a prompt()),
+ * that URLs can be entered and applied, and that the popover dismisses correctly.
+ */
+
+test.describe("Link Popover", () => {
+  test.describe.configure({ mode: "serial" });
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const result = await launchElectronApp({ workerIndex: testInfo.workerIndex });
+    electronApp = result.app;
+    page = result.page;
+
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        console.error(`[Console Error]: ${msg.text()}`);
+      }
+    });
+
+    // Open compose view
+    const composeButton = page.locator("button:has-text('Compose')");
+    await expect(composeButton).toBeVisible();
+    await composeButton.click();
+    await expect(page.locator("text=New Message")).toBeVisible({ timeout: 5000 });
+
+    // Type some text in the editor so we have content to work with
+    const editor = page.locator(".ProseMirror").first();
+    await expect(editor).toBeVisible({ timeout: 5000 });
+    await editor.click();
+    await page.keyboard.type("Click here for example");
+    await page.waitForTimeout(300);
+  });
+
+  test.afterAll(async () => {
+    if (electronApp) {
+      await closeApp(electronApp);
+    }
+  });
+
+  test("link button opens inline popover instead of window.prompt()", async () => {
+    // Find the link toolbar button (has title "Insert link")
+    const linkButton = page.locator('button[title="Insert link"]');
+    await expect(linkButton).toBeVisible();
+
+    // Click the link button — should open a popover, NOT call window.prompt()
+    await linkButton.click();
+    await page.waitForTimeout(300);
+
+    // The popover should contain a URL input and an Apply button
+    const urlInput = page.locator('input[type="url"]');
+    await expect(urlInput).toBeVisible({ timeout: 2000 });
+
+    const applyButton = page.locator('button:has-text("Apply")');
+    await expect(applyButton).toBeVisible();
+
+    // Default value should be https://
+    await expect(urlInput).toHaveValue("https://");
+
+    // Close by toggling the button (not Escape, which would close compose view)
+    await linkButton.click();
+    await page.waitForTimeout(200);
+    await expect(urlInput).not.toBeVisible();
+  });
+
+  test("can enter a URL and apply it to selected text", async () => {
+    const editor = page.locator(".ProseMirror").first();
+
+    // Select "Click here" (first 10 chars)
+    await editor.click();
+    await page.keyboard.press("Home");
+    for (let i = 0; i < 10; i++) {
+      await page.keyboard.press("Shift+ArrowRight");
+    }
+    await page.waitForTimeout(200);
+
+    // Open link popover
+    const linkButton = page.locator('button[title="Insert link"]');
+    await linkButton.click();
+    await page.waitForTimeout(300);
+
+    // Fill in a URL
+    const urlInput = page.locator('input[type="url"]');
+    await expect(urlInput).toBeVisible({ timeout: 2000 });
+    await urlInput.fill("https://example.com");
+
+    // Click Apply
+    const applyButton = page.locator('button:has-text("Apply")');
+    await applyButton.click();
+    await page.waitForTimeout(300);
+
+    // Popover should be closed
+    await expect(page.locator('input[type="url"]')).not.toBeVisible();
+
+    // The text should now be a link
+    const link = editor.locator('a[href="https://example.com"]');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveText("Click here");
+  });
+
+  test("clicking link button toggles popover open and closed", async () => {
+    const linkButton = page.locator('button[title="Insert link"]');
+    const urlInput = page.locator('input[type="url"]');
+
+    // Open
+    await linkButton.click();
+    await page.waitForTimeout(300);
+    await expect(urlInput).toBeVisible({ timeout: 2000 });
+
+    // Close by clicking button again
+    await linkButton.click();
+    await page.waitForTimeout(300);
+    await expect(urlInput).not.toBeVisible();
+  });
+
+  test("popover dismisses on click outside", async () => {
+    // Click the link button
+    const linkButton = page.locator('button[title="Insert link"]');
+    await linkButton.click();
+    await page.waitForTimeout(300);
+
+    const urlInput = page.locator('input[type="url"]');
+    await expect(urlInput).toBeVisible({ timeout: 2000 });
+
+    // Click somewhere outside (the editor body)
+    const editor = page.locator(".ProseMirror").first();
+    await editor.click({ position: { x: 5, y: 5 } });
+    await page.waitForTimeout(300);
+
+    // Popover should be gone
+    await expect(urlInput).not.toBeVisible();
+  });
+
+  test("Enter key in URL input applies the link", async () => {
+    const editor = page.locator(".ProseMirror").first();
+
+    // Move to end and type new text
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.type(" visit site");
+    await page.waitForTimeout(200);
+
+    // Select "visit site"
+    for (let i = 0; i < 10; i++) {
+      await page.keyboard.press("Shift+ArrowLeft");
+    }
+
+    // Open link popover
+    const linkButton = page.locator('button[title="Insert link"]');
+    await linkButton.click();
+    await page.waitForTimeout(300);
+
+    const urlInput = page.locator('input[type="url"]');
+    await expect(urlInput).toBeVisible({ timeout: 2000 });
+    await urlInput.fill("https://test.com");
+
+    // Press Enter to apply
+    await urlInput.press("Enter");
+    await page.waitForTimeout(300);
+
+    // Popover should close
+    await expect(urlInput).not.toBeVisible();
+
+    // Link should be applied
+    const link = editor.locator('a[href="https://test.com"]');
+    await expect(link).toBeVisible();
+  });
+
+  test("existing link shows Remove button and pre-fills URL", async () => {
+    const editor = page.locator(".ProseMirror").first();
+
+    // Click on the link we created earlier
+    const link = editor.locator('a[href="https://example.com"]');
+    await link.click();
+    await page.waitForTimeout(200);
+
+    // Open link popover — should show the existing URL
+    const linkButton = page.locator('button[title="Insert link"]');
+    await linkButton.click();
+    await page.waitForTimeout(300);
+
+    const urlInput = page.locator('input[type="url"]');
+    await expect(urlInput).toBeVisible({ timeout: 2000 });
+    await expect(urlInput).toHaveValue("https://example.com");
+
+    // Remove button should be visible for existing links
+    const removeButton = page.locator('button:has-text("Remove")');
+    await expect(removeButton).toBeVisible();
+
+    // Click Remove to unlink
+    await removeButton.click();
+    await page.waitForTimeout(300);
+
+    // Popover should close
+    await expect(urlInput).not.toBeVisible();
+
+    // The text should no longer be a link
+    await expect(editor.locator('a[href="https://example.com"]')).not.toBeVisible();
+  });
+
+  test("no window.prompt errors in console", async () => {
+    // Verify no "prompt() is not supported" errors were logged
+    const errors: string[] = [];
+    const errorHandler = (msg: { type: () => string; text: () => string }) => {
+      if (msg.type() === "error" && msg.text().includes("prompt")) {
+        errors.push(msg.text());
+      }
+    };
+    page.on("console", errorHandler);
+
+    // Click the link button one more time
+    const linkButton = page.locator('button[title="Insert link"]');
+    await linkButton.click();
+    await page.waitForTimeout(500);
+
+    // Close via toggle (not Escape)
+    await linkButton.click();
+    await page.waitForTimeout(200);
+
+    page.removeListener("console", errorHandler);
+    expect(errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `window.prompt()` with a custom `LinkPopover` component for entering URLs in the compose editor toolbar
- `window.prompt()` is not supported in Electron's renderer process, causing crashes when users click "add link"
- The popover renders an inline URL input with Apply/Remove actions, following existing popover patterns in the codebase

## Changes

- Added `LinkPopover` component with URL input, Apply button, and Remove button (for existing links)
- Popover supports click-outside dismiss, Escape key, and Enter to apply
- Replaced `setLink` callback (which used `window.prompt`) with `toggleLinkPopover` state toggle
- Wrapped the link toolbar button in a `relative` container to position the popover

Closes #66

## Test plan

- [ ] Open inline reply composer
- [ ] Click the link toolbar button — popover should appear with URL input
- [ ] Enter a URL and click Apply — link should be applied to selected text
- [ ] Click link button on existing link — popover pre-fills with current URL
- [ ] Click Remove on existing link — link mark should be removed
- [ ] Press Escape or click outside — popover dismisses without changes
- [ ] Verify no crash from `window.prompt()` in packaged Electron build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
