### PR TITLE
fix: update repo references from mail-app to exo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 <div align="center">
 
-<img width="1200" alt="Exo" src="docs/images/readme-hero.png" />
-
 ### Exo: Claude Code for your Inbox
 
-[![GitHub stars](https://img.shields.io/github/stars/ankitvgupta/mail-app?style=flat&logo=github)](https://github.com/ankitvgupta/mail-app/stargazers)
-[![GitHub release](https://img.shields.io/github/v/release/ankitvgupta/mail-app?style=flat&logo=github)](https://github.com/ankitvgupta/mail-app/releases)
-[![License](https://img.shields.io/github/license/ankitvgupta/mail-app?style=flat)](LICENSE)
-[![Download DMG](https://img.shields.io/github/v/release/ankitvgupta/mail-app?label=Download%20.dmg&logo=apple&style=flat-square)](https://github.com/ankitvgupta/mail-app/releases/latest)
+[![GitHub stars](https://img.shields.io/github/stars/ankitvgupta/exo?style=flat&logo=github)](https://github.com/ankitvgupta/exo/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/ankitvgupta/exo?style=flat&logo=github)](https://github.com/ankitvgupta/exo/releases)
+[![License](https://img.shields.io/github/license/ankitvgupta/exo?style=flat)](LICENSE)
+[![Download DMG](https://img.shields.io/github/v/release/ankitvgupta/exo?label=Download%20.dmg&logo=apple&style=flat-square)](https://github.com/ankitvgupta/exo/releases/latest)
 
 <br />
 
@@ -16,17 +14,18 @@ Built with Electron, React, TypeScript, and Tailwind CSS.
 
 <br />
 
-[**Download for macOS**](https://github.com/ankitvgupta/mail-app/releases/latest) &nbsp;&bull;&nbsp; [Documentation](https://exo.email) &nbsp;&bull;&nbsp; [Changelog](https://github.com/ankitvgupta/mail-app/releases) 
+[**Download for macOS**](https://github.com/ankitvgupta/exo/releases/latest) &nbsp;&bull;&nbsp; [Documentation](https://exo.email) &nbsp;&bull;&nbsp; [Changelog](https://github.com/ankitvgupta/exo/releases)
 
 <br />
 
+<img width="1200" alt="Exo" src="docs/images/readme-hero.png" />
 
 </div>
 
 
 # Exo
 
-[![Download DMG](https://img.shields.io/github/v/release/ankitvgupta/mail-app?label=Download%20.dmg&logo=apple&style=flat-square)](https://github.com/ankitvgupta/mail-app/releases/latest)
+[![Download DMG](https://img.shields.io/github/v/release/ankitvgupta/exo?label=Download%20.dmg&logo=apple&style=flat-square)](https://github.com/ankitvgupta/exo/releases/latest)
 
 An open source, AI-native desktop email client. Built with Electron, React, TypeScript, and Tailwind CSS.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Automated email draft generator using Claude AI and Gmail",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ankitvgupta/mail-app.git"
+    "url": "https://github.com/ankitvgupta/exo.git"
   },
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/main/demo/fake-inbox.ts
+++ b/src/main/demo/fake-inbox.ts
@@ -237,11 +237,11 @@ Diana`,
   {
     id: "demo-006",
     threadId: "thread-github-ci",
-    subject: "[ankitvgupta/mail-app] CI workflow failed on main",
+    subject: "[ankitvgupta/exo] CI workflow failed on main",
     from: "GitHub <noreply@github.com>",
     to: "me@example.com",
     date: new Date(now - 4 * hour).toISOString(),
-    body: `The workflow "Build & Test" in repository ankitvgupta/mail-app has failed.
+    body: `The workflow "Build & Test" in repository ankitvgupta/exo has failed.
 
 Commit: 4d96857a3f
 Message: Replace all mail-client references with mail-app (#5)
@@ -251,11 +251,11 @@ Failed jobs:
 - test-e2e (ubuntu-latest)
   Error: better-sqlite3 ABI mismatch — rebuilt for system Node but running under Electron
 
-View the workflow run: https://github.com/ankitvgupta/mail-app/actions/runs/14738291
+View the workflow run: https://github.com/ankitvgupta/exo/actions/runs/14738291
 
 ---
 You are receiving this because you are subscribed to this repository.`,
-    snippet: "The workflow Build & Test in repository ankitvgupta/mail-app has failed...",
+    snippet: "The workflow Build & Test in repository ankitvgupta/exo has failed...",
   },
 
   // Newsletter (skip)

--- a/src/shared/prompt-safety.ts
+++ b/src/shared/prompt-safety.ts
@@ -3,7 +3,7 @@
  *
  * Attacker-controlled fields (from, to, subject, body) must be wrapped in
  * clearly-delimited tags so the model treats them as data, not instructions.
- * See: https://github.com/ankitvgupta/mail-app/issues/47
+ * See: https://github.com/ankitvgupta/exo/issues/47
  */
 
 export const UNTRUSTED_DATA_INSTRUCTION =


### PR DESCRIPTION
## Summary
- Updated all `ankitvgupta/mail-app` references to `ankitvgupta/exo` across the codebase
- Fixed shields.io badge URLs and GitHub links in README.md
- Updated `package.json` repository URL
- Updated issue reference in `src/shared/prompt-safety.ts`
- Updated demo GitHub notification data in `src/main/demo/fake-inbox.ts`
- Moved the hero image below the "Download for macOS / Documentation / Changelog" line in the README header

## Changes
- `README.md` — 8 URL updates + hero image repositioned
- `package.json` — repository URL
- `src/shared/prompt-safety.ts` — issue link in comment
- `src/main/demo/fake-inbox.ts` — 4 references in fake GitHub notification

## Test plan
- [ ] Verify README renders correctly on GitHub (badges load, hero image displays below download links)
- [ ] Verify shields.io badges resolve to the new repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)