### PR TITLE
fix: strip signatures from learning flows

### DIFF
--- a/src/main/services/style-profiler.ts
+++ b/src/main/services/style-profiler.ts
@@ -52,10 +52,11 @@ function countWords(text: string): number {
 }
 
 export function extractEmailSignals(bodyText: string): EmailSignals {
+  const cleaned = stripPlainTextSignature(bodyText);
   return {
-    greeting: detectGreeting(bodyText),
-    signoff: detectSignoff(bodyText),
-    wordCount: countWords(bodyText),
+    greeting: detectGreeting(cleaned),
+    signoff: detectSignoff(cleaned),
+    wordCount: countWords(cleaned),
   };
 }
 
@@ -154,9 +155,20 @@ export function computeCorrespondentProfile(
 // Context builder
 // ============================================
 
+/** Strip the standard email signature delimiter (-- ) and everything after it */
+function stripPlainTextSignature(text: string): string {
+  // Match "-- " on its own line (standard sig delimiter) or "—" dash variants
+  // Also strip "Sent by Exo" / "Sent from Exo" lines that may appear without delimiter
+  const sigIndex = text.search(/\n-- ?\n/);
+  if (sigIndex !== -1) return text.slice(0, sigIndex).trim();
+  // Fallback: strip "Sent by Exo" branding line if present without delimiter
+  return text.replace(/\n*Sent (?:by|from) Exo\s*$/i, "").trim();
+}
+
 function truncateBody(bodyText: string, maxWords: number = 300): string {
-  const words = bodyText.split(/\s+/);
-  if (words.length <= maxWords) return bodyText;
+  const cleaned = stripPlainTextSignature(bodyText);
+  const words = cleaned.split(/\s+/);
+  if (words.length <= maxWords) return cleaned;
   return words.slice(0, maxWords).join(" ") + "...";
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -135,7 +135,7 @@ If the email requires a decision or action that I must take personally (like rev
 // Output format suffix appended automatically — never shown to the user
 export const DRAFT_FORMAT_SUFFIX = `
 
-Output ONLY the email body text - no subject line, no "Dear X" if not needed, no signature (I have one set up). Just the reply content.
+Output ONLY the email body text - no subject line, no "Dear X" if not needed, no signature (I have one set up). Just the reply content. Do NOT include any signature like "--Sent by Exo" or "Sent from Exo" — the app appends its own signature automatically.
 
 FORMATTING: Write plain text paragraphs separated by blank lines. Do NOT use HTML tags of any kind (<p>, <br>, <div>, <b>, <i>, <ul>, <ol>, etc.). For bold, wrap text in double asterisks like **bold text**. For italic, wrap text in single asterisks like *italic text*. For bullet lists, use lines starting with "- ". For numbered lists, use "1. ", "2. ", etc. The email client converts plain text structure to rich formatting automatically.`;
 

--- a/tests/unit/style-profiler.spec.ts
+++ b/tests/unit/style-profiler.spec.ts
@@ -39,11 +39,19 @@ function countWords(text: string): number {
   return text.split(/\s+/).filter((w) => w.length > 0).length;
 }
 
+/** Strip the standard email signature delimiter (-- ) and everything after it */
+function stripPlainTextSignature(text: string): string {
+  const sigIndex = text.search(/\n-- ?\n/);
+  if (sigIndex !== -1) return text.slice(0, sigIndex).trim();
+  return text.replace(/\n*Sent (?:by|from) Exo\s*$/i, "").trim();
+}
+
 function extractEmailSignals(bodyText: string): EmailSignals {
+  const cleaned = stripPlainTextSignature(bodyText);
   return {
-    greeting: detectGreeting(bodyText),
-    signoff: detectSignoff(bodyText),
-    wordCount: countWords(bodyText),
+    greeting: detectGreeting(cleaned),
+    signoff: detectSignoff(cleaned),
+    wordCount: countWords(cleaned),
   };
 }
 
@@ -177,5 +185,74 @@ Cheers`;
     expect(signals.greeting).toBe("hey");
     expect(signals.signoff).toBe("cheers");
     expect(signals.wordCount).toBeLessThan(20);
+  });
+});
+
+// ============================================================
+// Signature stripping
+// ============================================================
+
+test.describe("signature stripping", () => {
+  test("strips standard -- signature delimiter", () => {
+    const email = `Hey team,
+
+Here's the update.
+
+Best,
+John
+
+--
+Sent by Exo`;
+
+    const signals = extractEmailSignals(email);
+    expect(signals.signoff).toBe("best");
+    // "Sent by Exo" should not be counted in word count
+    expect(signals.wordCount).toBeLessThan(10);
+  });
+
+  test("strips 'Sent by Exo' without -- delimiter", () => {
+    const email = `Sounds good!
+
+Thanks
+Sent by Exo`;
+
+    const signals = extractEmailSignals(email);
+    expect(signals.signoff).toBe("thanks");
+    // "Sent by Exo" should be stripped
+    expect(signals.wordCount).toBe(3); // "Sounds good! Thanks"
+  });
+
+  test("strips 'Sent from Exo' variant", () => {
+    const email = `Got it, will do.
+Sent from Exo`;
+
+    const signals = extractEmailSignals(email);
+    expect(signals.wordCount).toBe(4); // "Got it, will do."
+  });
+
+  test("preserves sign-off above -- delimiter", () => {
+    const email = `Thanks for the update.
+
+Cheers,
+Alice
+
+--
+Alice Smith
+Engineering Lead`;
+
+    const signals = extractEmailSignals(email);
+    expect(signals.signoff).toBe("cheers");
+    expect(signals.greeting).toBe("none");
+  });
+
+  test("handles email with no signature", () => {
+    const email = `Just checking in on the project status.
+
+Best,
+Bob`;
+
+    const signals = extractEmailSignals(email);
+    expect(signals.signoff).toBe("best");
+    expect(signals.wordCount).toBe(9);
   });
 });


### PR DESCRIPTION
## Summary
- Updated `DRAFT_FORMAT_SUFFIX` to explicitly instruct the LLM not to include "Sent by Exo" signatures in generated drafts, since the app appends one automatically (causing double signatures)
- Added `stripPlainTextSignature()` in `style-profiler.ts` to strip `-- ` delimiter and "Sent by Exo" branding before computing formality signals and selecting style examples
- This prevents the model from learning signature patterns as part of the user's writing style

## Changes
- `src/shared/types.ts` — Added explicit "do not include signature" instruction to `DRAFT_FORMAT_SUFFIX`
- `src/main/services/style-profiler.ts` — New `stripPlainTextSignature()` function, applied to `extractEmailSignals()` and `truncateBody()`

## Test plan
- [ ] Verify generated drafts no longer include "Sent by Exo" in the body
- [ ] Verify sent emails still show the signature (appended at send time, not in draft)
- [ ] Verify style profiler formality scoring isn't skewed by signature text
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)