### PR TITLE
feat: Gmail label management (view, add, remove, create with l hotkey)

### DIFF
--- a/src/extensions/mail-ext-labels/package.json
+++ b/src/extensions/mail-ext-labels/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mail-ext-labels",
+  "version": "1.0.0",
+  "description": "View Gmail labels on emails",
+  "main": "./src/index.ts",
+  "mailExtension": {
+    "id": "labels",
+    "displayName": "Labels",
+    "description": "View Gmail labels on emails",
+    "builtIn": true,
+    "activationEvents": ["onEmail"],
+    "contributes": {
+      "sidebarPanels": [
+        {
+          "id": "email-labels",
+          "title": "Labels",
+          "priority": 80,
+          "scope": "sender"
+        }
+      ]
+    }
+  }
+}

--- a/src/extensions/mail-ext-labels/package.json
+++ b/src/extensions/mail-ext-labels/package.json
@@ -15,7 +15,7 @@
           "id": "email-labels",
           "title": "Labels",
           "priority": 80,
-          "scope": "email"
+          "scope": "sender"
         }
       ]
     }

--- a/src/extensions/mail-ext-labels/package.json
+++ b/src/extensions/mail-ext-labels/package.json
@@ -15,7 +15,7 @@
           "id": "email-labels",
           "title": "Labels",
           "priority": 80,
-          "scope": "sender"
+          "scope": "email"
         }
       ]
     }

--- a/src/extensions/mail-ext-labels/src/index.ts
+++ b/src/extensions/mail-ext-labels/src/index.ts
@@ -14,7 +14,7 @@ const extension: ExtensionModule = {
   },
 
   async deactivate(): Promise<void> {
-    console.log("[Ext:labels] Deactivated");
+    // No cleanup needed — label cache is in-memory and clears on exit
   },
 };
 

--- a/src/extensions/mail-ext-labels/src/index.ts
+++ b/src/extensions/mail-ext-labels/src/index.ts
@@ -1,0 +1,21 @@
+import type {
+  ExtensionContext,
+  ExtensionAPI,
+  ExtensionModule,
+} from "../../../shared/extension-types";
+import { createLabelsProvider } from "./labels-provider";
+
+const extension: ExtensionModule = {
+  async activate(context: ExtensionContext, api: ExtensionAPI): Promise<void> {
+    context.logger.info("Activating labels extension");
+    const provider = createLabelsProvider(context);
+    api.registerEnrichmentProvider(provider);
+    context.logger.info("Labels extension activated");
+  },
+
+  async deactivate(): Promise<void> {
+    console.log("[Ext:labels] Deactivated");
+  },
+};
+
+export const { activate, deactivate } = extension;

--- a/src/extensions/mail-ext-labels/src/labels-provider.ts
+++ b/src/extensions/mail-ext-labels/src/labels-provider.ts
@@ -59,8 +59,9 @@ export function createLabelsProvider(context: ExtensionContext): EnrichmentProvi
     panelId: "email-labels",
     priority: 90,
 
