### PR TITLE
fix: include EA display name in CC field when scheduling email

### DIFF
--- a/src/main/services/draft-generator.ts
+++ b/src/main/services/draft-generator.ts
@@ -95,7 +95,12 @@ ${profile.summary}
       calendaringResult = await calAgent.analyze(email);
 
       if (calendaringResult.hasSchedulingContext && calendaringResult.action === "defer_to_ea") {
-        cc.push(eaConfig.email);
+        // Format EA as "Name <email>" if name is available, otherwise just "email"
+        if (eaConfig.name) {
+          cc.push(`${eaConfig.name} <${eaConfig.email}>`);
+        } else {
+          cc.push(eaConfig.email);
+        }
         const deferralLanguage = calAgent.generateEADeferralLanguage(eaConfig);
         calendaringContext = `
 IMPORTANT SCHEDULING INSTRUCTION:

--- a/src/main/services/draft-generator.ts
+++ b/src/main/services/draft-generator.ts
@@ -2,6 +2,7 @@ import { createMessage } from "./anthropic-service";
 import type { GmailClient } from "./gmail-client";
 import { CalendaringAgent } from "./calendaring-agent";
 import { getEnrichmentBySender } from "../extensions/enrichment-store";
+import { quoteDisplayName } from "../utils/address-formatting";
 import {
   DEFAULT_DRAFT_PROMPT,
   DRAFT_FORMAT_SUFFIX,
@@ -97,7 +98,7 @@ ${profile.summary}
       if (calendaringResult.hasSchedulingContext && calendaringResult.action === "defer_to_ea") {
         // Format EA as "Name <email>" if name is available, otherwise just "email"
         if (eaConfig.name) {
-          cc.push(`${eaConfig.name} <${eaConfig.email}>`);
+          cc.push(`${quoteDisplayName(eaConfig.name)} <${eaConfig.email}>`);
         } else {
           cc.push(eaConfig.email);
         }


### PR DESCRIPTION
## Summary
- When auto-CCing the executive assistant on scheduling emails, include the configured display name formatted as `"Name <email>"` instead of just the bare email address

## Test plan
- [ ] Configure EA with name and email in Settings → Executive Assistant
- [ ] Send/receive an email that triggers scheduling detection
- [ ] Verify the draft CC includes the full name: `Kelley Tighe <kelley@ycombinator.com>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
