### PR TITLE
fix: prevent React #185 crash on startup with inline reply state

### DIFF
--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -2241,7 +2241,9 @@ class EmailDetailErrorBoundary extends React.Component<
       return (
         <div className="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-800/50">
           <div className="text-center">
-            <p className="text-gray-500 dark:text-gray-400 mb-2">Something went wrong displaying this email.</p>
+            <p className="text-gray-500 dark:text-gray-400 mb-2">
+              Something went wrong displaying this email.
+            </p>
             <button
               className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400"
               onClick={() => this.setState({ hasError: false })}
@@ -2890,7 +2892,14 @@ function EmailDetailInner({ isFullView = false }: EmailDetailProps) {
         }
       }
     }
-  }, [isFullView, composeState, currentAccountId, closeCompose, setInlineReplyOpen, selectedThreadId]);
+  }, [
+    isFullView,
+    composeState,
+    currentAccountId,
+    closeCompose,
+    setInlineReplyOpen,
+    selectedThreadId,
+  ]);
 
   // Safety net: if we're in full view with no valid email and no compose open,
   // fall back to split view so the email list becomes visible. This catches edge

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -2257,8 +2257,9 @@ class EmailDetailErrorBoundary extends React.Component<
 }
 
 export function EmailDetail({ isFullView = false }: EmailDetailProps) {
+  const selectedEmailId = useAppStore((s) => s.selectedEmailId);
   return (
-    <EmailDetailErrorBoundary>
+    <EmailDetailErrorBoundary key={selectedEmailId ?? "__none__"}>
       <EmailDetailInner isFullView={isFullView} />
     </EmailDetailErrorBoundary>
   );

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -2217,7 +2217,54 @@ interface EmailDetailProps {
   isFullView?: boolean;
 }
 
+class EmailDetailErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error("[EmailDetail] Render crash caught by error boundary:", error.message);
+    // Clear selection state so the user can recover by clicking another email
+    useAppStore.setState({
+      isInlineReplyOpen: false,
+      inlineReplyToEmailId: null,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-800/50">
+          <div className="text-center">
+            <p className="text-gray-500 dark:text-gray-400 mb-2">Something went wrong displaying this email.</p>
+            <button
+              className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400"
+              onClick={() => this.setState({ hasError: false })}
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export function EmailDetail({ isFullView = false }: EmailDetailProps) {
+  return (
+    <EmailDetailErrorBoundary>
+      <EmailDetailInner isFullView={isFullView} />
+    </EmailDetailErrorBoundary>
+  );
+}
+
+function EmailDetailInner({ isFullView = false }: EmailDetailProps) {
   const {
     emails,
     selectedEmailId,
@@ -2298,6 +2345,17 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
       }
     };
   }, []);
+
+  // Guard: clear inline reply state when thread context is unavailable.
+  // Prevents infinite re-render loops (React error #185) when the app enters
+  // an inconsistent state with isInlineReplyOpen=true but no selected thread
+  // (e.g. during startup sync when selectedEmailId is set before selectedThreadId).
+  useEffect(() => {
+    if (isInlineReplyOpen && !selectedThreadId) {
+      setInlineReplyOpen(false);
+      setInlineReplyToEmailId(null);
+    }
+  }, [isInlineReplyOpen, selectedThreadId, setInlineReplyOpen, setInlineReplyToEmailId]);
 
   const storeEmail = emails.find((e) => e.id === selectedEmailId);
 
@@ -2657,6 +2715,9 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   // the editor manually doesn't cause it to re-open).
   useEffect(() => {
     if (!draftEmail?.draft?.body || !replyTargetEmailId) return;
+    // Don't auto-open without a valid thread context — avoids render loops
+    // when selectedEmailId is set but selectedThreadId hasn't been set yet.
+    if (!selectedThreadId) return;
     // Don't re-open if already auto-opened for this thread
     if (autoOpenedThreadRef.current === draftEmail.threadId) return;
     // Don't re-open if the editor is already active for this thread
@@ -2680,6 +2741,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     inlineReplyInfo,
     composeState?.isOpen,
     openCompose,
+    selectedThreadId,
   ]);
 
   // Scroll to the target email before the browser paints.
@@ -2731,7 +2793,13 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   // send time — they don't affect the visible UI.
   const composeRequestIdRef = useRef(0);
   useEffect(() => {
-    if (isFullView && composeState?.isOpen && composeState.replyToEmailId && currentAccountId) {
+    if (
+      isFullView &&
+      composeState?.isOpen &&
+      composeState.replyToEmailId &&
+      currentAccountId &&
+      selectedThreadId
+    ) {
       const mode = composeState.mode;
       if (mode === "reply" || mode === "reply-all" || mode === "forward") {
         const requestId = ++composeRequestIdRef.current;
@@ -2821,7 +2889,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
         }
       }
     }
-  }, [isFullView, composeState, currentAccountId, closeCompose, setInlineReplyOpen]);
+  }, [isFullView, composeState, currentAccountId, closeCompose, setInlineReplyOpen, selectedThreadId]);
 
   // Safety net: if we're in full view with no valid email and no compose open,
   // fall back to split view so the email list becomes visible. This catches edge


### PR DESCRIPTION
## Summary

Fixes #96 — React error #185 (maximum update depth exceeded) crashes the app on startup when state is inconsistent: `isInlineReplyOpen=true` but `selectedThreadId=null`.

- **Guard effect** clears `isInlineReplyOpen` when `selectedThreadId` is null, breaking the infinite re-render loop
- **Auto-open draft effect** and **compose-to-inline conversion effect** now require `selectedThreadId` before activating inline reply machinery
- **Error boundary** wraps `EmailDetail` so render crashes show a recovery UI instead of crashing the whole app

## Changes

- `src/renderer/components/EmailDetail.tsx`: Added `EmailDetailErrorBoundary` class component, guard effect, and `selectedThreadId` guards on two existing effects

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] All 1338 unit tests pass
- [x] All 18 integration tests pass
- [ ] Manual: launch app with 6 accounts, verify no crash on startup
- [ ] Manual: verify inline reply still works normally (open draft, reply, forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