-    canEnrich(email: DashboardEmail): boolean {
-      return !!email.labelIds?.length;
+    canEnrich(_email: DashboardEmail): boolean {
+      // Always show the labels panel — even unlabeled emails need the "Add label" button
+      return true;
     },
 
     async enrich(email: DashboardEmail): Promise<EnrichmentData | null> {

--- a/src/extensions/mail-ext-labels/src/labels-provider.ts
+++ b/src/extensions/mail-ext-labels/src/labels-provider.ts
@@ -3,101 +3,28 @@ import type {
   EnrichmentProvider,
   EnrichmentData,
 } from "../../../shared/extension-types";
-import type { DashboardEmail, LabelInfo } from "../../../shared/types";
-import { getClient } from "../../../main/ipc/gmail.ipc";
+import type { DashboardEmail } from "../../../shared/types";
 
-// In-memory cache: accountId -> (labelId -> LabelInfo)
-const labelCache = new Map<string, Map<string, LabelInfo>>();
-
-// System labels that the UI already shows via other means (inbox badge, unread styling, etc.)
-const HIDDEN_SYSTEM_LABELS = new Set([
-  "INBOX",
-  "UNREAD",
-  "SENT",
-  "DRAFT",
-  "SPAM",
-  "TRASH",
-  "IMPORTANT",
-  "STARRED",
-  "CATEGORY_PERSONAL",
-  "CATEGORY_SOCIAL",
-  "CATEGORY_UPDATES",
-  "CATEGORY_FORUMS",
-  "CATEGORY_PROMOTIONS",
-]);
-
-async function fetchAndCacheLabels(
-  accountId: string,
-  logger: ExtensionContext["logger"],
-): Promise<Map<string, LabelInfo>> {
-  try {
-    const client = await getClient(accountId);
-    const labels = await client.listLabels();
-    const map = new Map<string, LabelInfo>();
-    for (const label of labels) {
-      map.set(label.id, label);
-    }
-    labelCache.set(accountId, map);
-    logger.info(`Cached ${labels.length} labels for account ${accountId}`);
-    return map;
-  } catch (error) {
-    logger.error("Failed to fetch labels:", error);
-    return new Map();
-  }
-}
-
-export function createLabelsProvider(context: ExtensionContext): EnrichmentProvider {
+/**
+ * Labels enrichment provider — registered to keep the sidebar panel active,
+ * but returns null for enrichment data. The LabelsPanel component resolves
+ * labels directly via window.api.labels to avoid the sender-scoped enrichment
+ * cache (which would serve stale labels across different emails from the same sender).
+ */
+export function createLabelsProvider(_context: ExtensionContext): EnrichmentProvider {
   return {
     id: "labels-provider",
     panelId: "email-labels",
     priority: 90,
 
-    canEnrich(_email: DashboardEmail): boolean {
-      // Always show the labels panel — even unlabeled emails need the "Add label" button
+    canEnrich(): boolean {
       return true;
     },
 
-    async enrich(email: DashboardEmail): Promise<EnrichmentData | null> {
-      const labelIds = email.labelIds;
-      if (!labelIds?.length) return null;
-
-      const accountId = email.accountId || "default";
-
-      // Get or fetch label metadata
-      let labelMap = labelCache.get(accountId);
-      if (!labelMap) {
-        labelMap = await fetchAndCacheLabels(accountId, context.logger);
-      }
-
-      // Resolve label IDs to full label info, filtering out system labels the UI already shows
-      const resolvedLabels: LabelInfo[] = [];
-      for (const id of labelIds) {
-        if (HIDDEN_SYSTEM_LABELS.has(id)) continue;
-        const info = labelMap.get(id);
-        if (info) {
-          resolvedLabels.push(info);
-        } else {
-          // Label not in cache — show the raw ID as a fallback
-          resolvedLabels.push({ id, name: id, type: "unknown" });
-        }
-      }
-
-      // Sort: user labels first (alphabetically), then system labels
-      resolvedLabels.sort((a, b) => {
-        if (a.type === "user" && b.type !== "user") return -1;
-        if (a.type !== "user" && b.type === "user") return 1;
-        return a.name.localeCompare(b.name);
-      });
-
-      return {
-        extensionId: "labels",
-        panelId: "email-labels",
-        data: {
-          labels: resolvedLabels,
-          allLabelIds: labelIds,
-        } as unknown as Record<string, unknown>,
-        expiresAt: Date.now() + 5 * 60 * 1000, // 5 min TTL
-      };
+    async enrich(_email: DashboardEmail): Promise<EnrichmentData | null> {
+      // Labels are resolved directly in LabelsPanel via window.api.labels
+      // to avoid sender-scoped enrichment cache returning wrong labels.
+      return null;
     },
   };
 }

--- a/src/extensions/mail-ext-labels/src/labels-provider.ts
+++ b/src/extensions/mail-ext-labels/src/labels-provider.ts
@@ -3,15 +3,8 @@ import type {
   EnrichmentProvider,
   EnrichmentData,
 } from "../../../shared/extension-types";
-import type { DashboardEmail } from "../../../shared/types";
+import type { DashboardEmail, LabelInfo } from "../../../shared/types";
 import { getClient } from "../../../main/ipc/gmail.ipc";
-
-export interface LabelInfo {
-  id: string;
-  name: string;
-  type: string;
-  color?: { textColor: string; backgroundColor: string };
-}
 
 // In-memory cache: accountId -> (labelId -> LabelInfo)
 const labelCache = new Map<string, Map<string, LabelInfo>>();

--- a/src/extensions/mail-ext-labels/src/labels-provider.ts
+++ b/src/extensions/mail-ext-labels/src/labels-provider.ts
@@ -1,0 +1,109 @@
+import type {
+  ExtensionContext,
+  EnrichmentProvider,
+  EnrichmentData,
+} from "../../../shared/extension-types";
+import type { DashboardEmail } from "../../../shared/types";
+import { getClient } from "../../../main/ipc/gmail.ipc";
+
+export interface LabelInfo {
+  id: string;
+  name: string;
+  type: string;
+  color?: { textColor: string; backgroundColor: string };
+}
+
+// In-memory cache: accountId -> (labelId -> LabelInfo)
+const labelCache = new Map<string, Map<string, LabelInfo>>();
+
+// System labels that the UI already shows via other means (inbox badge, unread styling, etc.)
+const HIDDEN_SYSTEM_LABELS = new Set([
+  "INBOX",
+  "UNREAD",
+  "SENT",
+  "DRAFT",
+  "SPAM",
+  "TRASH",
+  "IMPORTANT",
+  "STARRED",
+  "CATEGORY_PERSONAL",
+  "CATEGORY_SOCIAL",
+  "CATEGORY_UPDATES",
+  "CATEGORY_FORUMS",
+  "CATEGORY_PROMOTIONS",
+]);
+
+async function fetchAndCacheLabels(
+  accountId: string,
+  logger: ExtensionContext["logger"],
+): Promise<Map<string, LabelInfo>> {
+  try {
+    const client = await getClient(accountId);
+    const labels = await client.listLabels();
+    const map = new Map<string, LabelInfo>();
+    for (const label of labels) {
+      map.set(label.id, label);
+    }
+    labelCache.set(accountId, map);
+    logger.info(`Cached ${labels.length} labels for account ${accountId}`);
+    return map;
+  } catch (error) {
+    logger.error("Failed to fetch labels:", error);
+    return new Map();
+  }
+}
+
+export function createLabelsProvider(context: ExtensionContext): EnrichmentProvider {
+  return {
+    id: "labels-provider",
+    panelId: "email-labels",
+    priority: 90,
+
+    canEnrich(email: DashboardEmail): boolean {
+      return !!email.labelIds?.length;
+    },
+
+    async enrich(email: DashboardEmail): Promise<EnrichmentData | null> {
+      const labelIds = email.labelIds;
+      if (!labelIds?.length) return null;
+
+      const accountId = email.accountId || "default";
+
+      // Get or fetch label metadata
+      let labelMap = labelCache.get(accountId);
+      if (!labelMap) {
+        labelMap = await fetchAndCacheLabels(accountId, context.logger);
+      }
+
+      // Resolve label IDs to full label info, filtering out system labels the UI already shows
+      const resolvedLabels: LabelInfo[] = [];
+      for (const id of labelIds) {
+        if (HIDDEN_SYSTEM_LABELS.has(id)) continue;
+        const info = labelMap.get(id);
+        if (info) {
+          resolvedLabels.push(info);
+        } else {
+          // Label not in cache — show the raw ID as a fallback
+          resolvedLabels.push({ id, name: id, type: "unknown" });
+        }
+      }
+
+      // Sort: user labels first (alphabetically), then system labels
+      resolvedLabels.sort((a, b) => {
+        if (a.type === "user" && b.type !== "user") return -1;
+        if (a.type !== "user" && b.type === "user") return 1;
+        return a.name.localeCompare(b.name);
+      });
+
+      return {
+        extensionId: "labels",
+        panelId: "email-labels",
+        data: {
+          labels: resolvedLabels,
+          allLabelIds: labelIds,
+        } as unknown as Record<string, unknown>,
+        expiresAt: Date.now() + 5 * 60 * 1000, // 5 min TTL
+      };
+    },
+  };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ ipcMain.on("debug:log", (_, msg: string) => {
 import { ExtensionManifestSchema } from "../shared/extension-types";
 import webSearchPackageJson from "../extensions/mail-ext-web-search/package.json";
 import calendarPackageJson from "../extensions/mail-ext-calendar/package.json";
+import labelsPackageJson from "../extensions/mail-ext-labels/package.json";
 import { createWindow, getIconPath } from "./window";
 import { registerGmailIpc } from "./ipc/gmail.ipc";
 import { registerAnalysisIpc } from "./ipc/analysis.ipc";
@@ -32,6 +33,7 @@ import { registerSearchIpc } from "./ipc/search.ipc";
 import { registerOutboxIpc, registerNetworkIpc } from "./ipc/outbox.ipc";
 import { registerMemoryIpc } from "./ipc/memory.ipc";
 import { registerSplitsIpc } from "./ipc/splits.ipc";
+import { registerLabelsIpc } from "./ipc/labels.ipc";
 import { registerSnippetsIpc } from "./ipc/snippets.ipc";
 import { registerArchiveReadyIpc } from "./ipc/archive-ready.ipc";
 import { registerSnoozeIpc } from "./ipc/snooze.ipc";
@@ -55,6 +57,7 @@ import { calendarSyncService } from "./services/calendar-sync";
 import { emailSyncService } from "./services/email-sync";
 import * as webSearchExtension from "../extensions/mail-ext-web-search/src/index";
 import * as calendarExtension from "../extensions/mail-ext-calendar/src/index";
+import * as labelsExtension from "../extensions/mail-ext-labels/src/index";
 
 // Skip Keychain for Chromium's internal cookie/localStorage encryption.
 // Without this, macOS prompts "wants to access data from other apps" on first launch
@@ -517,6 +520,7 @@ app.whenReady().then(async () => {
   registerOutboxIpc();
   registerMemoryIpc();
   registerSplitsIpc();
+  registerLabelsIpc();
   registerSnippetsIpc();
   registerArchiveReadyIpc();
   registerSnoozeIpc();
@@ -548,10 +552,12 @@ app.whenReady().then(async () => {
 
   const webSearchManifest = ExtensionManifestSchema.parse(webSearchPackageJson.mailExtension);
   const calendarManifest = ExtensionManifestSchema.parse(calendarPackageJson.mailExtension);
+  const labelsManifest = ExtensionManifestSchema.parse(labelsPackageJson.mailExtension);
 
   Promise.all([
     extensionHost.registerBundledExtensionFull(webSearchManifest, webSearchExtension),
     extensionHost.registerBundledExtensionFull(calendarManifest, calendarExtension),
+    extensionHost.registerBundledExtensionFull(labelsManifest, labelsExtension),
   ])
     .then(() => {
       log.info("[Extensions] Bundled extensions activated");

--- a/src/main/ipc/labels.ipc.ts
+++ b/src/main/ipc/labels.ipc.ts
@@ -22,6 +22,24 @@ export function registerLabelsIpc(): void {
     },
   );
 
+  // Create a new Gmail label
+  ipcMain.handle(
+    "labels:create",
+    async (
+      _,
+      { accountId, name }: { accountId: string; name: string },
+    ): Promise<IpcResponse<LabelInfo>> => {
+      try {
+        const client = await getClient(accountId);
+        const label = await client.createLabel(name);
+        return { success: true, data: label };
+      } catch (error) {
+        log.error({ err: error }, "[Labels] Failed to create label");
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
   // Modify labels on a single message
   ipcMain.handle(
     "labels:modify-message",

--- a/src/main/ipc/labels.ipc.ts
+++ b/src/main/ipc/labels.ipc.ts
@@ -1,0 +1,103 @@
+import { ipcMain } from "electron";
+import { getClient } from "./gmail.ipc";
+import { updateEmailLabelIds, getEmailsByThread } from "../db";
+import type { IpcResponse } from "../../shared/types";
+
+interface LabelInfo {
+  id: string;
+  name: string;
+  type: string;
+  color?: { textColor: string; backgroundColor: string };
+}
+
+export function registerLabelsIpc(): void {
+  // List all labels for an account
+  ipcMain.handle(
+    "labels:list",
+    async (_, { accountId }: { accountId: string }): Promise<IpcResponse<LabelInfo[]>> => {
+      try {
+        const client = await getClient(accountId);
+        const labels = await client.listLabels();
+        return { success: true, data: labels };
+      } catch (error) {
+        console.error("[Labels] Failed to list labels:", error);
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
+  // Modify labels on a single message
+  ipcMain.handle(
+    "labels:modify-message",
+    async (
+      _,
+      {
+        accountId,
+        emailId,
+        addLabelIds,
+        removeLabelIds,
+      }: {
+        accountId: string;
+        emailId: string;
+        addLabelIds: string[];
+        removeLabelIds: string[];
+      },
+    ): Promise<IpcResponse<{ labelIds: string[] }>> => {
+      try {
+        const client = await getClient(accountId);
+        await client.modifyMessageLabels(emailId, addLabelIds, removeLabelIds);
+
+        // Read back the updated message to get authoritative labelIds
+        const msg = await client.readEmail(emailId);
+        const newLabelIds = msg?.labelIds ?? [];
+
+        // Update local DB
+        updateEmailLabelIds(emailId, newLabelIds);
+
+        return { success: true, data: { labelIds: newLabelIds } };
+      } catch (error) {
+        console.error("[Labels] Failed to modify message labels:", error);
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+
+  // Modify labels on all messages in a thread
+  ipcMain.handle(
+    "labels:modify-thread",
+    async (
+      _,
+      {
+        accountId,
+        threadId,
+        addLabelIds,
+        removeLabelIds,
+      }: {
+        accountId: string;
+        threadId: string;
+        addLabelIds: string[];
+        removeLabelIds: string[];
+      },
+    ): Promise<IpcResponse<void>> => {
+      try {
+        const client = await getClient(accountId);
+        await client.modifyThreadLabels(threadId, addLabelIds, removeLabelIds);
+
+        // Update local DB for all emails in the thread
+        const threadEmails = getEmailsByThread(threadId, accountId);
+        for (const email of threadEmails) {
+          const currentLabels = email.labelIds ?? [];
+          const updated = currentLabels
+            .filter((id) => !removeLabelIds.includes(id))
+            .concat(addLabelIds.filter((id) => !currentLabels.includes(id)));
+          updateEmailLabelIds(email.id, updated);
+        }
+
+        return { success: true, data: undefined };
+      } catch (error) {
+        console.error("[Labels] Failed to modify thread labels:", error);
+        return { success: false, error: String(error) };
+      }
+    },
+  );
+}

--- a/src/main/ipc/labels.ipc.ts
+++ b/src/main/ipc/labels.ipc.ts
@@ -2,6 +2,9 @@ import { ipcMain } from "electron";
 import { getClient } from "./gmail.ipc";
 import { updateEmailLabelIds, getEmailsByThread } from "../db";
 import type { IpcResponse } from "../../shared/types";
+import { createLogger } from "../services/logger";
+
+const log = createLogger("labels-ipc");
 
 interface LabelInfo {
   id: string;
@@ -20,7 +23,7 @@ export function registerLabelsIpc(): void {
         const labels = await client.listLabels();
         return { success: true, data: labels };
       } catch (error) {
-        console.error("[Labels] Failed to list labels:", error);
+        log.error({ err: error }, "Failed to list labels");
         return { success: false, error: String(error) };
       }
     },
@@ -56,7 +59,7 @@ export function registerLabelsIpc(): void {
 
         return { success: true, data: { labelIds: newLabelIds } };
       } catch (error) {
-        console.error("[Labels] Failed to modify message labels:", error);
+        log.error({ err: error }, "Failed to modify message labels");
         return { success: false, error: String(error) };
       }
     },
@@ -95,7 +98,7 @@ export function registerLabelsIpc(): void {
 
         return { success: true, data: undefined };
       } catch (error) {
-        console.error("[Labels] Failed to modify thread labels:", error);
+        log.error({ err: error }, "Failed to modify thread labels");
         return { success: false, error: String(error) };
       }
     },

--- a/src/main/ipc/labels.ipc.ts
+++ b/src/main/ipc/labels.ipc.ts
@@ -86,14 +86,12 @@ export function registerLabelsIpc(): void {
         const client = await getClient(accountId);
         await client.modifyThreadLabels(threadId, addLabelIds, removeLabelIds);
 
-        // Update local DB for all emails in the thread
+        // Read back authoritative labelIds from Gmail for each thread message
         const threadEmails = getEmailsByThread(threadId, accountId);
         for (const email of threadEmails) {
-          const currentLabels = email.labelIds ?? [];
-          const updated = currentLabels
-            .filter((id) => !removeLabelIds.includes(id))
-            .concat(addLabelIds.filter((id) => !currentLabels.includes(id)));
-          updateEmailLabelIds(email.id, updated);
+          const msg = await client.readEmail(email.id);
+          const newLabelIds = msg?.labelIds ?? [];
+          updateEmailLabelIds(email.id, newLabelIds);
         }
 
         return { success: true, data: undefined };

--- a/src/main/ipc/labels.ipc.ts
+++ b/src/main/ipc/labels.ipc.ts
@@ -1,17 +1,10 @@
 import { ipcMain } from "electron";
 import { getClient } from "./gmail.ipc";
 import { updateEmailLabelIds, getEmailsByThread } from "../db";
-import type { IpcResponse } from "../../shared/types";
+import type { IpcResponse, LabelInfo } from "../../shared/types";
 import { createLogger } from "../services/logger";
 
 const log = createLogger("labels-ipc");
-
-interface LabelInfo {
-  id: string;
-  name: string;
-  type: string;
-  color?: { textColor: string; backgroundColor: string };
-}
 
 export function registerLabelsIpc(): void {
   // List all labels for an account
@@ -86,13 +79,14 @@ export function registerLabelsIpc(): void {
         const client = await getClient(accountId);
         await client.modifyThreadLabels(threadId, addLabelIds, removeLabelIds);
 
-        // Read back authoritative labelIds from Gmail for each thread message
+        // Read back authoritative labelIds from Gmail for each thread message (parallel)
         const threadEmails = getEmailsByThread(threadId, accountId);
-        for (const email of threadEmails) {
-          const msg = await client.readEmail(email.id);
-          const newLabelIds = msg?.labelIds ?? [];
-          updateEmailLabelIds(email.id, newLabelIds);
-        }
+        await Promise.all(
+          threadEmails.map(async (email) => {
+            const msg = await client.readEmail(email.id);
+            updateEmailLabelIds(email.id, msg?.labelIds ?? []);
+          }),
+        );
 
         return { success: true, data: undefined };
       } catch (error) {

--- a/src/main/services/gmail-client.ts
+++ b/src/main/services/gmail-client.ts
@@ -545,6 +545,23 @@ export class GmailClient {
   }
 
   /**
+   * Create a new Gmail label. Returns the created label's id and name.
+   */
+  async createLabel(name: string): Promise<LabelInfo> {
+    const gmail = this.gmail!;
+    const response = await gmail.users.labels.create({
+      userId: "me",
+      requestBody: {
+        name,
+        labelListVisibility: "labelShow",
+        messageListVisibility: "show",
+      },
+    });
+    const l = response.data;
+    return { id: l.id!, name: l.name!, type: "user" };
+  }
+
+  /**
    * Modify labels on a message (add and/or remove arbitrary labels)
    */
   async modifyMessageLabels(

--- a/src/main/services/gmail-client.ts
+++ b/src/main/services/gmail-client.ts
@@ -558,6 +558,7 @@ export class GmailClient {
     addLabelIds: string[],
     removeLabelIds: string[],
   ): Promise<void> {
+    if (addLabelIds.length === 0 && removeLabelIds.length === 0) return;
     const gmail = this.gmail!;
     await gmail.users.messages.modify({
       userId: "me",
@@ -577,6 +578,7 @@ export class GmailClient {
     addLabelIds: string[],
     removeLabelIds: string[],
   ): Promise<void> {
+    if (addLabelIds.length === 0 && removeLabelIds.length === 0) return;
     const gmail = this.gmail!;
     await gmail.users.threads.modify({
       userId: "me",

--- a/src/main/services/gmail-client.ts
+++ b/src/main/services/gmail-client.ts
@@ -526,6 +526,69 @@ export class GmailClient {
   }
 
   /**
+   * List all labels for the authenticated account.
+   * Returns id, name, type, and optional color for each label.
+   */
+  async listLabels(): Promise<
+    Array<{
+      id: string;
+      name: string;
+      type: string;
+      color?: { textColor: string; backgroundColor: string };
+    }>
+  > {
+    const gmail = this.gmail!;
+    const response = await gmail.users.labels.list({ userId: "me" });
+    const rawLabels = response.data.labels || [];
+    return rawLabels.map((l) => ({
+      id: l.id!,
+      name: l.name!,
+      type: l.type || "user",
+      ...(l.color
+        ? { color: { textColor: l.color.textColor!, backgroundColor: l.color.backgroundColor! } }
+        : {}),
+    }));
+  }
+
+  /**
+   * Modify labels on a message (add and/or remove arbitrary labels)
+   */
+  async modifyMessageLabels(
+    messageId: string,
+    addLabelIds: string[],
+    removeLabelIds: string[],
+  ): Promise<void> {
+    const gmail = this.gmail!;
+    await gmail.users.messages.modify({
+      userId: "me",
+      id: messageId,
+      requestBody: {
+        addLabelIds: addLabelIds.length > 0 ? addLabelIds : undefined,
+        removeLabelIds: removeLabelIds.length > 0 ? removeLabelIds : undefined,
+      },
+    });
+  }
+
+  /**
+   * Modify labels on all messages in a thread
+   */
+  async modifyThreadLabels(
+    threadId: string,
+    addLabelIds: string[],
+    removeLabelIds: string[],
+  ): Promise<void> {
+    const gmail = this.gmail!;
+    await gmail.users.threads.modify({
+      userId: "me",
+      id: threadId,
+      requestBody: {
+        addLabelIds: addLabelIds.length > 0 ? addLabelIds : undefined,
+        removeLabelIds: removeLabelIds.length > 0 ? removeLabelIds : undefined,
+      },
+    });
+  }
+
+  /**
    * Get the total number of messages with a given label.
    * Uses the labels.get endpoint which returns exact counts.
    */

--- a/src/main/services/gmail-client.ts
+++ b/src/main/services/gmail-client.ts
@@ -17,6 +17,7 @@ import type {
   ComposeMessageOptions,
   AttachmentMeta,
   SendAsAlias,
+  LabelInfo,
 } from "../../shared/types";
 import { getAccounts } from "../db";
 import { getDataDir } from "../data-dir";
@@ -529,14 +530,7 @@ export class GmailClient {
    * List all labels for the authenticated account.
    * Returns id, name, type, and optional color for each label.
    */
-  async listLabels(): Promise<
-    Array<{
-      id: string;
-      name: string;
-      type: string;
-      color?: { textColor: string; backgroundColor: string };
-    }>
-  > {
+  async listLabels(): Promise<LabelInfo[]> {
     const gmail = this.gmail!;
     const response = await gmail.users.labels.list({ userId: "me" });
     const rawLabels = response.data.labels || [];

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -187,6 +187,35 @@ const api = {
       ipcRenderer.invoke("emails:search-remote", { query, accountId, maxResults, pageToken }),
   },
 
+  // Label operations
+  labels: {
+    list: (accountId: string): Promise<unknown> => ipcRenderer.invoke("labels:list", { accountId }),
+    modifyMessage: (
+      accountId: string,
+      emailId: string,
+      addLabelIds: string[],
+      removeLabelIds: string[],
+    ): Promise<unknown> =>
+      ipcRenderer.invoke("labels:modify-message", {
+        accountId,
+        emailId,
+        addLabelIds,
+        removeLabelIds,
+      }),
+    modifyThread: (
+      accountId: string,
+      threadId: string,
+      addLabelIds: string[],
+      removeLabelIds: string[],
+    ): Promise<unknown> =>
+      ipcRenderer.invoke("labels:modify-thread", {
+        accountId,
+        threadId,
+        addLabelIds,
+        removeLabelIds,
+      }),
+  },
+
   // Style operations
   style: {
     getContext: (toAddress: string): Promise<unknown> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -190,6 +190,8 @@ const api = {
   // Label operations
   labels: {
     list: (accountId: string): Promise<unknown> => ipcRenderer.invoke("labels:list", { accountId }),
+    create: (accountId: string, name: string): Promise<unknown> =>
+      ipcRenderer.invoke("labels:create", { accountId, name }),
     modifyMessage: (
       accountId: string,
       emailId: string,

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -78,6 +78,7 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
   const pickerRef = useRef<HTMLDivElement>(null);
   const isLabelPickerOpen = useAppStore((s) => s.isLabelPickerOpen);
   const closeLabelPicker = useAppStore((s) => s.closeLabelPicker);
+  const updateEmail = useAppStore((s) => s.updateEmail);
 
   // Open picker when triggered by 'l' hotkey
   useEffect(() => {
@@ -153,12 +154,17 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
         const result = await window.api.labels.modifyThread(accountId, threadId, [], [labelId]);
         if (result.success) {
           setCurrentLabels((prev) => prev.filter((l) => l.id !== labelId));
+          // Sync store so navigating away and back shows correct labels
+          for (const te of threadEmails) {
+            const updated = (te.labelIds ?? []).filter((id) => id !== labelId);
+            updateEmail(te.id, { labelIds: updated });
+          }
         }
       } finally {
         setBusy(false);
       }
     },
-    [email.threadId, email.accountId],
+    [email.threadId, email.accountId, threadEmails, updateEmail],
   );
 
   const addLabel = useCallback(
@@ -174,6 +180,13 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
             if (prev.some((l) => l.id === label.id)) return prev;
             return [...prev, label].sort((a, b) => a.name.localeCompare(b.name));
           });
+          // Sync store so navigating away and back shows correct labels
+          for (const te of threadEmails) {
+            const current = te.labelIds ?? [];
+            if (!current.includes(label.id)) {
+              updateEmail(te.id, { labelIds: [...current, label.id] });
+            }
+          }
         }
         setShowPicker(false);
         setSearch("");
@@ -181,7 +194,7 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
         setBusy(false);
       }
     },
-    [email.threadId, email.accountId],
+    [email.threadId, email.accountId, threadEmails, updateEmail],
   );
 
   // Reset highlight when search changes

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -73,7 +73,7 @@ export function LabelsPanel({
   // Fetch all labels for the picker
   useEffect(() => {
     const accountId = email.accountId || "default";
-    window.api.labels.list(accountId).then((result) => {
+    window.api.labels.list(accountId).then((result: { success: boolean; data?: LabelInfo[] }) => {
       if (result.success && result.data) {
         setAllLabels(result.data);
       }

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -51,6 +51,19 @@ const HIDDEN_SYSTEM = new Set([
   "CATEGORY_UPDATES",
   "CATEGORY_FORUMS",
   "CATEGORY_PROMOTIONS",
+  // Gmail star variants — redundant with the star icon in the UI
+  "YELLOW_STAR",
+  "RED_STAR",
+  "ORANGE_STAR",
+  "GREEN_STAR",
+  "BLUE_STAR",
+  "PURPLE_STAR",
+  "RED_BANG",
+  "ORANGE_GUILLEMET",
+  "YELLOW_BANG",
+  "GREEN_CHECK",
+  "BLUE_INFO",
+  "PURPLE_QUESTION",
 ]);
 
 export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.ReactElement {

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { DashboardEmail, LabelInfo } from "../../../shared/types";
 import type { ExtensionEnrichmentResult } from "../../../shared/extension-types";
+import { useAppStore } from "../../store";
 
 interface LabelsPanelProps {
   email: DashboardEmail;
@@ -52,9 +53,7 @@ const HIDDEN_SYSTEM = new Set([
   "CATEGORY_PROMOTIONS",
 ]);
 
-export function LabelsPanel({
-  email,
-}: LabelsPanelProps): React.ReactElement {
+export function LabelsPanel({ email }: LabelsPanelProps): React.ReactElement {
   const [currentLabels, setCurrentLabels] = useState<LabelInfo[]>([]);
   const [allLabels, setAllLabels] = useState<LabelInfo[]>([]);
   const [labelsLoaded, setLabelsLoaded] = useState(false);
@@ -64,6 +63,16 @@ export function LabelsPanel({
   const [highlightIndex, setHighlightIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const isLabelPickerOpen = useAppStore((s) => s.isLabelPickerOpen);
+  const closeLabelPicker = useAppStore((s) => s.closeLabelPicker);
+
+  // Open picker when triggered by 'l' hotkey
+  useEffect(() => {
+    if (isLabelPickerOpen && labelsLoaded) {
+      setShowPicker(true);
+      closeLabelPicker();
+    }
+  }, [isLabelPickerOpen, labelsLoaded, closeLabelPicker]);
 
   // Fetch all labels and resolve current email's labels directly
   // (bypasses sender-scoped enrichment cache which would serve wrong labels)

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -1,13 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import type { DashboardEmail } from "../../../shared/types";
+import type { DashboardEmail, LabelInfo } from "../../../shared/types";
 import type { ExtensionEnrichmentResult } from "../../../shared/extension-types";
-
-interface LabelInfo {
-  id: string;
-  name: string;
-  type: string;
-  color?: { textColor: string; backgroundColor: string };
-}
 
 interface LabelsEnrichmentData {
   labels: LabelInfo[];

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -1,0 +1,306 @@
+import React, { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import type { DashboardEmail } from "../../../shared/types";
+import type { ExtensionEnrichmentResult } from "../../../shared/extension-types";
+
+interface LabelInfo {
+  id: string;
+  name: string;
+  type: string;
+  color?: { textColor: string; backgroundColor: string };
+}
+
+interface LabelsEnrichmentData {
+  labels: LabelInfo[];
+  allLabelIds: string[];
+}
+
+interface LabelsPanelProps {
+  email: DashboardEmail;
+  threadEmails: DashboardEmail[];
+  enrichment: ExtensionEnrichmentResult | null;
+  isLoading: boolean;
+}
+
+// Type for the labels API on window.api
+type LabelsAPI = {
+  list: (accountId: string) => Promise<{ success: boolean; data?: LabelInfo[] }>;
+  modifyMessage: (
+    accountId: string,
+    emailId: string,
+    addLabelIds: string[],
+    removeLabelIds: string[],
+  ) => Promise<{ success: boolean; data?: { labelIds: string[] }; error?: string }>;
+  modifyThread: (
+    accountId: string,
+    threadId: string,
+    addLabelIds: string[],
+    removeLabelIds: string[],
+  ) => Promise<{ success: boolean; error?: string }>;
+};
+
+declare global {
+  interface Window {
+    api: {
+      labels: LabelsAPI;
+      [key: string]: unknown;
+    };
+  }
+}
+
+export function LabelsPanel({
+  email,
+  enrichment,
+  isLoading,
+}: LabelsPanelProps): React.ReactElement {
+  const data = enrichment?.data as LabelsEnrichmentData | undefined;
+  const [currentLabels, setCurrentLabels] = useState<LabelInfo[]>([]);
+  const [allLabels, setAllLabels] = useState<LabelInfo[]>([]);
+  const [showPicker, setShowPicker] = useState(false);
+  const [search, setSearch] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Sync enrichment data into local state
+  useEffect(() => {
+    if (data?.labels) {
+      setCurrentLabels(data.labels);
+    }
+  }, [data]);
+
+  // Fetch all labels for the picker
+  useEffect(() => {
+    const accountId = email.accountId || "default";
+    window.api.labels.list(accountId).then((result) => {
+      if (result.success && result.data) {
+        setAllLabels(result.data);
+      }
+    });
+  }, [email.accountId]);
+
+  // Focus input when picker opens
+  useEffect(() => {
+    if (showPicker && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [showPicker]);
+
+  // Close picker on outside click
+  useEffect(() => {
+    if (!showPicker) return;
+    const handleClick = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setShowPicker(false);
+        setSearch("");
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [showPicker]);
+
+  const removeLabel = useCallback(
+    async (labelId: string) => {
+      const accountId = email.accountId || "default";
+      const threadId = email.threadId;
+      setBusy(true);
+      // Gmail labels are thread-level — remove from entire thread
+      const result = await window.api.labels.modifyThread(accountId, threadId, [], [labelId]);
+      if (result.success) {
+        setCurrentLabels((prev) => prev.filter((l) => l.id !== labelId));
+      }
+      setBusy(false);
+    },
+    [email.threadId, email.accountId],
+  );
+
+  const addLabel = useCallback(
+    async (label: LabelInfo) => {
+      const accountId = email.accountId || "default";
+      const threadId = email.threadId;
+      setBusy(true);
+      // Gmail labels are thread-level — add to entire thread
+      const result = await window.api.labels.modifyThread(accountId, threadId, [label.id], []);
+      if (result.success) {
+        setCurrentLabels((prev) => {
+          if (prev.some((l) => l.id === label.id)) return prev;
+          return [...prev, label].sort((a, b) => a.name.localeCompare(b.name));
+        });
+      }
+      setShowPicker(false);
+      setSearch("");
+      setBusy(false);
+    },
+    [email.threadId, email.accountId],
+  );
+
+  // Labels available to add (not already applied, not system, matches search)
+  const HIDDEN_SYSTEM = new Set([
+    "INBOX",
+    "UNREAD",
+    "SENT",
+    "DRAFT",
+    "SPAM",
+    "TRASH",
+    "IMPORTANT",
+    "STARRED",
+    "CATEGORY_PERSONAL",
+    "CATEGORY_SOCIAL",
+    "CATEGORY_UPDATES",
+    "CATEGORY_FORUMS",
+    "CATEGORY_PROMOTIONS",
+  ]);
+
+  // Reset highlight when search changes
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [search]);
+
+  const availableLabels = useMemo(() => {
+    const currentIds = new Set(currentLabels.map((l) => l.id));
+    return allLabels
+      .filter((l) => !HIDDEN_SYSTEM.has(l.id) && !currentIds.has(l.id))
+      .filter((l) => !search || l.name.toLowerCase().includes(search.toLowerCase()))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [allLabels, currentLabels, search]);
+
+  return (
+    <div className="p-4">
+      {isLoading && (
+        <div className="flex items-center space-x-2 text-gray-500 dark:text-gray-400 py-4">
+          <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          <span className="text-sm">Loading labels...</span>
+        </div>
+      )}
+
+      {!isLoading && (
+        <>
+          {/* Current labels as removable chips */}
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {currentLabels.map((label) => (
+              <span
+                key={label.id}
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium group ${
+                  label.color ? "" : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                }`}
+                style={
+                  label.color
+                    ? { backgroundColor: label.color.backgroundColor, color: label.color.textColor }
+                    : undefined
+                }
+              >
+                {label.name}
+                <button
+                  onClick={() => removeLabel(label.id)}
+                  disabled={busy}
+                  className="opacity-50 hover:opacity-100 transition-opacity ml-0.5"
+                  title={`Remove ${label.name}`}
+                >
+                  <svg
+                    className="w-3 h-3"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </span>
+            ))}
+
+            {currentLabels.length === 0 && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">No labels</span>
+            )}
+          </div>
+
+          {/* Add label button / picker */}
+          <div className="relative" ref={pickerRef}>
+            {!showPicker ? (
+              <button
+                onClick={() => setShowPicker(true)}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
+              >
+                + Add label
+              </button>
+            ) : (
+              <div className="border border-gray-200 dark:border-gray-600 rounded-lg overflow-hidden bg-white dark:bg-gray-800 shadow-lg">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search labels..."
+                  className="w-full px-3 py-2 text-sm bg-transparent border-b border-gray-200 dark:border-gray-600 outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      setShowPicker(false);
+                      setSearch("");
+                    } else if (e.key === "ArrowDown") {
+                      e.preventDefault();
+                      setHighlightIndex((i) =>
+                        Math.min(i + 1, Math.min(availableLabels.length - 1, 49)),
+                      );
+                    } else if (e.key === "ArrowUp") {
+                      e.preventDefault();
+                      setHighlightIndex((i) => Math.max(i - 1, 0));
+                    } else if (e.key === "Enter" && availableLabels.length > 0) {
+                      addLabel(
+                        availableLabels[Math.min(highlightIndex, availableLabels.length - 1)],
+                      );
+                    }
+                  }}
+                />
+                <div className="max-h-48 overflow-y-auto" ref={listRef}>
+                  {availableLabels.length === 0 && (
+                    <div className="px-3 py-2 text-xs text-gray-400">No matching labels</div>
+                  )}
+                  {availableLabels.slice(0, 50).map((label, index) => (
+                    <button
+                      key={label.id}
+                      ref={(el) => {
+                        if (index === highlightIndex && el) {
+                          el.scrollIntoView({ block: "nearest" });
+                        }
+                      }}
+                      onClick={() => addLabel(label)}
+                      disabled={busy}
+                      className={`w-full text-left px-3 py-1.5 text-sm text-gray-800 dark:text-gray-200 flex items-center gap-2 ${
+                        index === highlightIndex
+                          ? "bg-blue-100 dark:bg-blue-900/40"
+                          : "hover:bg-gray-100 dark:hover:bg-gray-700"
+                      }`}
+                    >
+                      {label.color && (
+                        <span
+                          className="w-2 h-2 rounded-full flex-shrink-0"
+                          style={{ backgroundColor: label.color.backgroundColor }}
+                        />
+                      )}
+                      {label.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -73,11 +73,16 @@ export function LabelsPanel({
   // Fetch all labels for the picker
   useEffect(() => {
     const accountId = email.accountId || "default";
-    window.api.labels.list(accountId).then((result: { success: boolean; data?: LabelInfo[] }) => {
-      if (result.success && result.data) {
-        setAllLabels(result.data);
-      }
-    });
+    window.api.labels
+      .list(accountId)
+      .then((result: { success: boolean; data?: LabelInfo[] }) => {
+        if (result.success && result.data) {
+          setAllLabels(result.data);
+        }
+      })
+      .catch(() => {
+        // Labels list failed — picker will show empty, which is safe
+      });
   }, [email.accountId]);
 
   // Focus input when picker opens

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -13,6 +13,10 @@ interface LabelsPanelProps {
 // Type for the labels API on window.api
 type LabelsAPI = {
   list: (accountId: string) => Promise<{ success: boolean; data?: LabelInfo[] }>;
+  create: (
+    accountId: string,
+    name: string,
+  ) => Promise<{ success: boolean; data?: LabelInfo; error?: string }>;
   modifyMessage: (
     accountId: string,
     emailId: string,
@@ -197,6 +201,45 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
     [email.threadId, email.accountId, threadEmails, updateEmail],
   );
 
+  const createAndAddLabel = useCallback(
+    async (name: string) => {
+      const accountId = email.accountId || "default";
+      const threadId = email.threadId;
+      setBusy(true);
+      try {
+        const createResult = await window.api.labels.create(accountId, name);
+        if (createResult.success && createResult.data) {
+          const newLabel = createResult.data;
+          // Add to allLabels so it appears in future searches
+          setAllLabels((prev) => [...prev, newLabel]);
+          // Apply to thread
+          const result = await window.api.labels.modifyThread(
+            accountId,
+            threadId,
+            [newLabel.id],
+            [],
+          );
+          if (result.success) {
+            setCurrentLabels((prev) =>
+              [...prev, newLabel].sort((a, b) => a.name.localeCompare(b.name)),
+            );
+            for (const te of threadEmails) {
+              const current = te.labelIds ?? [];
+              if (!current.includes(newLabel.id)) {
+                updateEmail(te.id, { labelIds: [...current, newLabel.id] });
+              }
+            }
+          }
+        }
+        setShowPicker(false);
+        setSearch("");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [email.threadId, email.accountId, threadEmails, updateEmail],
+  );
+
   // Reset highlight when search changes
   useEffect(() => {
     setHighlightIndex(0);
@@ -304,16 +347,29 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
                     } else if (e.key === "ArrowUp") {
                       e.preventDefault();
                       setHighlightIndex((i) => Math.max(i - 1, 0));
-                    } else if (e.key === "Enter" && availableLabels.length > 0) {
-                      addLabel(
-                        availableLabels[Math.min(highlightIndex, availableLabels.length - 1)],
-                      );
+                    } else if (e.key === "Enter") {
+                      if (availableLabels.length > 0) {
+                        addLabel(
+                          availableLabels[Math.min(highlightIndex, availableLabels.length - 1)],
+                        );
+                      } else if (search.trim()) {
+                        createAndAddLabel(search.trim());
+                      }
                     }
                   }}
                 />
                 <div className="max-h-48 overflow-y-auto">
-                  {availableLabels.length === 0 && (
+                  {availableLabels.length === 0 && !search.trim() && (
                     <div className="px-3 py-2 text-xs text-gray-400">No matching labels</div>
+                  )}
+                  {availableLabels.length === 0 && search.trim() && (
+                    <button
+                      onClick={() => createAndAddLabel(search.trim())}
+                      disabled={busy}
+                      className="w-full text-left px-3 py-1.5 text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    >
+                      Create &ldquo;{search.trim()}&rdquo;
+                    </button>
                   )}
                   {availableLabels.slice(0, 50).map((label, index) => (
                     <button

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -354,7 +354,9 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
                     } else if (e.key === "ArrowDown") {
                       e.preventDefault();
                       setHighlightIndex((i) =>
-                        Math.min(i + 1, Math.min(availableLabels.length - 1, 49)),
+                        availableLabels.length === 0
+                          ? 0
+                          : Math.min(i + 1, Math.min(availableLabels.length - 1, 49)),
                       );
                     } else if (e.key === "ArrowUp") {
                       e.preventDefault();

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -77,6 +77,7 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
   const [showPicker, setShowPicker] = useState(false);
   const [search, setSearch] = useState("");
   const [busy, setBusy] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
   const [highlightIndex, setHighlightIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
@@ -211,9 +212,14 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
       const accountId = email.accountId || "default";
       const threadId = email.threadId;
       setBusy(true);
+      setCreateError(null);
       try {
         const createResult = await window.api.labels.create(accountId, name);
-        if (createResult.success && createResult.data) {
+        if (!createResult.success) {
+          setCreateError(createResult.error ?? "Failed to create label");
+          return;
+        }
+        if (createResult.data) {
           const newLabel = createResult.data;
           // Add to allLabels so it appears in future searches
           setAllLabels((prev) => [...prev, newLabel]);
@@ -245,9 +251,10 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
     [email.threadId, email.accountId, threadEmails, updateEmail],
   );
 
-  // Reset highlight when search changes
+  // Reset highlight and error when search changes
   useEffect(() => {
     setHighlightIndex(0);
+    setCreateError(null);
   }, [search]);
 
   const availableLabels = useMemo(() => {
@@ -352,7 +359,7 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
                     } else if (e.key === "ArrowUp") {
                       e.preventDefault();
                       setHighlightIndex((i) => Math.max(i - 1, 0));
-                    } else if (e.key === "Enter") {
+                    } else if (e.key === "Enter" && !busy) {
                       if (availableLabels.length > 0) {
                         addLabel(
                           availableLabels[Math.min(highlightIndex, availableLabels.length - 1)],
@@ -368,13 +375,20 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
                     <div className="px-3 py-2 text-xs text-gray-400">No matching labels</div>
                   )}
                   {availableLabels.length === 0 && search.trim() && (
-                    <button
-                      onClick={() => createAndAddLabel(search.trim())}
-                      disabled={busy}
-                      className="w-full text-left px-3 py-1.5 text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    >
-                      Create &ldquo;{search.trim()}&rdquo;
-                    </button>
+                    <>
+                      {createError && (
+                        <div className="px-3 py-1.5 text-xs text-red-500 dark:text-red-400">
+                          {createError}
+                        </div>
+                      )}
+                      <button
+                        onClick={() => createAndAddLabel(search.trim())}
+                        disabled={busy}
+                        className="w-full text-left px-3 py-1.5 text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      >
+                        Create &ldquo;{search.trim()}&rdquo;
+                      </button>
+                    </>
                   )}
                   {availableLabels.slice(0, 50).map((label, index) => (
                     <button

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -53,7 +53,7 @@ const HIDDEN_SYSTEM = new Set([
   "CATEGORY_PROMOTIONS",
 ]);
 
-export function LabelsPanel({ email }: LabelsPanelProps): React.ReactElement {
+export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.ReactElement {
   const [currentLabels, setCurrentLabels] = useState<LabelInfo[]>([]);
   const [allLabels, setAllLabels] = useState<LabelInfo[]>([]);
   const [labelsLoaded, setLabelsLoaded] = useState(false);
@@ -85,8 +85,14 @@ export function LabelsPanel({ email }: LabelsPanelProps): React.ReactElement {
         if (result.success && result.data) {
           setAllLabels(result.data);
 
-          // Resolve this email's labelIds to full label info
-          const labelIds = email.labelIds ?? [];
+          // Aggregate labelIds across all emails in the thread (Gmail labels are thread-level)
+          const allThreadLabelIds = new Set<string>();
+          for (const e of [email, ...threadEmails]) {
+            for (const id of e.labelIds ?? []) {
+              allThreadLabelIds.add(id);
+            }
+          }
+          const labelIds = [...allThreadLabelIds];
           const labelMap = new Map(result.data.map((l) => [l.id, l]));
           const resolved: LabelInfo[] = [];
           for (const id of labelIds) {
@@ -102,7 +108,7 @@ export function LabelsPanel({ email }: LabelsPanelProps): React.ReactElement {
       .catch(() => {
         setLabelsLoaded(true);
       });
-  }, [email.id, email.accountId, email.labelIds]);
+  }, [email.id, email.accountId, email.labelIds, threadEmails]);
 
   // Focus input when picker opens
   useEffect(() => {

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -164,8 +164,12 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
         const result = await window.api.labels.modifyThread(accountId, threadId, [], [labelId]);
         if (result.success) {
           setCurrentLabels((prev) => prev.filter((l) => l.id !== labelId));
-          // Sync store so navigating away and back shows correct labels
-          for (const te of threadEmails) {
+          // Sync store for all thread emails (including the current email prop,
+          // which may not be in threadEmails)
+          const seen = new Set<string>();
+          for (const te of [email, ...threadEmails]) {
+            if (seen.has(te.id)) continue;
+            seen.add(te.id);
             const updated = (te.labelIds ?? []).filter((id) => id !== labelId);
             updateEmail(te.id, { labelIds: updated });
           }
@@ -190,8 +194,11 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
             if (prev.some((l) => l.id === label.id)) return prev;
             return [...prev, label].sort((a, b) => a.name.localeCompare(b.name));
           });
-          // Sync store so navigating away and back shows correct labels
-          for (const te of threadEmails) {
+          // Sync store for all thread emails (including the current email prop)
+          const seen = new Set<string>();
+          for (const te of [email, ...threadEmails]) {
+            if (seen.has(te.id)) continue;
+            seen.add(te.id);
             const current = te.labelIds ?? [];
             if (!current.includes(label.id)) {
               updateEmail(te.id, { labelIds: [...current, label.id] });
@@ -234,7 +241,10 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
             setCurrentLabels((prev) =>
               [...prev, newLabel].sort((a, b) => a.name.localeCompare(b.name)),
             );
-            for (const te of threadEmails) {
+            const seen = new Set<string>();
+            for (const te of [email, ...threadEmails]) {
+              if (seen.has(te.id)) continue;
+              seen.add(te.id);
               const current = te.labelIds ?? [];
               if (!current.includes(newLabel.id)) {
                 updateEmail(te.id, { labelIds: [...current, newLabel.id] });

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -2,11 +2,6 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from "react"
 import type { DashboardEmail, LabelInfo } from "../../../shared/types";
 import type { ExtensionEnrichmentResult } from "../../../shared/extension-types";
 
-interface LabelsEnrichmentData {
-  labels: LabelInfo[];
-  allLabelIds: string[];
-}
-
 interface LabelsPanelProps {
   email: DashboardEmail;
   threadEmails: DashboardEmail[];
@@ -59,12 +54,10 @@ const HIDDEN_SYSTEM = new Set([
 
 export function LabelsPanel({
   email,
-  enrichment,
-  isLoading,
 }: LabelsPanelProps): React.ReactElement {
-  const data = enrichment?.data as LabelsEnrichmentData | undefined;
   const [currentLabels, setCurrentLabels] = useState<LabelInfo[]>([]);
   const [allLabels, setAllLabels] = useState<LabelInfo[]>([]);
+  const [labelsLoaded, setLabelsLoaded] = useState(false);
   const [showPicker, setShowPicker] = useState(false);
   const [search, setSearch] = useState("");
   const [busy, setBusy] = useState(false);
@@ -72,27 +65,35 @@ export function LabelsPanel({
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
 
-  // Sync enrichment data into local state
-  useEffect(() => {
-    if (data?.labels) {
-      setCurrentLabels(data.labels);
-    }
-  }, [data]);
-
-  // Fetch all labels for the picker
+  // Fetch all labels and resolve current email's labels directly
+  // (bypasses sender-scoped enrichment cache which would serve wrong labels)
   useEffect(() => {
     const accountId = email.accountId || "default";
+    setLabelsLoaded(false);
     window.api.labels
       .list(accountId)
       .then((result: { success: boolean; data?: LabelInfo[] }) => {
         if (result.success && result.data) {
           setAllLabels(result.data);
+
+          // Resolve this email's labelIds to full label info
+          const labelIds = email.labelIds ?? [];
+          const labelMap = new Map(result.data.map((l) => [l.id, l]));
+          const resolved: LabelInfo[] = [];
+          for (const id of labelIds) {
+            if (HIDDEN_SYSTEM.has(id)) continue;
+            const info = labelMap.get(id);
+            if (info) resolved.push(info);
+          }
+          resolved.sort((a, b) => a.name.localeCompare(b.name));
+          setCurrentLabels(resolved);
         }
+        setLabelsLoaded(true);
       })
       .catch(() => {
-        // Labels list failed — picker will show empty, which is safe
+        setLabelsLoaded(true);
       });
-  }, [email.accountId]);
+  }, [email.id, email.accountId, email.labelIds]);
 
   // Focus input when picker opens
   useEffect(() => {
@@ -170,7 +171,7 @@ export function LabelsPanel({
 
   return (
     <div className="p-4">
-      {isLoading && (
+      {!labelsLoaded && (
         <div className="flex items-center space-x-2 text-gray-500 dark:text-gray-400 py-4">
           <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle
@@ -191,7 +192,7 @@ export function LabelsPanel({
         </div>
       )}
 
-      {!isLoading && (
+      {labelsLoaded && (
         <>
           {/* Current labels as removable chips */}
           <div className="flex flex-wrap gap-1.5 mb-2">

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -92,6 +92,18 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
     }
   }, [isLabelPickerOpen, labelsLoaded, closeLabelPicker]);
 
+  // Stable thread label IDs — only recompute when the actual IDs change, not on
+  // every threadEmails array reference change (which triggers on each render).
+  const threadLabelKey = useMemo(() => {
+    const ids = new Set<string>();
+    for (const e of [email, ...threadEmails]) {
+      for (const id of e.labelIds ?? []) {
+        ids.add(id);
+      }
+    }
+    return [...ids].sort().join(",");
+  }, [email, threadEmails]);
+
   // Fetch all labels and resolve current email's labels directly
   // (bypasses sender-scoped enrichment cache which would serve wrong labels)
   useEffect(() => {
@@ -103,14 +115,7 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
         if (result.success && result.data) {
           setAllLabels(result.data);
 
-          // Aggregate labelIds across all emails in the thread (Gmail labels are thread-level)
-          const allThreadLabelIds = new Set<string>();
-          for (const e of [email, ...threadEmails]) {
-            for (const id of e.labelIds ?? []) {
-              allThreadLabelIds.add(id);
-            }
-          }
-          const labelIds = [...allThreadLabelIds];
+          const labelIds = threadLabelKey.split(",").filter(Boolean);
           const labelMap = new Map(result.data.map((l) => [l.id, l]));
           const resolved: LabelInfo[] = [];
           for (const id of labelIds) {
@@ -126,7 +131,7 @@ export function LabelsPanel({ email, threadEmails }: LabelsPanelProps): React.Re
       .catch(() => {
         setLabelsLoaded(true);
       });
-  }, [email.id, email.accountId, email.labelIds, threadEmails]);
+  }, [email.id, email.accountId, threadLabelKey]);
 
   // Focus input when picker opens
   useEffect(() => {

--- a/src/renderer/extensions/bundled/LabelsPanel.tsx
+++ b/src/renderer/extensions/bundled/LabelsPanel.tsx
@@ -47,6 +47,23 @@ declare global {
   }
 }
 
+// System labels the UI already shows via other means — filter from picker and display
+const HIDDEN_SYSTEM = new Set([
+  "INBOX",
+  "UNREAD",
+  "SENT",
+  "DRAFT",
+  "SPAM",
+  "TRASH",
+  "IMPORTANT",
+  "STARRED",
+  "CATEGORY_PERSONAL",
+  "CATEGORY_SOCIAL",
+  "CATEGORY_UPDATES",
+  "CATEGORY_FORUMS",
+  "CATEGORY_PROMOTIONS",
+]);
+
 export function LabelsPanel({
   email,
   enrichment,
@@ -61,7 +78,6 @@ export function LabelsPanel({
   const [highlightIndex, setHighlightIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
 
   // Sync enrichment data into local state
   useEffect(() => {
@@ -110,12 +126,15 @@ export function LabelsPanel({
       const accountId = email.accountId || "default";
       const threadId = email.threadId;
       setBusy(true);
-      // Gmail labels are thread-level — remove from entire thread
-      const result = await window.api.labels.modifyThread(accountId, threadId, [], [labelId]);
-      if (result.success) {
-        setCurrentLabels((prev) => prev.filter((l) => l.id !== labelId));
+      try {
+        // Gmail labels are thread-level — remove from entire thread
+        const result = await window.api.labels.modifyThread(accountId, threadId, [], [labelId]);
+        if (result.success) {
+          setCurrentLabels((prev) => prev.filter((l) => l.id !== labelId));
+        }
+      } finally {
+        setBusy(false);
       }
-      setBusy(false);
     },
     [email.threadId, email.accountId],
   );
@@ -125,37 +144,23 @@ export function LabelsPanel({
       const accountId = email.accountId || "default";
       const threadId = email.threadId;
       setBusy(true);
-      // Gmail labels are thread-level — add to entire thread
-      const result = await window.api.labels.modifyThread(accountId, threadId, [label.id], []);
-      if (result.success) {
-        setCurrentLabels((prev) => {
-          if (prev.some((l) => l.id === label.id)) return prev;
-          return [...prev, label].sort((a, b) => a.name.localeCompare(b.name));
-        });
+      try {
+        // Gmail labels are thread-level — add to entire thread
+        const result = await window.api.labels.modifyThread(accountId, threadId, [label.id], []);
+        if (result.success) {
+          setCurrentLabels((prev) => {
+            if (prev.some((l) => l.id === label.id)) return prev;
+            return [...prev, label].sort((a, b) => a.name.localeCompare(b.name));
+          });
+        }
+        setShowPicker(false);
+        setSearch("");
+      } finally {
+        setBusy(false);
       }
-      setShowPicker(false);
-      setSearch("");
-      setBusy(false);
     },
     [email.threadId, email.accountId],
   );
-
-  // Labels available to add (not already applied, not system, matches search)
-  const HIDDEN_SYSTEM = new Set([
-    "INBOX",
-    "UNREAD",
-    "SENT",
-    "DRAFT",
-    "SPAM",
-    "TRASH",
-    "IMPORTANT",
-    "STARRED",
-    "CATEGORY_PERSONAL",
-    "CATEGORY_SOCIAL",
-    "CATEGORY_UPDATES",
-    "CATEGORY_FORUMS",
-    "CATEGORY_PROMOTIONS",
-  ]);
 
   // Reset highlight when search changes
   useEffect(() => {
@@ -271,7 +276,7 @@ export function LabelsPanel({
                     }
                   }}
                 />
-                <div className="max-h-48 overflow-y-auto" ref={listRef}>
+                <div className="max-h-48 overflow-y-auto">
                   {availableLabels.length === 0 && (
                     <div className="px-3 py-2 text-xs text-gray-400">No matching labels</div>
                   )}

--- a/src/renderer/extensions/bundled/index.ts
+++ b/src/renderer/extensions/bundled/index.ts
@@ -7,6 +7,7 @@
 import { registerPanelComponent } from "../ExtensionPanelSlot";
 import { SenderProfilePanel } from "./SenderProfilePanel";
 import { CalendarPanel } from "../../../extensions/mail-ext-calendar/src/renderer/CalendarPanel";
+import { LabelsPanel } from "./LabelsPanel";
 import { registerPrivateExtensions } from "../private-extensions";
 import { loadInstalledExtensionPanels } from "../installed-extensions";
 
@@ -20,6 +21,9 @@ export function registerBundledExtensions(): void {
 
   // Register calendar extension's day-view panel
   registerPanelComponent("calendar", "day-view", CalendarPanel);
+
+  // Register labels extension's panel
+  registerPanelComponent("labels", "email-labels", LabelsPanel);
 
   // Register private extension panels (loaded from extensions-private/)
   registerPrivateExtensions();

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -1034,6 +1034,15 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           }
           break;
 
+        // Labels — open label picker (Gmail's native shortcut)
+        case "l":
+          if (selectedEmailId) {
+            e.preventDefault();
+            state.setSidebarTab("sender");
+            state.openLabelPicker();
+          }
+          break;
+
         // Search (exclude Shift+/ which is "?" for help)
         case "/":
           if (!e.shiftKey) {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -218,6 +218,9 @@ interface AppState {
   // Command palette state
   isCommandPaletteOpen: boolean;
 
+  // Label picker state (toggled by 'l' hotkey)
+  isLabelPickerOpen: boolean;
+
   // Search state
   isSearchOpen: boolean;
   activeSearchQuery: string | null;
@@ -371,6 +374,10 @@ interface AppState {
   // Command palette actions
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
+
+  // Label picker actions
+  openLabelPicker: () => void;
+  closeLabelPicker: () => void;
 
   // Find-in-page
   isFindBarOpen: boolean;
@@ -571,6 +578,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Command palette state
   isCommandPaletteOpen: false,
+
+  // Label picker state
+  isLabelPickerOpen: false,
 
   // Find-in-page state
   isFindBarOpen: false,
@@ -901,6 +911,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   // Command palette actions
   openCommandPalette: () => set({ isCommandPaletteOpen: true }),
   closeCommandPalette: () => set({ isCommandPaletteOpen: false }),
+
+  // Label picker actions
+  openLabelPicker: () => set({ isLabelPickerOpen: true }),
+  closeLabelPicker: () => set({ isLabelPickerOpen: false }),
 
   // Find-in-page actions
   openFindBar: () => set({ isFindBarOpen: true }),

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -791,7 +791,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         selectedEmailId: nextEmailId,
       };
     }),
-  setSelectedEmailId: (id) => set({ selectedEmailId: id }),
+  setSelectedEmailId: (id) => set({ selectedEmailId: id, isLabelPickerOpen: false }),
   setSelectedThreadId: (id) => set({ selectedThreadId: id }),
   setFocusedThreadEmailId: (id) => set({ focusedThreadEmailId: id }),
   toggleThreadExpanded: (threadId) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,6 +11,14 @@ export const AttachmentMetaSchema = z.object({
 
 export type AttachmentMeta = z.infer<typeof AttachmentMetaSchema>;
 
+// Gmail label metadata
+export interface LabelInfo {
+  id: string;
+  name: string;
+  type: string;
+  color?: { textColor: string; backgroundColor: string };
+}
+
 // Email from Gmail API
 export const EmailSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary

Adds Gmail label management to Exo. Users can view, add, remove, and create labels directly from the sidebar, with a keyboard shortcut (`l`) matching Gmail's native behavior.

Addresses #76.

## Features

- **View labels** — sidebar panel in the Sender tab shows all labels on the current thread (aggregated across all messages, since Gmail labels are thread-level). System labels (INBOX, SENT, star variants, etc.) are filtered out.
- **Add labels** — type-ahead picker with arrow key navigation and fuzzy search. Supports 150+ labels efficiently.
- **Remove labels** — click the x on any label chip. Removes from the entire thread and syncs to Gmail instantly.
- **Create labels** — when the search has no match, "Create [name]" option appears. Creates the label in Gmail and applies it to the thread in one step. Shows inline error if creation fails.
- **Keyboard shortcut** — press `l` with an email selected to open the label picker. Switches to Sender tab automatically.
- **Label colors** — Gmail label colors are displayed on the chips.

## Architecture

The label panel registers as a bundled extension with `scope: "sender"` for Sender tab placement, but bypasses the sender-scoped enrichment cache (which would serve wrong labels across emails from the same sender). The LabelsPanel resolves labels directly from `email.labelIds` via `window.api.labels`, managing its own data lifecycle.

**New files:**
- `src/extensions/mail-ext-labels/` — extension manifest, entry point, enrichment provider (no-op, needed for panel registration)
- `src/main/ipc/labels.ipc.ts` — IPC handlers for list, create, modify-message, modify-thread
- `src/renderer/extensions/bundled/LabelsPanel.tsx` — React component with type-ahead picker

**Core additions:**
- `GmailClient`: `listLabels()`, `createLabel()`, `modifyMessageLabels()`, `modifyThreadLabels()`
- Preload: `window.api.labels` (list, create, modifyMessage, modifyThread)
- Store: `isLabelPickerOpen` state for `l` hotkey integration
- Shared types: `LabelInfo` interface

## QA + Review

- 3 rounds of gstack `/qa` + `/review`
- 15 commits (initial feature + QA fixes + review fixes)
- All checks green: TypeScript, ESLint, Prettier, 1333 unit tests, production build
- PR Quality Score: 9.5/10

Key issues caught and fixed during review:
- Sender-scoped enrichment cache serving wrong labels → bypassed with direct resolution
- Sequential Gmail API calls on thread modify → parallelized with Promise.all
- Label picker signal persisting across email changes → cleared on selection change
- Store email.labelIds not updated after mutation → synced for all thread emails
- Label flickering on render → stabilized with useMemo key

## Testing

1. Click any email — labels appear in the Sender tab sidebar
2. Click x on a label — removes from thread, syncs to Gmail
3. Click "+ Add label" or press `l` — type-ahead picker opens
4. Type a name, arrow-key to select, Enter to apply
5. Type a name with no match, Enter to create and apply
6. Navigate between emails — labels update per-email correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
