### PR TITLE
Strip HTML from email bodies before sending to agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1678,9 +1678,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -6530,9 +6530,9 @@
       "optional": true
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8485,9 +8485,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -9283,9 +9283,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -10913,9 +10913,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -12032,9 +12032,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14702,9 +14702,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/src/main/agents/tools/analysis-tools.ts
+++ b/src/main/agents/tools/analysis-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { type ToolDefinition, ToolRiskLevel } from "./types";
 import type { DashboardEmail } from "../../../shared/types";
-import { stripHtmlForSearch } from "../../db";
+import { htmlToPlainText } from "../../db";
 
 const analyzeEmail: ToolDefinition<{ emailId: string }> = {
   name: "analyze_email",
@@ -33,7 +33,7 @@ const analyzeEmail: ToolDefinition<{ emailId: string }> = {
       from: email.from,
       to: email.to,
       date: email.date,
-      body: email.body ? stripHtmlForSearch(email.body) : undefined,
+      body: email.body ? htmlToPlainText(email.body) : undefined,
       message: "No cached analysis found. The email content is provided for inline analysis.",
     };
   },

--- a/src/main/agents/tools/analysis-tools.ts
+++ b/src/main/agents/tools/analysis-tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { type ToolDefinition, ToolRiskLevel } from "./types";
 import type { DashboardEmail } from "../../../shared/types";
+import { stripHtmlForSearch } from "../../db";
 
 const analyzeEmail: ToolDefinition<{ emailId: string }> = {
   name: "analyze_email",
@@ -32,7 +33,7 @@ const analyzeEmail: ToolDefinition<{ emailId: string }> = {
       from: email.from,
       to: email.to,
       date: email.date,
-      body: email.body,
+      body: email.body ? stripHtmlForSearch(email.body) : undefined,
       message: "No cached analysis found. The email content is provided for inline analysis.",
     };
   },

--- a/src/main/agents/tools/email-tools.ts
+++ b/src/main/agents/tools/email-tools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { type ToolDefinition, ToolRiskLevel } from "./types";
 import type { DashboardEmail } from "../../../shared/types";
 import { draftBodyToHtml } from "../../../shared/draft-utils";
-import { stripHtmlForSearch } from "../../db";
+import { htmlToPlainText } from "../../db";
 
 const readEmail: ToolDefinition<{ emailId: string }> = {
   name: "read_email",
@@ -18,11 +18,8 @@ const readEmail: ToolDefinition<{ emailId: string }> = {
     if (!email) {
       throw new Error(`Email not found: ${input.emailId}`);
     }
-    // Strip HTML to plain text — agents don't need markup and it wastes tokens
-    if (email.body) {
-      email.body = stripHtmlForSearch(email.body);
-    }
-    return email;
+    // Return with plain text body — agents don't need HTML markup and it wastes tokens
+    return { ...email, body: email.body ? htmlToPlainText(email.body) : email.body };
   },
 };
 
@@ -108,13 +105,8 @@ const readThread: ToolDefinition<{ threadId: string; accountId?: string }> = {
   }),
   async execute(input, ctx) {
     const emails = await ctx.db("getEmailsByThread", input.threadId, input.accountId);
-    // Strip HTML to plain text — agents don't need markup and it wastes tokens
-    for (const email of emails) {
-      if (email.body) {
-        email.body = stripHtmlForSearch(email.body);
-      }
-    }
-    return emails;
+    // Return with plain text bodies — agents don't need HTML markup and it wastes tokens
+    return emails.map((e) => ({ ...e, body: e.body ? htmlToPlainText(e.body) : e.body }));
   },
 };
 
@@ -520,7 +512,7 @@ const searchGmail: ToolDefinition<{ accountId: string; query: string; maxResults
           from: email.from,
           to: email.to,
           date: email.date,
-          snippet: email.snippet || (email.body ? stripHtmlForSearch(email.body).slice(0, 200) : ""),
+          snippet: email.snippet || (email.body ? htmlToPlainText(email.body).slice(0, 200) : ""),
         });
       }
     }

