### PR TITLE
Add Learn My Style feature for writing style inference

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -1872,7 +1872,21 @@ type SentEmailRow = {
   body: string;
   date: string;
   is_reply: number; // 1 if subject starts with Re:
+  to_address?: string;
 };
+
+export function getRecentSentEmailsWithBody(limit: number = 100): SentEmailRow[] {
+  const db = getDatabase();
+  const stmt = db.prepare(`
+    SELECT id, subject, body_text, body, to_address, date,
+      CASE WHEN subject LIKE 'Re:%' OR subject LIKE 'RE:%' THEN 1 ELSE 0 END as is_reply
+    FROM emails
+    WHERE label_ids LIKE '%"SENT"%'
+    ORDER BY date DESC
+    LIMIT ?
+  `);
+  return stmt.all(limit) as SentEmailRow[];
+}
 
 export function getSentEmailsToRecipient(
   recipientEmail: string,

--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -581,9 +581,9 @@ export function registerSettingsIpc(): void {
       const syncService = getEmailSyncService();
       const { getAccounts: getDbAccounts } = await import("../db");
       const accounts = getDbAccounts();
-      const gmailClient =
-        accounts.length > 0 ? syncService.getClientForAccount(accounts[0].id) : null;
-      const result = await inferStyleFromSentEmails(gmailClient);
+      const firstAccountId = accounts.length > 0 ? accounts[0].id : undefined;
+      const gmailClient = firstAccountId ? syncService.getClientForAccount(firstAccountId) : null;
+      const result = await inferStyleFromSentEmails(gmailClient, firstAccountId);
       return { success: true, data: result };
     } catch (error) {
       return {

--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -572,6 +572,27 @@ export function registerSettingsIpc(): void {
     },
   );
 
+  // Infer writing style from sent emails using Claude Opus
+  ipcMain.handle("style:infer", async (): Promise<IpcResponse<string>> => {
+    try {
+      const { inferStyleFromSentEmails } = await import("../services/style-profiler");
+      const { getEmailSyncService } = await import("./sync.ipc");
+      // Use any available gmail client for fallback (style is cross-account)
+      const syncService = getEmailSyncService();
+      const { getAccounts: getDbAccounts } = await import("../db");
+      const accounts = getDbAccounts();
+      const gmailClient =
+        accounts.length > 0 ? syncService.getClientForAccount(accounts[0].id) : null;
+      const result = await inferStyleFromSentEmails(gmailClient);
+      return { success: true, data: result };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  });
+
   // Get EA config
   ipcMain.handle("settings:get-ea", async (): Promise<IpcResponse<EAConfig>> => {
     try {

--- a/src/main/services/style-profiler.ts
+++ b/src/main/services/style-profiler.ts
@@ -219,6 +219,7 @@ async function fetchAndCacheSentEmails(
       body: email.body,
       date: email.date,
       is_reply: email.subject.toLowerCase().startsWith("re:") ? 1 : 0,
+      to_address: email.to,
     });
   }
 
@@ -424,9 +425,10 @@ export async function inferStyleFromSentEmails(
   // Build the email samples for the prompt
   const emailSamples = emails
     .map((e) => {
-      // Strip quoted/forwarded content first so we only analyze the user's own writing
-      const stripped = stripQuotedContent(e.body);
-      const text = stripHtmlForSearch(stripped);
+      // Use pre-extracted plain text when available, otherwise strip HTML first
+      const plainText = e.body_text ?? stripHtmlForSearch(e.body);
+      // Strip quoted/forwarded content so we only analyze the user's own writing
+      const text = stripQuotedContent(plainText);
       const truncated = truncateBody(text, 300);
       const type = e.is_reply ? "reply" : "new";
       return `---\nTo: ${e.to_address ?? "unknown"}\nSubject: ${e.subject}\nDate: ${e.date}\nType: ${type}\n\n${truncated}\n---`;

--- a/src/main/services/style-profiler.ts
+++ b/src/main/services/style-profiler.ts
@@ -11,6 +11,7 @@ import {
 } from "../db";
 import type { GmailClient } from "./gmail-client";
 import { createMessage } from "./anthropic-service";
+import { stripQuotedContent } from "./strip-quoted-content";
 import { createLogger } from "./logger";
 
 const log = createLogger("style-profiler");
@@ -420,7 +421,9 @@ export async function inferStyleFromSentEmails(gmailClient?: GmailClient | null)
   // Build the email samples for the prompt
   const emailSamples = emails
     .map((e) => {
-      const text = e.body_text ?? stripHtmlForSearch(e.body);
+      // Strip quoted/forwarded content first so we only analyze the user's own writing
+      const stripped = stripQuotedContent(e.body);
+      const text = stripHtmlForSearch(stripped);
       const truncated = truncateBody(text, 300);
       const type = e.is_reply ? "reply" : "new";
       return `---\nTo: ${e.to_address ?? "unknown"}\nSubject: ${e.subject}\nDate: ${e.date}\nType: ${type}\n\n${truncated}\n---`;

--- a/src/main/services/style-profiler.ts
+++ b/src/main/services/style-profiler.ts
@@ -381,7 +381,10 @@ Do NOT include example phrases or quoted text from the emails.`;
  * their writing style using Claude Opus. Returns a style description that
  * can be used as the stylePrompt.
  */
-export async function inferStyleFromSentEmails(gmailClient?: GmailClient | null): Promise<string> {
+export async function inferStyleFromSentEmails(
+  gmailClient?: GmailClient | null,
+  gmailAccountId?: string,
+): Promise<string> {
   // Fetch recent sent emails from local DB (all accounts)
   let emails = getRecentSentEmailsWithBody(100);
 
@@ -392,7 +395,7 @@ export async function inferStyleFromSentEmails(gmailClient?: GmailClient | null)
       const gmailRows = await fetchAndCacheSentEmails(
         gmailClient,
         "from:me in:sent",
-        "default",
+        gmailAccountId ?? "default",
         100,
       );
       // Merge, dedup by ID

--- a/src/main/services/style-profiler.ts
+++ b/src/main/services/style-profiler.ts
@@ -7,8 +7,10 @@ import {
   getCorrespondentProfile,
   saveCorrespondentProfile,
   getSentEmailCountToRecipient,
+  getRecentSentEmailsWithBody,
 } from "../db";
 import type { GmailClient } from "./gmail-client";
+import { createMessage } from "./anthropic-service";
 import { createLogger } from "./logger";
 
 const log = createLogger("style-profiler");
@@ -181,6 +183,7 @@ type SentEmailRow = {
   body: string;
   date: string;
   is_reply: number;
+  to_address?: string;
 };
 
 /**
@@ -346,4 +349,103 @@ export async function buildStyleContext(
   });
 
   return context;
+}
+
+// ============================================
+// Style inference via metaprompting
+// ============================================
+
+const STYLE_INFERENCE_PROMPT = `You are analyzing a user's email writing style. Below are their most recent sent emails.
+Study these emails carefully and produce a concise style guide that captures how this person writes.
+
+Focus on:
+- Tone and formality level (casual, professional, mixed)
+- Greeting patterns (do they say "Hi", "Hey", nothing?)
+- Sign-off patterns (do they use "Best", "Thanks", just their name, nothing?)
+- Sentence structure (short and punchy? long and detailed? mixed?)
+- Vocabulary level (simple, technical, colloquial)
+- Use of punctuation (exclamation marks, ellipses, em dashes)
+- Capitalization habits (proper case, all lowercase, etc.)
+- How they handle different contexts (replies vs new emails, quick responses vs longer ones)
+- Any distinctive quirks or patterns
+
+Output a 3-5 sentence style description written as instructions to an AI drafting emails
+on their behalf. Write in second person ("You write..."). Be specific and concrete —
+reference actual patterns you observed rather than generic descriptions.
+
+Do NOT include example phrases or quoted text from the emails.`;
+
+/**
+ * Analyze the user's last 100 sent emails across all accounts and infer
+ * their writing style using Claude Opus. Returns a style description that
+ * can be used as the stylePrompt.
+ */
+export async function inferStyleFromSentEmails(gmailClient?: GmailClient | null): Promise<string> {
+  // Fetch recent sent emails from local DB (all accounts)
+  let emails = getRecentSentEmailsWithBody(100);
+
+  // Gmail fallback if we have very few local sent emails
+  if (emails.length < 20 && gmailClient) {
+    log.info(`[StyleInference] Only ${emails.length} local sent emails, fetching from Gmail`);
+    try {
+      const gmailRows = await fetchAndCacheSentEmails(
+        gmailClient,
+        "from:me in:sent",
+        "default",
+        100,
+      );
+      // Merge, dedup by ID
+      const seenIds = new Set(emails.map((e) => e.id));
+      for (const row of gmailRows) {
+        if (!seenIds.has(row.id)) {
+          emails.push(row);
+          seenIds.add(row.id);
+        }
+      }
+      // Re-sort by date DESC and limit
+      emails = emails
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .slice(0, 100);
+    } catch (err) {
+      log.warn({ err }, "[StyleInference] Gmail fallback failed");
+    }
+  }
+
+  if (emails.length === 0) {
+    throw new Error("No sent emails found to analyze writing style");
+  }
+
+  log.info(`[StyleInference] Analyzing ${emails.length} sent emails with Opus`);
+
+  // Build the email samples for the prompt
+  const emailSamples = emails
+    .map((e) => {
+      const text = e.body_text ?? stripHtmlForSearch(e.body);
+      const truncated = truncateBody(text, 300);
+      const type = e.is_reply ? "reply" : "new";
+      return `---\nTo: ${e.to_address ?? "unknown"}\nSubject: ${e.subject}\nDate: ${e.date}\nType: ${type}\n\n${truncated}\n---`;
+    })
+    .join("\n\n");
+
+  const response = await createMessage(
+    {
+      model: "claude-opus-4-20250514",
+      max_tokens: 1024,
+      system: [{ type: "text", text: STYLE_INFERENCE_PROMPT }],
+      messages: [
+        {
+          role: "user",
+          content: `Here are my ${emails.length} most recent sent emails. Analyze my writing style:\n\n${emailSamples}`,
+        },
+      ],
+    },
+    { caller: "style-inference" },
+  );
+
+  const textBlock = response.content.find((block) => block.type === "text");
+  if (!textBlock || textBlock.type !== "text") {
+    throw new Error("No text response from style inference");
+  }
+
+  return textBlock.text.trim();
 }

--- a/src/main/services/style-profiler.ts
+++ b/src/main/services/style-profiler.ts
@@ -371,9 +371,10 @@ Focus on:
 - How they handle different contexts (replies vs new emails, quick responses vs longer ones)
 - Any distinctive quirks or patterns
 
-Output a 3-5 sentence style description written as instructions to an AI drafting emails
+Output a 6-10 sentence style description written as instructions to an AI drafting emails
 on their behalf. Write in second person ("You write..."). Be specific and concrete —
-reference actual patterns you observed rather than generic descriptions.
+reference actual patterns you observed rather than generic descriptions. Cover how the
+style varies by context (quick replies vs longer emails, familiar vs unfamiliar recipients).
 
 Do NOT include example phrases or quoted text from the emails.`;
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -191,6 +191,7 @@ const api = {
   style: {
     getContext: (toAddress: string): Promise<unknown> =>
       ipcRenderer.invoke("style:get-context", { toAddress }),
+    infer: (): Promise<unknown> => ipcRenderer.invoke("style:infer"),
   },
 
   // Contact suggestions (for email autocomplete)

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -480,6 +480,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   const handleInferStyle = async () => {
     setIsInferring(true);
+    setSaveResult(null);
     try {
       const result = (await window.api.style.infer()) as {
         success: boolean;
@@ -488,7 +489,11 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       };
       if (result.success && result.data) {
         setStylePrompt(result.data);
+      } else {
+        setSaveResult(result.error || "Failed to infer writing style");
       }
+    } catch {
+      setSaveResult("Failed to infer writing style");
     } finally {
       setIsInferring(false);
     }

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -63,6 +63,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [saveResult, setSaveResult] = useState<string | null>(null);
   const [stylePrompt, setStylePrompt] = useState("");
   const [isInferring, setIsInferring] = useState(false);
+  const [inferError, setInferError] = useState<string | null>(null);
   const [agentDrafterPrompt, setAgentDrafterPrompt] = useState("");
   const [isRerunningAll, setIsRerunningAll] = useState(false);
   const [rerunResult, setRerunResult] = useState<string | null>(null);
@@ -480,7 +481,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   const handleInferStyle = async () => {
     setIsInferring(true);
-    setSaveResult(null);
+    setInferError(null);
     try {
       const result = (await window.api.style.infer()) as {
         success: boolean;
@@ -490,10 +491,10 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       if (result.success && result.data) {
         setStylePrompt(result.data);
       } else {
-        setSaveResult(result.error || "Failed to infer writing style");
+        setInferError(result.error || "Failed to infer writing style");
       }
     } catch {
-      setSaveResult("Failed to infer writing style");
+      setInferError("Failed to infer writing style");
     } finally {
       setIsInferring(false);
     }
@@ -2111,6 +2112,9 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                   This prompt is prepended to your draft generation when style examples are
                   available. It tells the AI how to interpret the examples of your past emails.
                 </p>
+                {inferError && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1">{inferError}</p>
+                )}
               </div>
 
               <button

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -64,6 +64,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [stylePrompt, setStylePrompt] = useState("");
   const [isInferring, setIsInferring] = useState(false);
   const [inferError, setInferError] = useState<string | null>(null);
+  const [isSavingStyle, setIsSavingStyle] = useState(false);
   const [styleSaved, setStyleSaved] = useState(false);
   const [agentDrafterPrompt, setAgentDrafterPrompt] = useState("");
   const [isRerunningAll, setIsRerunningAll] = useState(false);
@@ -465,7 +466,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   };
 
   const handleSaveStylePrompt = async () => {
-    setIsSaving(true);
+    setIsSavingStyle(true);
     setStyleSaved(false);
     try {
       const result = (await window.api.settings.setPrompts({
@@ -477,7 +478,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         setTimeout(() => setStyleSaved(false), 2000);
       }
     } finally {
-      setIsSaving(false);
+      setIsSavingStyle(false);
     }
   };
 
@@ -2126,10 +2127,10 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
               <div className="flex items-center gap-3 mt-4">
                 <button
                   onClick={handleSaveStylePrompt}
-                  disabled={isSaving}
+                  disabled={isSavingStyle}
                   className="px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors disabled:opacity-50"
                 >
-                  {isSaving ? "Saving..." : "Save Style Prompt"}
+                  {isSavingStyle ? "Saving..." : "Save Style Prompt"}
                 </button>
                 {styleSaved && <p className="text-sm text-green-600 dark:text-green-400">Saved.</p>}
               </div>

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -64,6 +64,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [stylePrompt, setStylePrompt] = useState("");
   const [isInferring, setIsInferring] = useState(false);
   const [inferError, setInferError] = useState<string | null>(null);
+  const [styleSaved, setStyleSaved] = useState(false);
   const [agentDrafterPrompt, setAgentDrafterPrompt] = useState("");
   const [isRerunningAll, setIsRerunningAll] = useState(false);
   const [rerunResult, setRerunResult] = useState<string | null>(null);
@@ -465,11 +466,13 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   const handleSaveStylePrompt = async () => {
     setIsSaving(true);
+    setStyleSaved(false);
     try {
       await window.api.settings.setPrompts({
         stylePrompt: stylePrompt || undefined,
       });
       queryClient.invalidateQueries({ queryKey: ["prompts"] });
+      setStyleSaved(true);
     } finally {
       setIsSaving(false);
     }
@@ -2117,13 +2120,16 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 )}
               </div>
 
-              <button
-                onClick={handleSaveStylePrompt}
-                disabled={isSaving}
-                className="mt-4 px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors disabled:opacity-50"
-              >
-                {isSaving ? "Saving..." : "Save Style Prompt"}
-              </button>
+              <div className="flex items-center gap-3 mt-4">
+                <button
+                  onClick={handleSaveStylePrompt}
+                  disabled={isSaving}
+                  className="px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors disabled:opacity-50"
+                >
+                  {isSaving ? "Saving..." : "Save Style Prompt"}
+                </button>
+                {styleSaved && <p className="text-sm text-green-600 dark:text-green-400">Saved.</p>}
+              </div>
             </div>
           </div>
         )}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -62,6 +62,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [isSaving, setIsSaving] = useState(false);
   const [saveResult, setSaveResult] = useState<string | null>(null);
   const [stylePrompt, setStylePrompt] = useState("");
+  const [isInferring, setIsInferring] = useState(false);
   const [agentDrafterPrompt, setAgentDrafterPrompt] = useState("");
   const [isRerunningAll, setIsRerunningAll] = useState(false);
   const [rerunResult, setRerunResult] = useState<string | null>(null);
@@ -475,6 +476,22 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   const handleResetStylePrompt = () => {
     setStylePrompt(DEFAULT_STYLE_PROMPT);
+  };
+
+  const handleInferStyle = async () => {
+    setIsInferring(true);
+    try {
+      const result = (await window.api.style.infer()) as {
+        success: boolean;
+        data?: string;
+        error?: string;
+      };
+      if (result.success && result.data) {
+        setStylePrompt(result.data);
+      }
+    } finally {
+      setIsInferring(false);
+    }
   };
 
   const handleSaveEA = async () => {
@@ -2062,12 +2079,21 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                     Style Prompt
                   </label>
-                  <button
-                    onClick={handleResetStylePrompt}
-                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-                  >
-                    Reset to default
-                  </button>
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={handleInferStyle}
+                      disabled={isInferring}
+                      className="text-xs text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50"
+                    >
+                      {isInferring ? "Analyzing..." : "Learn My Style"}
+                    </button>
+                    <button
+                      onClick={handleResetStylePrompt}
+                      className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      Reset to default
+                    </button>
+                  </div>
                 </div>
                 <textarea
                   value={stylePrompt}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -468,11 +468,14 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
     setIsSaving(true);
     setStyleSaved(false);
     try {
-      await window.api.settings.setPrompts({
+      const result = (await window.api.settings.setPrompts({
         stylePrompt: stylePrompt || undefined,
-      });
+      })) as { success: boolean };
       queryClient.invalidateQueries({ queryKey: ["prompts"] });
-      setStyleSaved(true);
+      if (result.success) {
+        setStyleSaved(true);
+        setTimeout(() => setStyleSaved(false), 2000);
+      }
     } finally {
       setIsSaving(false);
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -721,6 +721,7 @@ export type IpcChannels = {
 
   // Style operations
   "style:get-context": { toAddress: string };
+  "style:infer": void;
 
   // Settings operations
   "settings:get": void;

--- a/tests/unit/style-inference.spec.ts
+++ b/tests/unit/style-inference.spec.ts
@@ -51,10 +51,33 @@ Do NOT include example phrases or quoted text from the emails.`;
  * Build the email samples portion of the prompt, mirroring the logic
  * in inferStyleFromSentEmails.
  */
+// Simplified version of stripQuotedContent for plain text
+// (matches the production code path: body_text → stripQuotedContent → truncateBody)
+function stripQuotedContent(text: string): string {
+  if (!text) return text;
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    // "On ... wrote:" header
+    if (/^on\s.+wrote:\s*$/i.test(line)) {
+      return lines.slice(0, i).join("\n").trimEnd();
+    }
+    // Block of ">" quoted lines
+    if (line.startsWith(">")) {
+      const above = lines.slice(0, i).join("\n").trimEnd();
+      if (above && !above.split("\n").every((l) => l.trim().startsWith(">"))) {
+        return above;
+      }
+    }
+  }
+  return text;
+}
+
 function buildEmailSamples(emails: SentEmailRow[]): string {
   return emails
     .map((e) => {
-      const text = e.body_text ?? stripHtmlForSearch(e.body);
+      const plainText = e.body_text ?? stripHtmlForSearch(e.body);
+      const text = stripQuotedContent(plainText);
       const truncated = truncateBody(text, 300);
       const type = e.is_reply ? "reply" : "new";
       return `---\nTo: ${e.to_address ?? "unknown"}\nSubject: ${e.subject}\nDate: ${e.date}\nType: ${type}\n\n${truncated}\n---`;

--- a/tests/unit/style-inference.spec.ts
+++ b/tests/unit/style-inference.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the style inference metaprompting feature.
+ *
+ * Since style-profiler.ts imports from ../db which transitively imports electron,
+ * we re-implement the prompt construction logic here for testing in system Node.
+ */
+import { test, expect } from "@playwright/test";
+
+// Re-implement the pure functions used in inferStyleFromSentEmails
+function stripHtmlForSearch(html: string): string {
+  return html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function truncateBody(bodyText: string, maxWords: number = 300): string {
+  const words = bodyText.split(/\s+/);
+  if (words.length <= maxWords) return bodyText;
+  return words.slice(0, maxWords).join(" ") + "...";
+}
+
+type SentEmailRow = {
+  id: string;
+  subject: string;
+  body_text: string | null;
+  body: string;
+  date: string;
+  is_reply: number;
+  to_address?: string;
+};
+
+const STYLE_INFERENCE_PROMPT = `You are analyzing a user's email writing style. Below are their most recent sent emails.
+Study these emails carefully and produce a concise style guide that captures how this person writes.
+
+Focus on:
+- Tone and formality level (casual, professional, mixed)
+- Greeting patterns (do they say "Hi", "Hey", nothing?)
+- Sign-off patterns (do they use "Best", "Thanks", just their name, nothing?)
+- Sentence structure (short and punchy? long and detailed? mixed?)
+- Vocabulary level (simple, technical, colloquial)
+- Use of punctuation (exclamation marks, ellipses, em dashes)
+- Capitalization habits (proper case, all lowercase, etc.)
+- How they handle different contexts (replies vs new emails, quick responses vs longer ones)
+- Any distinctive quirks or patterns
+
+Output a 3-5 sentence style description written as instructions to an AI drafting emails
+on their behalf. Write in second person ("You write..."). Be specific and concrete —
+reference actual patterns you observed rather than generic descriptions.
+
+Do NOT include example phrases or quoted text from the emails.`;
+
+/**
+ * Build the email samples portion of the prompt, mirroring the logic
+ * in inferStyleFromSentEmails.
+ */
+function buildEmailSamples(emails: SentEmailRow[]): string {
+  return emails
+    .map((e) => {
+      const text = e.body_text ?? stripHtmlForSearch(e.body);
+      const truncated = truncateBody(text, 300);
+      const type = e.is_reply ? "reply" : "new";
+      return `---\nTo: ${e.to_address ?? "unknown"}\nSubject: ${e.subject}\nDate: ${e.date}\nType: ${type}\n\n${truncated}\n---`;
+    })
+    .join("\n\n");
+}
+
+function makeEmail(overrides: Partial<SentEmailRow> = {}): SentEmailRow {
+  return {
+    id: `msg_${Math.random().toString(36).slice(2)}`,
+    subject: "Test subject",
+    body_text: "Hey, just wanted to check in on the project. Let me know if you need anything. Thanks",
+    body: "<p>Hey, just wanted to check in on the project.</p>",
+    date: "2026-04-01",
+    is_reply: 0,
+    to_address: "alice@example.com",
+    ...overrides,
+  };
+}
+
+// ============================================================
+// Prompt construction
+// ============================================================
+
+test.describe("style inference prompt construction", () => {
+  test("builds prompt with correct email format", () => {
+    const email = makeEmail({
+      to_address: "bob@company.com",
+      subject: "Re: Q4 planning",
+      date: "2026-03-15",
+      is_reply: 1,
+      body_text: "Sounds good, let's sync tomorrow.",
+    });
+
+    const samples = buildEmailSamples([email]);
+
+    expect(samples).toContain("To: bob@company.com");
+    expect(samples).toContain("Subject: Re: Q4 planning");
+    expect(samples).toContain("Date: 2026-03-15");
+    expect(samples).toContain("Type: reply");
+    expect(samples).toContain("Sounds good, let's sync tomorrow.");
+  });
+
+  test("marks new emails as type 'new'", () => {
+    const email = makeEmail({ is_reply: 0 });
+    const samples = buildEmailSamples([email]);
+    expect(samples).toContain("Type: new");
+  });
+
+  test("uses body_text when available, falls back to stripped HTML", () => {
+    const emailWithText = makeEmail({
+      body_text: "Plain text body",
+      body: "<p>HTML body</p>",
+    });
+    const emailWithoutText = makeEmail({
+      body_text: null,
+      body: "<p>HTML body content</p>",
+    });
+
+    const samplesWithText = buildEmailSamples([emailWithText]);
+    const samplesWithoutText = buildEmailSamples([emailWithoutText]);
+
+    expect(samplesWithText).toContain("Plain text body");
+    expect(samplesWithoutText).toContain("HTML body content");
+    expect(samplesWithoutText).not.toContain("<p>");
+  });
+
+  test("truncates long emails to 300 words", () => {
+    const longBody = Array(400).fill("word").join(" ");
+    const email = makeEmail({ body_text: longBody });
+    const samples = buildEmailSamples([email]);
+
+    // 300 words + "..." suffix
+    const bodyInSamples = samples.split("\n\n").slice(1).join("\n\n").split("\n---")[0];
+    const wordCount = bodyInSamples.trim().split(/\s+/).length;
+    expect(wordCount).toBeLessThanOrEqual(301); // 300 words + "..."
+    expect(samples).toContain("...");
+  });
+
+  test("handles missing to_address", () => {
+    const email = makeEmail({ to_address: undefined });
+    const samples = buildEmailSamples([email]);
+    expect(samples).toContain("To: unknown");
+  });
+
+  test("handles multiple emails", () => {
+    const emails = [
+      makeEmail({ subject: "First email", to_address: "a@b.com" }),
+      makeEmail({ subject: "Second email", to_address: "c@d.com" }),
+      makeEmail({ subject: "Third email", to_address: "e@f.com" }),
+    ];
+    const samples = buildEmailSamples(emails);
+
+    expect(samples).toContain("Subject: First email");
+    expect(samples).toContain("Subject: Second email");
+    expect(samples).toContain("Subject: Third email");
+    // Emails are separated by double newline
+    expect(samples.split("---\n\n---").length).toBe(3);
+  });
+});
+
+// ============================================================
+// System prompt content
+// ============================================================
+
+test.describe("style inference system prompt", () => {
+  test("instructs second-person output", () => {
+    expect(STYLE_INFERENCE_PROMPT).toContain('Write in second person ("You write...")');
+  });
+
+  test("prohibits quoting email content", () => {
+    expect(STYLE_INFERENCE_PROMPT).toContain(
+      "Do NOT include example phrases or quoted text from the emails",
+    );
+  });
+
+  test("requests 3-5 sentence output", () => {
+    expect(STYLE_INFERENCE_PROMPT).toContain("3-5 sentence style description");
+  });
+
+  test("covers key style dimensions", () => {
+    expect(STYLE_INFERENCE_PROMPT).toContain("Greeting patterns");
+    expect(STYLE_INFERENCE_PROMPT).toContain("Sign-off patterns");
+    expect(STYLE_INFERENCE_PROMPT).toContain("Sentence structure");
+    expect(STYLE_INFERENCE_PROMPT).toContain("Capitalization");
+  });
+});

--- a/tests/unit/style-inference.spec.ts
+++ b/tests/unit/style-inference.spec.ts
@@ -41,9 +41,10 @@ Focus on:
 - How they handle different contexts (replies vs new emails, quick responses vs longer ones)
 - Any distinctive quirks or patterns
 
-Output a 3-5 sentence style description written as instructions to an AI drafting emails
+Output a 6-10 sentence style description written as instructions to an AI drafting emails
 on their behalf. Write in second person ("You write..."). Be specific and concrete —
-reference actual patterns you observed rather than generic descriptions.
+reference actual patterns you observed rather than generic descriptions. Cover how the
+style varies by context (quick replies vs longer emails, familiar vs unfamiliar recipients).
 
 Do NOT include example phrases or quoted text from the emails.`;
 
@@ -194,8 +195,8 @@ test.describe("style inference system prompt", () => {
     );
   });
 
-  test("requests 3-5 sentence output", () => {
-    expect(STYLE_INFERENCE_PROMPT).toContain("3-5 sentence style description");
+  test("requests 6-10 sentence output", () => {
+    expect(STYLE_INFERENCE_PROMPT).toContain("6-10 sentence style description");
   });
 
   test("covers key style dimensions", () => {


### PR DESCRIPTION
## Summary
- Adds a "Learn My Style" button in Settings > Style that reads the user's last 100 sent emails across all accounts and uses Claude Opus to infer their writing style
- The inferred style description populates the style prompt textarea for user review before saving
- Strips quoted/forwarded content from emails so only the user's own writing is analyzed
- Includes error handling for failed inference and proper account ID propagation for Gmail fallback

## Changes
- `src/main/db/index.ts` — New `getRecentSentEmailsWithBody()` query for cross-account sent emails with body
- `src/main/services/style-profiler.ts` — New `inferStyleFromSentEmails()` function with metaprompt + `stripQuotedContent` preprocessing
- `src/main/ipc/settings.ipc.ts` — New `style:infer` IPC handler
- `src/preload/index.ts` — Expose `style.infer()` to renderer
- `src/shared/types.ts` — Add `style:infer` IPC channel type
- `src/renderer/components/SettingsPanel.tsx` — "Learn My Style" button with loading state and error feedback
- `tests/unit/style-inference.spec.ts` — 10 unit tests for prompt construction and system prompt content

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] Manual: Open Settings > Style tab, click "Learn My Style", verify textarea populates with inferred style
- [ ] Manual: Verify "Save Style Prompt" persists the inferred style
- [ ] Manual: Verify error feedback when API call fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
