### PR TITLE
fix: stop re-generating auto-drafts for emails after app restart

### DIFF
--- a/src/main/agents/task-id.ts
+++ b/src/main/agents/task-id.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared helpers for auto-draft agent task IDs.
+ * Format: `auto-draft-{emailId}-{timestamp}`
+ * Used by the prefetch service to create task IDs and by the DB layer to
+ * identify completed auto-draft runs from agent_conversation_mirror.
+ */
+
+const AUTO_DRAFT_PREFIX = "auto-draft-";
+const AUTO_DRAFT_TASK_ID_REGEX = /^auto-draft-(.+)-\d+$/;
+
+export function buildAutoDraftTaskId(emailId: string): string {
+  return `${AUTO_DRAFT_PREFIX}${emailId}-${Date.now()}`;
+}
+
+export function parseAutoDraftTaskId(taskId: string): string | null {
+  const match = taskId.match(AUTO_DRAFT_TASK_ID_REGEX);
+  return match ? match[1] : null;
+}
+
+export const AUTO_DRAFT_TASK_ID_LIKE_PATTERN = `${AUTO_DRAFT_PREFIX}%`;

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -17,6 +17,7 @@ import type {
   SendAsAlias,
 } from "../../shared/types";
 import { createLogger } from "../services/logger";
+import { parseAutoDraftTaskId, AUTO_DRAFT_TASK_ID_LIKE_PATTERN } from "../agents/task-id";
 
 const log = createLogger("db");
 