--- a/src/main/agents/tools/email-tools.ts
+++ b/src/main/agents/tools/email-tools.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { type ToolDefinition, ToolRiskLevel } from "./types";
 import type { DashboardEmail } from "../../../shared/types";
 import { draftBodyToHtml } from "../../../shared/draft-utils";
+import { stripHtmlForSearch } from "../../db";
 
 const readEmail: ToolDefinition<{ emailId: string }> = {
   name: "read_email",
@@ -16,6 +17,10 @@ const readEmail: ToolDefinition<{ emailId: string }> = {
     const email = await ctx.db("getEmail", input.emailId);
     if (!email) {
       throw new Error(`Email not found: ${input.emailId}`);
+    }
+    // Strip HTML to plain text — agents don't need markup and it wastes tokens
+    if (email.body) {
+      email.body = stripHtmlForSearch(email.body);
     }
     return email;
   },
@@ -103,6 +108,12 @@ const readThread: ToolDefinition<{ threadId: string; accountId?: string }> = {
   }),
   async execute(input, ctx) {
     const emails = await ctx.db("getEmailsByThread", input.threadId, input.accountId);
+    // Strip HTML to plain text — agents don't need markup and it wastes tokens
+    for (const email of emails) {
+      if (email.body) {
+        email.body = stripHtmlForSearch(email.body);
+      }
+    }
     return emails;
   },
 };
@@ -509,7 +520,7 @@ const searchGmail: ToolDefinition<{ accountId: string; query: string; maxResults
           from: email.from,
           to: email.to,
           date: email.date,
-          snippet: email.snippet || email.body?.slice(0, 200) || "",
+          snippet: email.snippet || (email.body ? stripHtmlForSearch(email.body).slice(0, 200) : ""),
         });
       }
     }

--- a/src/main/agents/tools/email-tools.ts
+++ b/src/main/agents/tools/email-tools.ts
@@ -14,7 +14,7 @@ const readEmail: ToolDefinition<{ emailId: string }> = {
     emailId: z.string().describe("The email ID to read"),
   }),
   async execute(input, ctx) {
-    const email = await ctx.db("getEmail", input.emailId);
+    const email = (await ctx.db("getEmail", input.emailId)) as DashboardEmail | null;
     if (!email) {
       throw new Error(`Email not found: ${input.emailId}`);
     }
@@ -104,7 +104,11 @@ const readThread: ToolDefinition<{ threadId: string; accountId?: string }> = {
     accountId: z.string().optional().describe("Account ID to filter by (optional)"),
   }),
   async execute(input, ctx) {
-    const emails = await ctx.db("getEmailsByThread", input.threadId, input.accountId);
+    const emails = (await ctx.db(
+      "getEmailsByThread",
+      input.threadId,
+      input.accountId,
+    )) as DashboardEmail[];
     // Return with plain text bodies — agents don't need HTML markup and it wastes tokens
     return emails.map((e) => ({ ...e, body: e.body ? htmlToPlainText(e.body) : e.body }));
   },

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -527,6 +527,42 @@ export function stripHtmlForSearch(html: string): string {
     .trim();
 }
 
