### PR TITLE
fix: keep action-required emails at low priority

### DIFF
--- a/src/main/services/email-analyzer.ts
+++ b/src/main/services/email-analyzer.ts
@@ -43,6 +43,8 @@ OUTPUT FORMAT:
   "priority": "high" or "medium" or "low" (only include if needs_reply is true)
 }
 
+Anything that requires me to do external work (e.g. update a document or send an invite) should remain in at least "low" priority and not be skipped.
+
 SKIP REPLIES FOR:
 - Newsletters, marketing emails, promotions, and advertising
 - Automated notifications (GitHub, CI/CD, build status, receipts, shipping updates, alerts)

--- a/src/main/services/email-analyzer.ts
+++ b/src/main/services/email-analyzer.ts
@@ -48,7 +48,7 @@ Anything that requires me to do external work (e.g. update a document or send an
 SKIP REPLIES FOR:
 - Newsletters, marketing emails, promotions, and advertising
 - Automated notifications (GitHub, CI/CD, build status, receipts, shipping updates, alerts)
-- Calendar invites and event notifications (handled by calendar app)
+- Received calendar invites and event notifications (handled by calendar app) — but if the email asks the user to create/send an invite, that's action-required
 - CC'd emails where the user is not the primary recipient
 - FYI-only messages with no question or action required
 - Transactional emails (order confirmations, password resets, subscription confirmations)
@@ -135,6 +135,11 @@ Example 12 - Request for decision (high priority):
 Email Subject: "Need your sign-off on vendor contract"
 Email Body: "Hi, Legal has approved the contract with Acme Corp. We need your signature by EOD today to lock in the current pricing (they're raising rates next month). I've attached the final version with all the negotiated terms. The key changes from our discussion: 2-year term with option to extend, net-30 payment terms, and the custom SLA we requested. Please review and let me know if you have any concerns."
 Output: {"needs_reply": true, "reason": "Time-sensitive contract requiring sign-off with deadline today", "priority": "high"}
+
+Example 13 - Action-required task (low priority):
+Email Subject: "Please update the team roster spreadsheet"
+Email Body: "Hi, could you add the two new hires to the shared roster spreadsheet by end of week? The link is in the pinned message in our Slack channel. Thanks!"
+Output: {"needs_reply": false, "reason": "Task to update an external document - no email reply needed but action required", "priority": "low"}
 
 Now analyze the following email:`;
 

--- a/src/main/services/email-analyzer.ts
+++ b/src/main/services/email-analyzer.ts
@@ -139,7 +139,7 @@ Output: {"needs_reply": true, "reason": "Time-sensitive contract requiring sign-
 Example 13 - Action-required task (low priority):
 Email Subject: "Please update the team roster spreadsheet"
 Email Body: "Hi, could you add the two new hires to the shared roster spreadsheet by end of week? The link is in the pinned message in our Slack channel. Thanks!"
-Output: {"needs_reply": false, "reason": "Task to update an external document - no email reply needed but action required", "priority": "low"}
+Output: {"needs_reply": true, "reason": "Action required - update external document by end of week", "priority": "low"}
 
 Now analyze the following email:`;
 

--- a/src/main/services/email-analyzer.ts
+++ b/src/main/services/email-analyzer.ts
@@ -43,7 +43,7 @@ OUTPUT FORMAT:
   "priority": "high" or "medium" or "low" (only include if needs_reply is true)
 }
 
-Anything that requires me to do external work (e.g. update a document or send an invite) should remain in at least "low" priority and not be skipped.
+Anything that requires the user to do external work (e.g. update a document or send an invite) should remain in at least "low" priority and not be skipped.
 
 SKIP REPLIES FOR:
 - Newsletters, marketing emails, promotions, and advertising


### PR DESCRIPTION
## Summary
- Added guidance to the default email analysis prompt to prevent emails requiring external work (updating documents, sending invites, etc.) from being skipped
- These emails now remain at least "low" priority so they stay visible in the inbox

## Changes
- `src/main/services/email-analyzer.ts`: Added instruction above the "SKIP REPLIES FOR" section clarifying that action-required emails should not be skipped

## Test plan
- [ ] Run evals (`npm run eval`) to verify no regressions in email classification
- [ ] Verify emails requiring external action are classified as at least "low" priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
