### PR TITLE
fix: resolve flaky undo-send test strict mode violation

### DIFF
--- a/tests/e2e/undo-send.spec.ts
+++ b/tests/e2e/undo-send.spec.ts
@@ -104,7 +104,7 @@ test.describe("Undo Send - Inline Reply", () => {
   });
 
   test("app loads with inbox emails", async () => {
-    await expect(page.locator("text=Exo")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Exo" })).toBeVisible();
     await expect(page.locator("text=Inbox").first()).toBeVisible();
     await expect(page.locator("button").filter({ hasText: "Garry Tan" }).first()).toBeVisible({
       timeout: 5000,


### PR DESCRIPTION
## Summary
- Fixed `tests/e2e/undo-send.spec.ts` test that was failing in CI due to a Playwright strict mode violation
- The `text=Exo` locator matched 3 elements: the app heading plus demo emails containing "exo" in GitHub notification content (from the repo rename to `exo`)
- Changed to `getByRole('heading', { name: 'Exo' })` which uniquely targets the app title
- This also resolves the "Worker teardown timeout" error which was a secondary effect of the test failing all retries

## Changes
- `tests/e2e/undo-send.spec.ts`: Replace `page.locator("text=Exo")` with `page.getByRole("heading", { name: "Exo" })`

## Test plan
- [ ] CI passes with no flaky undo-send test failures
- [ ] Undo-send e2e tests pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)