### PR TITLE
fix: handle SonicBoom fd=-1 errors to prevent sync:init crash

### DIFF
--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -137,7 +137,7 @@ function initLogger(): Logger {
   fileDest.on("error", (err) => {
     // Best-effort: log to stderr so there's a breadcrumb, but never throw.
     // eslint-disable-next-line no-console
-    console.error("[logger] SonicBoom file destination error:", err.message);
+    console.error("[logger] SonicBoom file destination error:", err);
   });
   _destinations = [fileDest];
 
@@ -156,16 +156,21 @@ function initLogger(): Logger {
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const pinoPretty = require("pino-pretty");
+      const prettyStream = pinoPretty({ colorize: true });
+      prettyStream.on?.("error", (err: Error) => {
+        // eslint-disable-next-line no-console
+        console.error("[logger] pino-pretty stream error:", err);
+      });
       streams.push({
         level: "debug" as const,
-        stream: pinoPretty({ colorize: true }),
+        stream: prettyStream,
       });
     } catch {
       // pino-pretty not available, fall back to raw JSON to stdout
       const stdoutDest = pino.destination({ dest: 1, sync: true }) as SonicBoom;
       stdoutDest.on("error", (err) => {
         // eslint-disable-next-line no-console
-        console.error("[logger] SonicBoom stdout destination error:", err.message);
+        console.error("[logger] SonicBoom stdout destination error:", err);
       });
       _destinations.push(stdoutDest);
       streams.push({

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -157,7 +157,7 @@ function initLogger(): Logger {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const pinoPretty = require("pino-pretty");
       const prettyStream = pinoPretty({ colorize: true });
-      prettyStream.on?.("error", (err: Error) => {
+      prettyStream.on("error", (err: Error) => {
         // eslint-disable-next-line no-console
         console.error("[logger] pino-pretty stream error:", err);
       });

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -116,8 +116,11 @@ function initLogger(): Logger {
   const logDir = getLogDir();
   try {
     mkdirSync(logDir, { recursive: true });
-  } catch {
-    /* ignore */
+  } catch (e) {
+    // Don't silently swallow — leave a breadcrumb so we can debug startup
+    // failures like the fd=-1 crash in issue #97.
+    // eslint-disable-next-line no-console
+    console.error("[logger] Failed to create log directory:", logDir, e);
   }
 
   cleanOldLogs(logDir);
@@ -126,8 +129,16 @@ function initLogger(): Logger {
   const logFile = join(logDir, `${today}.log`);
   const dev = isDev();
 
-  // pino.destination() returns SonicBoom at runtime but is typed as DestinationStream
+  // pino.destination() returns SonicBoom at runtime but is typed as DestinationStream.
+  // Attach an error handler immediately so that if the file descriptor fails to
+  // open (fd = -1), the error is swallowed rather than crashing the app with
+  // an unhandled "fd is out of range" RangeError (see GitHub issue #97).
   const fileDest = pino.destination({ dest: logFile, sync: false, mkdir: true }) as SonicBoom;
+  fileDest.on("error", (err) => {
+    // Best-effort: log to stderr so there's a breadcrumb, but never throw.
+    // eslint-disable-next-line no-console
+    console.error("[logger] SonicBoom file destination error:", err.message);
+  });
   _destinations = [fileDest];
 
   const streams: pino.StreamEntry[] = [
@@ -152,6 +163,10 @@ function initLogger(): Logger {
     } catch {
       // pino-pretty not available, fall back to raw JSON to stdout
       const stdoutDest = pino.destination({ dest: 1, sync: true }) as SonicBoom;
+      stdoutDest.on("error", (err) => {
+        // eslint-disable-next-line no-console
+        console.error("[logger] SonicBoom stdout destination error:", err.message);
+      });
       _destinations.push(stdoutDest);
       streams.push({
         level: "debug" as const,


### PR DESCRIPTION
## Summary

Fixes #97. The app crashes on startup with `RangeError: fd is out of range (-1)` during `sync:init` when the SonicBoom logger fails to open its log file (e.g., directory doesn't exist on first launch).

- Added `'error'` event handlers on all SonicBoom destinations (file, stdout, pino-pretty) so unhandled fd=-1 errors are caught instead of crashing the app
- Stopped silently swallowing `mkdirSync` failures in logger init — now logs to stderr for debuggability
- Logs full error objects (not just `.message`) to preserve stack traces

## Changes

- `src/main/services/logger.ts`: Added error handlers on SonicBoom file destination, stdout fallback destination, and pino-pretty stream. Changed mkdirSync catch from silent ignore to console.error.

## Root cause

SonicBoom opens log files asynchronously (`sync: false`). If the file descriptor fails to open, `fd` stays at `-1`. Without an `'error'` event handler, Node.js throws the error as an unhandled event, which surfaces as `RangeError: fd is out of range (-1)` when `sync:init` tries to log.

The existing `safeSonicBoomWrapper` catches synchronous write errors, but async SonicBoom error events were unhandled.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test:unit` — all 1338 tests pass
- [x] `npm run lint` passes
- [x] Adversarial review completed, findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
