### PR TITLE
fix: derive default from-address to prevent React error #310

### DIFF
--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useAppStore } from "../store";
 import { useSignature } from "./useSignature";
 import type { ComposeAttachmentItem } from "../components/AttachmentList";
@@ -14,6 +14,11 @@ import type {
 function extractBareEmail(addr: string): string {
   const match = addr.match(/<([^>]+)>$/);
   return match ? match[1] : addr;
+}
+
+/** Format a SendAsAlias as "Display Name <email>" or just "email". */
+function formatAlias(alias: SendAsAlias): string {
+  return alias.displayName ? `${alias.displayName} <${alias.email}>` : alias.email;
 }
 
 /** Build a name map from an array of potentially formatted addresses. */
@@ -133,7 +138,8 @@ export function useComposeForm({
 
   // --- Send-as aliases ---
   const [sendAsAliases, setSendAsAliases] = useState<SendAsAlias[]>([]);
-  const [from, setFrom] = useState<string | undefined>(undefined);
+  // Tracks the user's explicit selection; undefined means "use derived default"
+  const [fromOverride, setFromOverride] = useState<string | undefined>(undefined);
 
   // Fetch aliases on mount
   useEffect(() => {
@@ -143,56 +149,49 @@ export function useComposeForm({
       .then((result) => {
         if (result.success && result.data.length > 0) {
           setSendAsAliases(result.data);
-
-          // Smart reply default: auto-select the alias that the original email was sent to.
-          // replyInfo.to/cc only has the REPLY addresses (original sender for plain reply),
-          // so we also check the original email's To/CC from the store — that's where
-          // the user's alias appears as a recipient.
-          if (replyInfo) {
-            const replyRecipients = [...(replyInfo.to || []), ...(replyInfo.cc || [])].map((addr) =>
-              extractBareEmail(addr).toLowerCase(),
-            );
-
-            // Also check the original email's recipients (covers plain reply)
-            const originalEmail = replyToEmailId
-              ? useAppStore.getState().emails.find((e) => e.id === replyToEmailId)
-              : undefined;
-            const originalRecipients = originalEmail
-              ? [
-                  ...(originalEmail.to || "").split(",").map((s) => s.trim()),
-                  ...(originalEmail.cc || "").split(",").map((s) => s.trim()),
-                ].map((addr) => extractBareEmail(addr).toLowerCase())
-              : [];
-
-            const allRecipients = [...replyRecipients, ...originalRecipients];
-            const matchingAlias = result.data.find((a) =>
-              allRecipients.includes(a.email.toLowerCase()),
-            );
-            if (matchingAlias) {
-              setFrom(
-                matchingAlias.displayName
-                  ? `${matchingAlias.displayName} <${matchingAlias.email}>`
-                  : matchingAlias.email,
-              );
-              return;
-            }
-          }
-
-          // Default to the default alias
-          const defaultAlias = result.data.find((a) => a.isDefault);
-          if (defaultAlias) {
-            setFrom(
-              defaultAlias.displayName
-                ? `${defaultAlias.displayName} <${defaultAlias.email}>`
-                : defaultAlias.email,
-            );
-          }
         }
       })
       .catch(() => {
         // Silently fail — compose still works without aliases
       });
   }, [accountId]);
+
+  // Derive the default "from" address from aliases without storing in state.
+  // Smart reply default: pick the alias that the original email was sent to.
+  const derivedFrom = useMemo(() => {
+    if (sendAsAliases.length === 0) return undefined;
+
+    if (replyInfo) {
+      const replyRecipients = [...(replyInfo.to || []), ...(replyInfo.cc || [])].map((addr) =>
+        extractBareEmail(addr).toLowerCase(),
+      );
+
+      const originalEmail = replyToEmailId
+        ? useAppStore.getState().emails.find((e) => e.id === replyToEmailId)
+        : undefined;
+      const originalRecipients = originalEmail
+        ? [
+            ...(originalEmail.to || "").split(",").map((s) => s.trim()),
+            ...(originalEmail.cc || "").split(",").map((s) => s.trim()),
+          ].map((addr) => extractBareEmail(addr).toLowerCase())
+        : [];
+
+      const allRecipients = [...replyRecipients, ...originalRecipients];
+      const matchingAlias = sendAsAliases.find((a) =>
+        allRecipients.includes(a.email.toLowerCase()),
+      );
+      if (matchingAlias) return formatAlias(matchingAlias);
+    }
+
+    const defaultAlias = sendAsAliases.find((a) => a.isDefault);
+    if (defaultAlias) return formatAlias(defaultAlias);
+
+    return formatAlias(sendAsAliases[0]);
+  }, [sendAsAliases, replyInfo, replyToEmailId]);
+
+  // Effective "from": user's explicit pick wins, otherwise use derived default
+  const from = fromOverride ?? derivedFrom;
+  const setFrom = setFromOverride;
 
   // --- Send state ---
   const [isSending, setIsSending] = useState(false);

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -141,8 +141,10 @@ export function useComposeForm({
   // Tracks the user's explicit selection; undefined means "use derived default"
   const [fromOverride, setFromOverride] = useState<string | undefined>(undefined);
 
-  // Fetch aliases on mount
+  // Fetch aliases on mount (and when account changes)
   useEffect(() => {
+    setFromOverride(undefined);
+
     if (typeof window.api.compose.getSendAsAliases !== "function") return;
 
     (window.api.compose.getSendAsAliases(accountId) as Promise<IpcResponse<SendAsAlias[]>>)

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -144,11 +144,14 @@ export function useComposeForm({
   // Fetch aliases on mount (and when account changes)
   useEffect(() => {
     setFromOverride(undefined);
+    setSendAsAliases([]);
+    let cancelled = false;
 
     if (typeof window.api.compose.getSendAsAliases !== "function") return;
 
     (window.api.compose.getSendAsAliases(accountId) as Promise<IpcResponse<SendAsAlias[]>>)
       .then((result) => {
+        if (cancelled) return;
         if (result.success && result.data.length > 0) {
           setSendAsAliases(result.data);
         }
@@ -156,7 +159,15 @@ export function useComposeForm({
       .catch(() => {
         // Silently fail — compose still works without aliases
       });
+    return () => {
+      cancelled = true;
+    };
   }, [accountId]);
+
+  // Subscribe to the reply email reactively so derivedFrom updates if emails load async
+  const replyEmail = useAppStore((s) =>
+    replyToEmailId ? s.emails.find((e) => e.id === replyToEmailId) : undefined,
+  );
 
   // Derive the default "from" address from aliases without storing in state.
   // Smart reply default: pick the alias that the original email was sent to.
@@ -168,13 +179,10 @@ export function useComposeForm({
         extractBareEmail(addr).toLowerCase(),
       );
 
-      const originalEmail = replyToEmailId
-        ? useAppStore.getState().emails.find((e) => e.id === replyToEmailId)
-        : undefined;
-      const originalRecipients = originalEmail
+      const originalRecipients = replyEmail
         ? [
-            ...(originalEmail.to || "").split(",").map((s) => s.trim()),
-            ...(originalEmail.cc || "").split(",").map((s) => s.trim()),
+            ...(replyEmail.to || "").split(",").map((s) => s.trim()),
+            ...(replyEmail.cc || "").split(",").map((s) => s.trim()),
           ].map((addr) => extractBareEmail(addr).toLowerCase())
         : [];
 
@@ -189,7 +197,7 @@ export function useComposeForm({
     if (defaultAlias) return formatAlias(defaultAlias);
 
     return formatAlias(sendAsAliases[0]);
-  }, [sendAsAliases, replyInfo, replyToEmailId]);
+  }, [sendAsAliases, replyInfo, replyEmail]);
 
   // Effective "from": user's explicit pick wins, otherwise use derived default
   const from = fromOverride ?? derivedFrom;


### PR DESCRIPTION
## Summary

- Fixes React error #310 (`Cannot update a component while rendering a different component`) thrown by the compose flow's `FromSelector` component (#98)
- Replaces `useEffect`-based state setting of the default "from" address with a `useMemo`-derived value, eliminating the render-cycle state update that triggered the crash
- Adds a `fromOverride` state that only tracks explicit user selections, falling back to the derived default

## Changes

- `src/renderer/hooks/useComposeForm.ts`:
  - Added `formatAlias()` helper (extracted from inline logic)
  - Replaced `from`/`setFrom` state with `fromOverride`/`setFromOverride` for explicit user picks
  - Added `derivedFrom` via `useMemo` to compute default from-address from aliases + reply context
  - `from` is now `fromOverride ?? derivedFrom` — user pick wins, otherwise derived
  - Reset `fromOverride` on `accountId` change to prevent stale alias from previous account

## Root cause

The `useComposeForm` hook set `from` state inside a `useEffect` callback after fetching send-as aliases. Under specific timing (large account, fast alias resolution), this state update could fire during another component's commit phase, violating React's rules and crashing the app.

## Test plan

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] All 1338 unit tests pass (`npm run test:unit`)
- [ ] Manual: open compose with multiple aliases, verify default selection works
- [ ] Manual: reply to email, verify correct alias is auto-selected
- [ ] Manual: switch accounts while compose is open, verify alias resets

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
