### PR TITLE
fix: strip email signature before draft-edit learning comparison

### DIFF
--- a/src/main/services/draft-edit-learner.ts
+++ b/src/main/services/draft-edit-learner.ts
@@ -676,10 +676,10 @@ export async function learnFromDraftEdit(params: {
 
   // 2. Normalize both to plain text for comparison
   const originalDraft = htmlToPlainText(rawDraftBody);
-  const strippedHtml = sentBodyHtml.replace(
-    /<div[^>]*class="[^"]*gmail_quote[^"]*"[^>]*>[\s\S]*$/i,
-    "",
-  );
+  const strippedHtml = sentBodyHtml
+    // Strip email signature (includes "Sent by Exo" branding) — added at send time, not a user edit
+    .replace(/<div[^>]*class="[^"]*email-signature[^"]*"[^>]*>[\s\S]*$/i, "")
+    .replace(/<div[^>]*class="[^"]*gmail_quote[^"]*"[^>]*>[\s\S]*$/i, "");
   const sentPlainText = htmlToPlainText(strippedHtml);
 
   // 3. Check if the edit is meaningful


### PR DESCRIPTION
## Summary

- **Fix:** The draft-edit-learner was incorrectly learning from the "Sent by Exo" email signature because it's appended at send time (in `useComposeForm.ts`) but not stored in the original AI draft. Every sent email looked like it had a user edit adding the signature.
- **Change:** Strip `<div class="email-signature">` (and everything after it) from the sent HTML before comparing against the draft, using the same regex pattern already used for `gmail_quote` stripping.
- **Scope:** One-line change in `draft-edit-learner.ts`. The style profiler is not affected — it only extracts keyword-based sign-offs that don't match "Sent by Exo".

## Test plan
- [x] Unit tests pass (1333/1333)
- [x] Type check clean
- [ ] Verify draft-edit-learner no longer extracts observations about the signature when sending an AI-generated draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
