### PR TITLE
feat: make Gmail draft sync optional, default off

### DIFF
--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -56,6 +56,7 @@ function getStore(): Store<{ config: Config }> {
           analysisPrompt: DEFAULT_ANALYSIS_PROMPT,
           draftPrompt: DEFAULT_DRAFT_PROMPT,
           enableSenderLookup: true,
+          syncDraftsToGmail: false,
           theme: "system" as const,
           inboxDensity: "compact" as const,
           undoSendDelay: 5,

--- a/src/main/services/gmail-draft-sync.ts
+++ b/src/main/services/gmail-draft-sync.ts
@@ -41,7 +41,11 @@ export async function syncDraftToGmail(
   forwardTo?: string[],
 ): Promise<void> {
   if (useFakeData) return;
-  if (!getConfig().syncDraftsToGmail) return;
+
+  const syncEnabled = getConfig().syncDraftsToGmail;
+
+  // If sync is disabled and there's no old draft to clean up, skip entirely.
+  if (!syncEnabled && !oldGmailDraftId) return;
 
   try {
     const email = getEmail(emailId);
@@ -63,6 +67,10 @@ export async function syncDraftToGmail(
         // Draft may have been deleted externally — that's fine
       }
     }
+
+    // Stop here if sync is disabled — old draft was cleaned up above,
+    // but we don't create a new Gmail draft.
+    if (!syncEnabled) return;
 
     const isForward = composeMode === "forward";
 

--- a/src/main/services/gmail-draft-sync.ts
+++ b/src/main/services/gmail-draft-sync.ts
@@ -42,12 +42,12 @@ export async function syncDraftToGmail(
 ): Promise<void> {
   if (useFakeData) return;
 
-  const syncEnabled = getConfig().syncDraftsToGmail;
-
-  // If sync is disabled and there's no old draft to clean up, skip entirely.
-  if (!syncEnabled && !oldGmailDraftId) return;
-
   try {
+    const syncEnabled = getConfig().syncDraftsToGmail;
+
+    // If sync is disabled and there's no old draft to clean up, skip entirely.
+    if (!syncEnabled && !oldGmailDraftId) return;
+
     const email = getEmail(emailId);
     if (!email) {
       log.warn(`[GmailDraftSync] Email not found: ${emailId}`);

--- a/src/main/services/gmail-draft-sync.ts
+++ b/src/main/services/gmail-draft-sync.ts
@@ -165,7 +165,6 @@ export function saveDraftAndSync(
  */
 export async function deleteGmailDraftById(accountId: string, gmailDraftId: string): Promise<void> {
   if (useFakeData) return;
-  if (!getConfig().syncDraftsToGmail) return;
 
   try {
     const client = await getClient(accountId || "default");

--- a/src/main/services/gmail-draft-sync.ts
+++ b/src/main/services/gmail-draft-sync.ts
@@ -12,6 +12,7 @@ import {
   saveDraft,
 } from "../db";
 import { getClient } from "../ipc/gmail.ipc";
+import { getConfig } from "../ipc/settings.ipc";
 import { createLogger } from "./logger";
 
 const log = createLogger("gmail-draft-sync");
@@ -40,6 +41,7 @@ export async function syncDraftToGmail(
   forwardTo?: string[],
 ): Promise<void> {
   if (useFakeData) return;
+  if (!getConfig().syncDraftsToGmail) return;
 
   try {
     const email = getEmail(emailId);
@@ -163,6 +165,7 @@ export function saveDraftAndSync(
  */
 export async function deleteGmailDraftById(accountId: string, gmailDraftId: string): Promise<void> {
   if (useFakeData) return;
+  if (!getConfig().syncDraftsToGmail) return;
 
   try {
     const client = await getClient(accountId || "default");

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -81,6 +81,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   // General settings state
   const [enableSenderLookup, setEnableSenderLookup] = useState(true);
+  const [syncDraftsToGmail, setSyncDraftsToGmail] = useState(false);
   const [modelConfig, setModelConfig] = useState<ModelConfig>(DEFAULT_MODEL_CONFIG);
   const [isSavingGeneral, setIsSavingGeneral] = useState(false);
   const [isExportingLogs, setIsExportingLogs] = useState(false);
@@ -225,6 +226,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   useEffect(() => {
     if (generalConfig) {
       setEnableSenderLookup(generalConfig.enableSenderLookup ?? true);
+      setSyncDraftsToGmail(generalConfig.syncDraftsToGmail ?? false);
       setModelConfig({ ...DEFAULT_MODEL_CONFIG, ...generalConfig.modelConfig });
       setGithubToken(generalConfig.githubToken ?? "");
       setAllowPrereleaseUpdates(generalConfig.allowPrereleaseUpdates ?? false);
@@ -380,6 +382,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
     try {
       await window.api.settings.set({
         enableSenderLookup,
+        syncDraftsToGmail,
         modelConfig,
         githubToken: githubToken || undefined,
         allowPrereleaseUpdates,
@@ -1369,6 +1372,34 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     </ul>
                   </div>
                 )}
+              </div>
+
+              {/* Gmail Draft Sync Toggle */}
+              <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-600 mb-6">
+                <div className="flex items-center justify-between mb-3">
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+                      Sync Drafts to Gmail
+                    </h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                      Push AI-generated drafts to Gmail so they appear in other email clients.
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => setSyncDraftsToGmail(!syncDraftsToGmail)}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                      syncDraftsToGmail
+                        ? "bg-blue-600 dark:bg-blue-500"
+                        : "bg-gray-200 dark:bg-gray-700"
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                        syncDraftsToGmail ? "translate-x-6" : "translate-x-1"
+                      }`}
+                    />
+                  </button>
+                </div>
               </div>
 
               {/* Troubleshooting */}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -375,6 +375,7 @@ export const ConfigSchema = z.object({
   autoDraft: AutoDraftConfigSchema.optional(),
   agentDrafterPrompt: z.string().optional(),
   enableSenderLookup: z.boolean().default(true),
+  syncDraftsToGmail: z.boolean().default(false),
   theme: z.enum(["light", "dark", "system"]).default("system"),
   inboxDensity: z.enum(["default", "compact"]).default("compact"),
   undoSendDelay: z.number().min(0).max(30).default(5), // seconds; 0 = disabled


### PR DESCRIPTION
## Summary

- Add `syncDraftsToGmail` boolean config field (default: `false`) to make Gmail draft syncing opt-in
- Gate all Gmail draft create/delete operations (`syncDraftToGmail`, `deleteGmailDraftById`) behind the new setting
- Add a toggle in Settings panel (under Sender Lookup) with label "Sync Drafts to Gmail"

## Changes

- `src/shared/types.ts`: Add `syncDraftsToGmail: z.boolean().default(false)` to `ConfigSchema`
- `src/main/services/gmail-draft-sync.ts`: Import `getConfig` and add early returns when sync is disabled in `syncDraftToGmail()` and `deleteGmailDraftById()`. All downstream callers (`deleteGmailDraftsBatch`, `cleanupStaleDraftsForThread`, `saveDraftAndSync`) are transitively gated.
- `src/renderer/components/SettingsPanel.tsx`: Add state, config initialization, save handler, and toggle UI following the existing `enableSenderLookup` pattern

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] All 1333 unit tests pass
- [ ] Verify toggle appears in Settings and persists across app restart
- [ ] Verify drafts are NOT synced to Gmail when toggle is off (default)
- [ ] Verify drafts ARE synced to Gmail when toggle is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