@@ -4371,21 +4372,19 @@ export function listConversationMirrors(providerId?: string): ConversationMirror
 /**
  * Load email IDs that have had a successful auto-draft agent run,
  * derived from the agent_conversation_mirror table.
- * Task IDs follow the format: auto-draft-{emailId}-{timestamp}
  */
 export function loadCompletedAgentDraftEmailIds(): Set<string> {
   const db = getDatabase();
   const rows = db
     .prepare(
-      `SELECT DISTINCT local_task_id FROM agent_conversation_mirror
-       WHERE local_task_id LIKE 'auto-draft-%' AND status = 'completed'`,
+      `SELECT local_task_id FROM agent_conversation_mirror
+       WHERE local_task_id LIKE ? AND status = 'completed'`,
     )
-    .all() as Array<{ local_task_id: string }>;
+    .all(AUTO_DRAFT_TASK_ID_LIKE_PATTERN) as Array<{ local_task_id: string }>;
   const emailIds = new Set<string>();
   for (const row of rows) {
-    // Extract emailId from "auto-draft-{emailId}-{timestamp}"
-    const match = row.local_task_id.match(/^auto-draft-(.+)-\d+$/);
-    if (match) emailIds.add(match[1]);
+    const emailId = parseAutoDraftTaskId(row.local_task_id);
+    if (emailId) emailIds.add(emailId);
   }
   return emailIds;
 }

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -423,6 +423,16 @@ const NUMBERED_MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 3,
+    name: "index_agent_conversation_mirror_local_task_id",
+    up: (db) => {
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_agent_conversation_mirror_task_status
+         ON agent_conversation_mirror(local_task_id, status)`,
+      );
+    },
+  },
 ];
 
 function runNumberedMigrations(db: DatabaseInstance): void {

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -4357,3 +4357,25 @@ export function listConversationMirrors(providerId?: string): ConversationMirror
     updatedAt: row.updatedAt as string,
   }));
 }
+
+/**
+ * Load email IDs that have had a successful auto-draft agent run,
+ * derived from the agent_conversation_mirror table.
+ * Task IDs follow the format: auto-draft-{emailId}-{timestamp}
+ */
+export function loadCompletedAgentDraftEmailIds(): Set<string> {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT local_task_id FROM agent_conversation_mirror
+       WHERE local_task_id LIKE 'auto-draft-%' AND status = 'completed'`,
+    )
+    .all() as Array<{ local_task_id: string }>;
+  const emailIds = new Set<string>();
+  for (const row of rows) {
+    // Extract emailId from "auto-draft-{emailId}-{timestamp}"
+    const match = row.local_task_id.match(/^auto-draft-(.+)-\d+$/);
+    if (match) emailIds.add(match[1]);
+  }
+  return emailIds;
+}

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -428,6 +428,16 @@ const NUMBERED_MIGRATIONS: Migration[] = [
     version: 3,
     name: "index_agent_conversation_mirror_local_task_id",
     up: (db) => {
+      // Guard: migrations run before SCHEMA (see initDatabase order), so on a
+      // fresh DB the table doesn't exist yet. CREATE INDEX IF NOT EXISTS only
+      // guards the index, not the table — skip here and let SCHEMA + the index
+      // in the schema file handle fresh DBs.
+      const tableExists = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_conversation_mirror'",
+        )
+        .get();
+      if (!tableExists) return;
       db.exec(
         `CREATE INDEX IF NOT EXISTS idx_agent_conversation_mirror_task_status
          ON agent_conversation_mirror(local_task_id, status)`,

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -372,6 +372,7 @@ CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope, scope_value);
 CREATE INDEX IF NOT EXISTS idx_emails_message_id ON emails(message_id);
 CREATE INDEX IF NOT EXISTS idx_emails_in_reply_to ON emails(in_reply_to);
 CREATE INDEX IF NOT EXISTS idx_send_as_account ON send_as_aliases(account_id);
+CREATE INDEX IF NOT EXISTS idx_agent_conversation_mirror_task_status ON agent_conversation_mirror(local_task_id, status);
 `;
 
 // FTS5 full-text search schema (separate because SQLite can't IF NOT EXISTS for virtual tables)

--- a/src/main/ipc/drafts.ipc.ts
+++ b/src/main/ipc/drafts.ipc.ts
@@ -278,8 +278,10 @@ FORMATTING: Write plain text paragraphs separated by blank lines. Do NOT use HTM
           `[Drafts] Rerun all: cleared ${clearedCount} pending drafts, ${tracesCleared} agent traces`,
         );
 
-        // Reset prefetch tracking so emails can be re-queued
-        prefetchService.clear();
+        // Reset prefetch tracking so emails can be re-queued.
+        // Use clearForRerun() so the next processAllPending() does NOT re-seed
+        // processedDrafts from DB — the seed would re-block all the just-cleared drafts.
+        prefetchService.clearForRerun();
 
         // Re-trigger the full prefetch pipeline (fire-and-forget, but catch errors)
         prefetchService.processAllPending().catch((err) => {

--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -509,8 +509,10 @@ export function registerSettingsIpc(): void {
           analysisChanged || draftChanged || archiveReadyChanged || agentDrafterChanged;
 
         if (anyChanged) {
-          // Full clear to reset all tracking sets, then re-process
-          prefetchService.clear();
+          // Clear tracking sets to re-process; use clearForRerun so the DB-seeded
+          // processedDrafts doesn't re-block the emails whose pending drafts/traces
+          // we just cleared above.
+          prefetchService.clearForRerun();
 
           // Notify renderer to refresh emails (stale analysis/draft data is gone)
           for (const win of BrowserWindow.getAllWindows()) {

--- a/src/main/services/prefetch-service.ts
+++ b/src/main/services/prefetch-service.ts
@@ -11,6 +11,7 @@ import {
   getAnalyzedArchiveThreadIds,
   getAccounts,
   updateDraftAgentTaskId,
+  loadCompletedAgentDraftEmailIds,
 } from "../db";
 import { getConfig, getModelIdForFeature } from "../ipc/settings.ipc";
 import { getExtensionHost } from "../extensions";
@@ -104,6 +105,7 @@ class PrefetchService {
   private processedAnalysis = new Set<string>();
   private processedSenderProfiles = new Set<string>();
   private processedDrafts = new Set<string>();
+  private seededFromDb = false;
   private processedExtensionEnrichments = new Set<string>();
   private processedArchiveReady = new Set<string>();
 
@@ -260,6 +262,17 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
     const _t0 = performance.now();
     log.info(`[PERF] processAllPending START`);
 
+    // Seed processedDrafts from persisted completions (agent_conversation_mirror)
+    // so we don't re-run agent drafts that already succeeded in a previous session.
+    // Only seed once (startup) — subsequent calls (e.g. rerun-all) should not re-seed.
+    if (!this.seededFromDb) {
+      const persistedCompletions = loadCompletedAgentDraftEmailIds();
+      for (const emailId of persistedCompletions) {
+        this.processedDrafts.add(emailId);
+      }
+      this.seededFromDb = true;
+    }
+
     const tConfig = performance.now();
     const config = getConfig();
     log.info(
@@ -370,7 +383,6 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
             e.analysis?.needsReply &&
             e.analysis?.priority !== "skip" &&
             allowedPriorities.includes(e.analysis?.priority || "low") &&
-            !e.draft &&
             !this.processedDrafts.has(e.id) &&
             !this.queue.some((t) => t.type === "agent-draft" && t.emailId === e.id) &&
             !this.agentDraftItems.has(e.id) &&

--- a/src/main/services/prefetch-service.ts
+++ b/src/main/services/prefetch-service.ts
@@ -1494,9 +1494,23 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
   }
 
   /**
-   * Clear all state - call on logout or account switch
+   * Clear all state — call on logout or account switch.
+   * Resets seededFromDb so the next processAllPending() re-seeds processedDrafts
+   * from the DB (the new account's history).
    */
   clear(): void {
+    this.clearForRerun();
+    this.seededFromDb = false;
+  }
+
+  /**
+   * Clear in-memory state for a rerun of the pipeline, but keep seededFromDb
+   * as-is so the next processAllPending() does NOT re-seed from the DB.
+   * Used by "rerun all drafts" and prompt-change flows where the caller has
+   * already invalidated the relevant DB state (pending drafts + traces) and
+   * wants the pipeline to re-run without the seed re-blocking everything.
+   */
+  clearForRerun(): void {
     this.reset();
     this.queue = [];
     this.cachedInboxEmails = null;

--- a/src/main/services/prefetch-service.ts
+++ b/src/main/services/prefetch-service.ts
@@ -16,6 +16,7 @@ import {
 import { getConfig, getModelIdForFeature } from "../ipc/settings.ipc";
 import { getExtensionHost } from "../extensions";
 import { agentCoordinator } from "../agents/agent-coordinator";
+import { buildAutoDraftTaskId } from "../agents/task-id";
 import type { AgentContext } from "../agents/types";
 import { DEFAULT_AGENT_DRAFTER_PROMPT } from "../../shared/types";
 import type { Email, DashboardEmail } from "../../shared/types";
@@ -1054,7 +1055,10 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
    * so it can research context before drafting.
    */
   private async processAgentDraft(emailId: string): Promise<void> {
-    if (this.processedDrafts.has(emailId)) return;
+    // Force-queued items bypass the processedDrafts guard — the DB seed on startup
+    // could re-add a previously-completed email to processedDrafts during the window
+    // between forceQueueAgentDraft() clearing it and the task actually running.
+    if (this.processedDrafts.has(emailId) && !this.forceQueuedDrafts.has(emailId)) return;
 
     // Skip in test/demo mode — agent worker may not be available or we shouldn't make real API calls
     const isTestMode = process.env.EXO_TEST_MODE === "true";
@@ -1096,7 +1100,7 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
       `[Prefetch] Starting agent draft for email ${emailId} (priority=${email.analysis?.priority ?? "unknown"})`,
     );
 
-    const taskId = `auto-draft-${emailId}-${Date.now()}`;
+    const taskId = buildAutoDraftTaskId(emailId);
 
     try {
       const config = getConfig();
@@ -1474,7 +1478,7 @@ When you see emails in a thread where ${eaName} is coordinating scheduling with 
       ? accounts.find((a) => a.id === email.accountId)
       : (accounts.find((a) => a.isPrimary) ?? accounts[0]);
 
-    const taskId = `auto-draft-${emailId}-${Date.now()}`;
+    const taskId = buildAutoDraftTaskId(emailId);
     const context: AgentContext = {
       accountId: account?.id || "",
       currentEmailId: emailId,


### PR DESCRIPTION
## Summary

Fixes an issue where agent-composed draft emails would reappear in the inbox after being deleted, once the app restarted.

## Why this was happening

When the auto-draft pipeline decides whether to generate a draft for an email, it checks `!e.draft` — but `e.draft` comes from the `drafts` table (reply drafts only). When the agent uses `compose_new_email`, it writes to the `local_drafts` table, which is invisible to that check.

The in-memory `processedDrafts` set was the only thing preventing repeat runs, but it's lost on restart. So every app relaunch → pipeline sees "needs reply, no draft" → agent runs again → new local draft created → the user deletes it → next launch → repeat. Same intro email got generated 7+ times over several weeks.

## Fix

Seed `processedDrafts` on startup from `agent_conversation_mirror` — the table that already persists completed agent task runs. Auto-draft task IDs follow the `auto-draft-{emailId}-{timestamp}` convention, so the email ID can be extracted from completed rows. No new tables or tracking logic.

- Removed `!e.draft` from the candidate filter — the persisted set now covers it
- `seededFromDb` flag ensures seeding only happens once on startup, so the "rerun all drafts" path still works
- Added a composite index on `agent_conversation_mirror(local_task_id, status)` to keep the startup query fast as the mirror table grows (covering index for `LIKE 'auto-draft-%' AND status = 'completed'`)

## What's NOT fixed here (follow-up)

The archive/delete cleanup path in `sync.ipc.ts` only deletes agent traces when `email.draft?.agentTaskId` is set (i.e. reply drafts). For compose drafts — or any email where the draft row was already deleted — the trace in `agent_conversation_mirror` is orphaned forever. That's the underlying reason the table grows unboundedly. Worth a separate PR that matches traces by email ID pattern instead of the stored `agent_task_id`.

## Test plan

- [x] `npm run test:unit` — 1338 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Launch app, confirm previously-regenerating drafts stay deleted after restart
- [ ] Launch app on a fresh DB, confirm auto-drafts still generate the first time
- [ ] Trigger "rerun all drafts" from Settings, confirm it still regenerates everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