+/** Decode HTML entities including numeric (&#NNN; / &#xHH;) for agent-facing text. */
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&[#\w]+;/gi, " ");
+}
+
+/**
+ * Convert HTML to plain text for AI agent consumption.
+ * Preserves paragraph breaks and decodes all HTML entities (including numeric).
+ * Use this instead of stripHtmlForSearch when the text will be read by an LLM.
+ */
+export function htmlToPlainText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "") // remove style blocks
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "") // remove script blocks
+      .replace(/<br\s*\/?>/gi, "\n") // <br> → newline
+      .replace(/<\/(?:p|div|h[1-6]|li|tr|blockquote)>/gi, "\n") // block-close → newline
+      .replace(/<(?:hr)\s*\/?>/gi, "\n---\n") // <hr> → separator
+      .replace(/<[^>]+>/g, "") // strip remaining tags
+  )
+    .replace(/[ \t]+/g, " ") // collapse horizontal whitespace only
+    .replace(/\n /g, "\n") // trim leading space after newlines
+    .replace(/ \n/g, "\n") // trim trailing space before newlines
+    .replace(/\n{3,}/g, "\n\n") // collapse 3+ newlines to 2
+    .trim();
+}
+
 /**
  * Escape FTS5 special characters so user input doesn't cause syntax errors.
  * Wraps each non-operator token in double quotes to treat it as a literal phrase.

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -536,8 +536,14 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&gt;/gi, ">")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
+      const cp = parseInt(hex, 16);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
+    })
+    .replace(/&#(\d+);/g, (_, dec) => {
+      const cp = parseInt(dec, 10);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
+    })
     .replace(/&[#\w]+;/gi, " ");
 }
 

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -554,7 +554,7 @@ export function htmlToPlainText(html: string): string {
       .replace(/<br\s*\/?>/gi, "\n") // <br> → newline
       .replace(/<\/(?:p|div|h[1-6]|li|tr|blockquote)>/gi, "\n") // block-close → newline
       .replace(/<(?:hr)\s*\/?>/gi, "\n---\n") // <hr> → separator
-      .replace(/<[^>]+>/g, "") // strip remaining tags
+      .replace(/<[^>]+>/g, ""), // strip remaining tags
   )
     .replace(/[ \t]+/g, " ") // collapse horizontal whitespace only
     .replace(/\n /g, "\n") // trim leading space after newlines

--- a/tests/unit/html-to-plaintext.spec.ts
+++ b/tests/unit/html-to-plaintext.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Unit tests for htmlToPlainText — the HTML-to-text converter used when
+ * sending email bodies to AI agents. Preserves paragraph structure and
+ * decodes numeric HTML entities so text is usable for LLM comprehension.
+ *
+ * Function is copied from src/main/db/index.ts because that file imports
+ * Electron-only modules (same pattern as search.spec.ts).
+ */
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
+      const cp = parseInt(hex, 16);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
+    })
+    .replace(/&#(\d+);/g, (_, dec) => {
+      const cp = parseInt(dec, 10);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
+    })
+    .replace(/&[#\w]+;/gi, " ");
+}
+
+function htmlToPlainText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/(?:p|div|h[1-6]|li|tr|blockquote)>/gi, "\n")
+      .replace(/<(?:hr)\s*\/?>/gi, "\n---\n")
+      .replace(/<[^>]+>/g, ""),
+  )
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n /g, "\n")
+    .replace(/ \n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+test.describe("htmlToPlainText", () => {
+  test.describe("tag stripping", () => {
+    test("strips inline tags", () => {
+      expect(htmlToPlainText("<p>Hello <strong>world</strong></p>")).toBe("Hello world");
+    });
+
+    test("removes style blocks entirely", () => {
+      expect(htmlToPlainText("<style>.x { color: red; }</style><p>Hello</p>")).toBe("Hello");
+    });
+
+    test("removes script blocks entirely", () => {
+      expect(htmlToPlainText("<script>alert('hi')</script><p>Hello</p>")).toBe("Hello");
+    });
+
+    test("strips attributes along with tags", () => {
+      expect(htmlToPlainText('<a href="https://example.com" class="foo">link</a>')).toBe("link");
+    });
+  });
+
+  test.describe("structure preservation", () => {
+    test("<br> becomes newline", () => {
+      expect(htmlToPlainText("line 1<br>line 2")).toBe("line 1\nline 2");
+    });
+
+    test("<br/> and <br /> both become newline", () => {
+      expect(htmlToPlainText("a<br/>b<br />c")).toBe("a\nb\nc");
+    });
+
+    test("paragraphs separated by newline", () => {
+      expect(htmlToPlainText("<p>one</p><p>two</p>")).toBe("one\ntwo");
+    });
+
+    test("list items on separate lines", () => {
+      expect(htmlToPlainText("<ul><li>a</li><li>b</li><li>c</li></ul>")).toBe("a\nb\nc");
+    });
+
+    test("headings on their own line", () => {
+      expect(htmlToPlainText("<h1>Title</h1><p>body</p>")).toBe("Title\nbody");
+    });
+
+    test("blockquote separated", () => {
+      expect(htmlToPlainText("<p>Reply:</p><blockquote>original</blockquote><p>more</p>")).toBe(
+        "Reply:\noriginal\nmore",
+      );
+    });
+
+    test("<hr> becomes separator", () => {
+      expect(htmlToPlainText("<p>above</p><hr><p>below</p>")).toBe("above\n\n---\nbelow");
+    });
+
+    test("collapses 3+ consecutive newlines to 2", () => {
+      expect(htmlToPlainText("<p>a</p><p></p><p></p><p>b</p>")).toBe("a\n\nb");
+    });
+
+    test("preserves single newlines inside paragraphs", () => {
+      // <br> inside <p> should keep the newline but not double it
+      expect(htmlToPlainText("<p>line 1<br>line 2</p>")).toBe("line 1\nline 2");
+    });
+  });
+
+  test.describe("entity decoding", () => {
+    test("decodes common named entities", () => {
+      expect(htmlToPlainText("&amp; &lt; &gt; &quot; &#39;")).toBe("& < > \" '");
+    });
+
+    test("decodes nbsp as space", () => {
+      expect(htmlToPlainText("hello&nbsp;world")).toBe("hello world");
+    });
+
+    test("decodes numeric decimal entity for right single quote", () => {
+      // &#8217; is the right single quote — common in contractions like "don't"
+      // This is the exact bug the review caught: don't → don t when not decoded
+      expect(htmlToPlainText("don&#8217;t")).toBe("don\u2019t");
+    });
+
+    test("decodes numeric hex entity", () => {
+      // &#x2014; is em dash
+      expect(htmlToPlainText("a&#x2014;b")).toBe("a\u2014b");
+    });
+
+    test("decodes numeric entities for emoji", () => {
+      // &#128512; is 😀
+      expect(htmlToPlainText("hi &#128512;")).toBe("hi \u{1F600}");
+    });
+
+    test("out-of-range hex entity returns replacement char (no RangeError)", () => {
+      // This was the Devin fix — without bounds check, throws RangeError
+      expect(htmlToPlainText("&#xFFFFFFFF;")).toBe("\uFFFD");
+    });
+
+    test("out-of-range decimal entity returns replacement char (no RangeError)", () => {
+      expect(htmlToPlainText("&#99999999;")).toBe("\uFFFD");
+    });
+
+    test("unknown entity becomes space", () => {
+      expect(htmlToPlainText("a&unknownthing;b")).toBe("a b");
+    });
+  });
+
+  test.describe("whitespace handling", () => {
+    test("collapses horizontal whitespace but keeps newlines", () => {
+      expect(htmlToPlainText("<p>a    b</p><p>c</p>")).toBe("a b\nc");
+    });
+
+    test("trims leading and trailing whitespace", () => {
+      expect(htmlToPlainText("  <p>hello</p>  ")).toBe("hello");
+    });
+
+    test("trims spaces adjacent to newlines", () => {
+      expect(htmlToPlainText("<p>a </p><p> b</p>")).toBe("a\nb");
+    });
+  });
+
+  test.describe("realistic email cases", () => {
+    test("Gmail-style reply with quoted content preserves structure", () => {
+      const html = `<div dir="ltr">Hi Ankit,<div><br></div><div>Looking forward to it.</div></div>
+<br>
+<div class="gmail_quote"><blockquote>On Wed, Ankit wrote:<br>Can you make it?</blockquote></div>`;
+      const result = htmlToPlainText(html);
+      expect(result).toContain("Hi Ankit,");
+      expect(result).toContain("Looking forward to it.");
+      expect(result).toContain("On Wed, Ankit wrote:");
+      expect(result).toContain("Can you make it?");
+      expect(result).not.toContain("<div");
+      expect(result).not.toContain("gmail_quote");
+      // Structure preserved: paragraphs separated by newlines
+      expect(result.split("\n").length).toBeGreaterThan(2);
+    });
+
+    test("contractions survive entity decoding", () => {
+      // This is the specific comprehension bug: without numeric decoding,
+      // "don't" becomes "don t" and confuses the agent
+      const html = "<p>We don&#8217;t have a meeting, won&#8217;t confirm.</p>";
+      const result = htmlToPlainText(html);
+      expect(result).toContain("don\u2019t");
+      expect(result).toContain("won\u2019t");
+      expect(result).not.toContain("don t");
+    });
+
+    test("signature block flattens cleanly", () => {
+      const html = `<p>Thanks,</p>
+<div><span>Scott Stephenson</span><br><span>CEO</span><br><a href="mailto:s@ex.com">s@ex.com</a></div>`;
+      const result = htmlToPlainText(html);
+      expect(result).toContain("Thanks,");
+      expect(result).toContain("Scott Stephenson");
+      expect(result).toContain("CEO");
+      expect(result).toContain("s@ex.com");
+      expect(result).not.toContain("mailto:");
+      expect(result).not.toContain("<span");
+    });
+
+    test("token reduction vs raw HTML", () => {
+      // Demonstrates the core value: stripped text is substantially shorter
+      const html = `<div dir="ltr" style="font-family: Arial; color: #333;">
+        <p style="margin: 0 0 10px 0;"><span style="font-weight: bold;">Hi there,</span></p>
+        <p style="margin: 0 0 10px 0;">This is a test.</p>
+      </div>`;
+      const plain = htmlToPlainText(html);
+      expect(plain.length).toBeLessThan(html.length / 2);
+      expect(plain).toContain("Hi there,");
+      expect(plain).toContain("This is a test.");
+    });
+  });
+
+  test.describe("edge cases", () => {
+    test("empty string returns empty string", () => {
+      expect(htmlToPlainText("")).toBe("");
+    });
+
+    test("plain text with no HTML passes through", () => {
+      expect(htmlToPlainText("just plain text")).toBe("just plain text");
+    });
+
+    test("only tags returns empty string", () => {
+      expect(htmlToPlainText("<div></div><p></p><br>")).toBe("");
+    });
+
+    test("nested block tags produce correct structure", () => {
+      expect(htmlToPlainText("<div><div><p>deep</p></div></div>")).toBe("deep");
+    });
+
+    test("case-insensitive tag matching", () => {
+      // </P> → \n, <Br> → \n, so upper\n\nmixed (collapsed from 3+)
+      expect(htmlToPlainText("<P>upper</P><Br><DIV>mixed</DIV>")).toBe("upper\n\nmixed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Agent tools (`read_email`, `read_thread`, `analyze_email`, `search_gmail`) were passing raw HTML email bodies to AI agents (OpenClaw, private extensions), wasting tokens on markup, signatures, and nested quote formatting
- Now uses the existing `stripHtmlForSearch()` utility to convert HTML to plain text at the agent tool boundary
- The renderer still receives HTML for display; only agents see plain text

## Changes
- `src/main/agents/tools/email-tools.ts`: Strip HTML in `read_email`, `read_thread`, and `search_gmail` snippet fallback
- `src/main/agents/tools/analysis-tools.ts`: Strip HTML in `analyze_email` when returning email content for inline analysis

## Test plan
- [ ] Verify agents receive plain text email bodies (no HTML tags)
- [ ] Verify email display in the renderer still shows formatted HTML
- [ ] Verify `read_thread` strips HTML on all emails in the thread
- [ ] Type check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
