### PR TITLE
fix: add cancel button during re-authentication OAuth flow

### DIFF
--- a/src/main/ipc/sync.ipc.ts
+++ b/src/main/ipc/sync.ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow } from "electron";
+import { app, ipcMain, BrowserWindow } from "electron";
 import { GmailClient, isAuthError } from "../services/gmail-client";
 import { emailSyncService, type SyncStatus, type AccountInfo } from "../services/email-sync";
 import { prefetchService } from "../services/prefetch-service";
@@ -259,6 +259,9 @@ export function registerSyncIpc(): void {
     }
   });
 
+  // Track client undergoing re-authentication so it can be cancelled
+  let pendingReauthClient: GmailClient | null = null;
+
   // Re-authenticate a Gmail account (triggered by user clicking "Re-authenticate" in banner)
   ipcMain.handle(
     "auth:reauth",
@@ -269,7 +272,9 @@ export function registerSyncIpc(): void {
           return { success: false, error: "Account not connected" };
         }
 
+        pendingReauthClient = client;
         await client.reauth();
+        pendingReauthClient = null;
 
         // Re-register with sync service and restart sync
         await emailSyncService.registerAccount(client);
@@ -278,6 +283,7 @@ export function registerSyncIpc(): void {
         log.info(`[Auth] Re-authenticated account ${accountId}, sync restarted`);
         return { success: true, data: undefined };
       } catch (error) {
+        pendingReauthClient = null;
         return {
           success: false,
           error: error instanceof Error ? error.message : "Unknown error",
@@ -285,6 +291,22 @@ export function registerSyncIpc(): void {
       }
     },
   );
+
+  // Cancel an in-progress re-authentication OAuth flow
+  ipcMain.handle("gmail:cancel-reauth", async (): Promise<void> => {
+    if (pendingReauthClient) {
+      pendingReauthClient.abortOAuth();
+      pendingReauthClient = null;
+    }
+  });
+
+  // Abort any in-progress reauth on quit so the IPC reply rejects cleanly
+  app.on("before-quit", () => {
+    if (pendingReauthClient) {
+      pendingReauthClient.abortOAuth();
+      pendingReauthClient = null;
+    }
+  });
 
   // Get all accounts
   ipcMain.handle("accounts:list", async (): Promise<IpcResponse<AccountRecord[]>> => {

--- a/src/main/ipc/sync.ipc.ts
+++ b/src/main/ipc/sync.ipc.ts
@@ -267,6 +267,10 @@ export function registerSyncIpc(): void {
     "auth:reauth",
     async (_, { accountId }: { accountId: string }): Promise<IpcResponse<void>> => {
       try {
+        if (pendingReauthClient) {
+          return { success: false, error: "Another re-authentication is already in progress" };
+        }
+
         const client = activeClients.get(accountId);
         if (!client) {
           return { success: false, error: "Account not connected" };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -590,6 +590,7 @@ const api = {
     },
     reauth: (accountId: string): Promise<unknown> =>
       ipcRenderer.invoke("auth:reauth", { accountId }),
+    cancelReauth: (): Promise<void> => ipcRenderer.invoke("gmail:cancel-reauth"),
     removeAllListeners: (): void => {
       ipcRenderer.removeAllListeners("auth:token-expired");
       ipcRenderer.removeAllListeners("auth:extension-auth-required");

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1507,7 +1507,6 @@ export default function App() {
 
   const handleCancelReauth = async () => {
     await window.api.auth.cancelReauth();
-    setReauthingAccountId(null);
   };
 
   const handleSetupComplete = () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1451,7 +1451,10 @@ export default function App() {
     }
   };
 
+  const [reauthingAccountId, setReauthingAccountId] = useState<string | null>(null);
+
   const handleReauth = async (accountId: string) => {
+    setReauthingAccountId(accountId);
     try {
       const result = await window.api.auth.reauth(accountId);
       if ((result as Record<string, unknown>).success) {
@@ -1483,13 +1486,28 @@ export default function App() {
         // Trigger a sync to pick up any new messages from Gmail
         window.api.sync.now(accountId).catch(console.error);
       } else {
-        console.error("[Auth] Re-auth failed");
-        addBreadcrumb("error", "Re-auth failed");
+        const error = (result as Record<string, unknown>).error;
+        if (error === "Authorization cancelled") {
+          // User cancelled — don't show as an error
+        } else {
+          console.error("[Auth] Re-auth failed");
+          addBreadcrumb("error", "Re-auth failed");
+        }
       }
     } catch (err) {
-      console.error("[Auth] Re-auth error:", err);
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: "re-auth" });
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg !== "Authorization cancelled") {
+        console.error("[Auth] Re-auth error:", err);
+        captureException(err instanceof Error ? err : new Error(msg), { context: "re-auth" });
+      }
+    } finally {
+      setReauthingAccountId(null);
     }
+  };
+
+  const handleCancelReauth = async () => {
+    await window.api.auth.cancelReauth();
+    setReauthingAccountId(null);
   };
 
   const handleSetupComplete = () => {
@@ -1910,12 +1928,27 @@ export default function App() {
               <strong>{account.email}</strong> session expired
             </span>
           </div>
-          <button
-            onClick={() => handleReauth(account.id)}
-            className="px-3 py-1 text-sm font-medium text-amber-800 dark:text-amber-200 bg-amber-200 dark:bg-amber-800 hover:bg-amber-300 dark:hover:bg-amber-700 rounded transition-colors"
-          >
-            Re-authenticate
-          </button>
+          {reauthingAccountId === account.id ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-amber-600 dark:text-amber-400">
+                Waiting for browser…
+              </span>
+              <button
+                onClick={handleCancelReauth}
+                className="px-3 py-1 text-sm font-medium text-red-800 dark:text-red-200 bg-red-200 dark:bg-red-800 hover:bg-red-300 dark:hover:bg-red-700 rounded transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => handleReauth(account.id)}
+              disabled={reauthingAccountId !== null}
+              className="px-3 py-1 text-sm font-medium text-amber-800 dark:text-amber-200 bg-amber-200 dark:bg-amber-800 hover:bg-amber-300 dark:hover:bg-amber-700 rounded transition-colors disabled:opacity-50"
+            >
+              Re-authenticate
+            </button>
+          )}
         </div>
       ))}
       {[...extensionAuthRequired.entries()].map(([extId, { displayName, message }]) => (


### PR DESCRIPTION
## Summary

Fixes #68 — When a token expires and the app triggers re-authentication, the user had no way to cancel the OAuth flow. The browser opens and waits up to 5 minutes; if the user doesn't complete it, the IPC reply is never sent and the renderer gets an unhandled error.

This mirrors the cancel pattern from PR #41 (setup wizard OAuth) for the reauth path:

- **`sync.ipc.ts`**: Track `pendingReauthClient` during reauth, add `gmail:cancel-reauth` IPC handler that calls `abortOAuth()`, abort on `app.on('before-quit')`
- **`preload/index.ts`**: Expose `cancelReauth` IPC to the renderer
- **`App.tsx`**: Track `reauthingAccountId` state, show "Waiting for browser… Cancel" in the reauth banner during OAuth, suppress "Authorization cancelled" errors, disable other reauth buttons while one is in progress

## Changes

- `src/main/ipc/sync.ipc.ts` — added `pendingReauthClient` tracking, `gmail:cancel-reauth` handler, and `before-quit` cleanup
- `src/preload/index.ts` — exposed `cancelReauth` IPC method
- `src/renderer/App.tsx` — added cancel button UI, reauth-in-progress state, cancellation error suppression

## Test plan

- [ ] Expire a token (or simulate), click Re-authenticate, then click Cancel — OAuth flow aborts cleanly
- [ ] Complete a normal re-authentication — flow works as before
- [ ] Quit the app during re-authentication — no unhandled IPC errors
- [ ] With multiple expired accounts, only one reauth button is active at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
