### PR TITLE
Fix Settings panel rendering at various window sizes

### DIFF
--- a/src/renderer/components/ExtensionsTab.tsx
+++ b/src/renderer/components/ExtensionsTab.tsx
@@ -259,7 +259,7 @@ export function ExtensionsTab() {
   };
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="max-w-3xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Extensions</h2>

--- a/src/renderer/components/MemoriesTab.tsx
+++ b/src/renderer/components/MemoriesTab.tsx
@@ -275,14 +275,14 @@ export function MemoriesTab({
 
   if (isLoading) {
     return (
-      <div className="max-w-3xl p-4 text-sm text-gray-500 dark:text-gray-400">
+      <div className="max-w-3xl mx-auto p-4 text-sm text-gray-500 dark:text-gray-400">
         Loading memories...
       </div>
     );
   }
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="max-w-3xl mx-auto space-y-6">
       <div>
         <div className="flex items-center justify-between mb-2">
           <div>

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -706,7 +706,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
       {/* Tabs */}
       <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex space-x-1 p-2">
+        <div className="flex space-x-1 p-2 overflow-x-auto whitespace-nowrap">
           <button
             onClick={() => setActiveTab("general")}
             data-active={activeTab === "general" ? "true" : undefined}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -871,7 +871,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-6">
         {activeTab === "general" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 General Settings
@@ -1420,7 +1420,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "accounts" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 Connected Accounts
@@ -1535,7 +1535,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "calendar" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 Calendar Visibility
@@ -1613,19 +1613,19 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "splits" && (
-          <div className="max-w-3xl">
+          <div className="max-w-3xl mx-auto">
             <SplitConfigEditor />
           </div>
         )}
 
         {activeTab === "snippets" && (
-          <div className="max-w-3xl">
+          <div className="max-w-3xl mx-auto">
             <SnippetsEditor />
           </div>
         )}
 
         {activeTab === "signatures" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 Email Signatures
@@ -1858,7 +1858,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "prompts" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             {isLoading ? (
               <p className="text-gray-500 dark:text-gray-400">Loading settings...</p>
             ) : (
@@ -2032,7 +2032,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "style" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 Writing Style
@@ -2094,7 +2094,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "assistant" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 Executive Assistant Integration
@@ -2201,7 +2201,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "queue" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
                 Background Processing Queue
@@ -3147,7 +3147,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         {activeTab === "extensions" && <ExtensionsTab />}
 
         {activeTab === "analytics" && (
-          <div className="max-w-3xl space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
                 Analytics

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1372,7 +1372,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
               </div>
 
               {/* Troubleshooting */}
-              <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-600">
+              <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-600 mb-6">
                 <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
                   Troubleshooting
                 </h3>

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -2442,7 +2442,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         )}
 
         {activeTab === "agents" && (
-          <div className="space-y-6">
+          <div className="max-w-3xl mx-auto space-y-6">
             <div>
               <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
                 Agent Settings


### PR DESCRIPTION
## Summary
Three independent fixes for Settings panel rendering issues observed at non-default window sizes. Each is a small className-only change in its own commit.

1. **Tabs overflow** — the 14-tab strip was a plain `flex` with no overflow handling, so tabs past "Queue" became unreachable below ~1300px wide, and long labels wrapped to 2 lines. Now: `overflow-x-auto whitespace-nowrap`.
2. **Save button gap** — the Troubleshooting card on the General tab was missing the `mb-6` every other card has, so the Save Changes button was visually glued to it.
3. **Content centering on wide windows** — every tab's content is `max-w-3xl` but was left-aligned, leaving the vertical scrollbar floating in 500+px of empty space on wide screens. Added `mx-auto` to all such wrappers in `SettingsPanel`, `MemoriesTab`, and `ExtensionsTab`.

## Changes
- `src/renderer/components/SettingsPanel.tsx`
- `src/renderer/components/MemoriesTab.tsx`
- `src/renderer/components/ExtensionsTab.tsx`

## Test plan
- [x] Manual verification in running dev app at 1440×900, 1024×720, 800×600, 640×720 viewports (via Chrome DevTools Protocol)
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes
- [x] `npx prettier --check` on changed files passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
