### PR TITLE
fix: agent worker crash on app.isPackaged in packaged builds

### DIFF
--- a/src/main/agents/tools/analysis-tools.ts
+++ b/src/main/agents/tools/analysis-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { type ToolDefinition, ToolRiskLevel } from "./types";
 import type { DashboardEmail } from "../../../shared/types";
-import { htmlToPlainText } from "../../db";
+import { htmlToPlainText } from "../../util/html-to-text";
 
 const analyzeEmail: ToolDefinition<{ emailId: string }> = {
   name: "analyze_email",

--- a/src/main/agents/tools/email-tools.ts
+++ b/src/main/agents/tools/email-tools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { type ToolDefinition, ToolRiskLevel } from "./types";
 import type { DashboardEmail } from "../../../shared/types";
 import { draftBodyToHtml } from "../../../shared/draft-utils";
-import { htmlToPlainText } from "../../db";
+import { htmlToPlainText } from "../../util/html-to-text";
 
 const readEmail: ToolDefinition<{ emailId: string }> = {
   name: "read_email",

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -527,48 +527,6 @@ export function stripHtmlForSearch(html: string): string {
     .trim();
 }
 
-/** Decode HTML entities including numeric (&#NNN; / &#xHH;) for agent-facing text. */
-function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
-      const cp = parseInt(hex, 16);
-      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
-    })
-    .replace(/&#(\d+);/g, (_, dec) => {
-      const cp = parseInt(dec, 10);
-      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
-    })
-    .replace(/&[#\w]+;/gi, " ");
-}
-
-/**
- * Convert HTML to plain text for AI agent consumption.
- * Preserves paragraph breaks and decodes all HTML entities (including numeric).
- * Use this instead of stripHtmlForSearch when the text will be read by an LLM.
- */
-export function htmlToPlainText(html: string): string {
-  return decodeHtmlEntities(
-    html
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "") // remove style blocks
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "") // remove script blocks
-      .replace(/<br\s*\/?>/gi, "\n") // <br> → newline
-      .replace(/<\/(?:p|div|h[1-6]|li|tr|blockquote)>/gi, "\n") // block-close → newline
-      .replace(/<(?:hr)\s*\/?>/gi, "\n---\n") // <hr> → separator
-      .replace(/<[^>]+>/g, ""), // strip remaining tags
-  )
-    .replace(/[ \t]+/g, " ") // collapse horizontal whitespace only
-    .replace(/\n /g, "\n") // trim leading space after newlines
-    .replace(/ \n/g, "\n") // trim trailing space before newlines
-    .replace(/\n{3,}/g, "\n\n") // collapse 3+ newlines to 2
-    .trim();
-}
-
 /**
  * Escape FTS5 special characters so user input doesn't cause syntax errors.
  * Wraps each non-operator token in double quotes to treat it as a literal phrase.

--- a/src/main/util/html-to-text.ts
+++ b/src/main/util/html-to-text.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure HTML-to-text helpers used by the agent worker. Kept dependency-free
+ * so importing from the utility process doesn't drag in electron/better-sqlite3
+ * via the db module — @electron-toolkit/utils dereferences `electron.app` at
+ * module load time, which is undefined in utility processes.
+ */
+
+/** Decode HTML entities including numeric (&#NNN; / &#xHH;) for agent-facing text. */
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
+      const cp = parseInt(hex, 16);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
+    })
+    .replace(/&#(\d+);/g, (_, dec) => {
+      const cp = parseInt(dec, 10);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
+    })
+    .replace(/&[#\w]+;/gi, " ");
+}
+
+/**
+ * Convert HTML to plain text for AI agent consumption.
+ * Preserves paragraph breaks and decodes all HTML entities (including numeric).
+ * Use this instead of stripHtmlForSearch when the text will be read by an LLM.
+ */
+export function htmlToPlainText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "") // remove style blocks
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "") // remove script blocks
+      .replace(/<br\s*\/?>/gi, "\n") // <br> → newline
+      .replace(/<\/(?:p|div|h[1-6]|li|tr|blockquote)>/gi, "\n") // block-close → newline
+      .replace(/<(?:hr)\s*\/?>/gi, "\n---\n") // <hr> → separator
+      .replace(/<[^>]+>/g, ""), // strip remaining tags
+  )
+    .replace(/[ \t]+/g, " ") // collapse horizontal whitespace only
+    .replace(/\n /g, "\n") // trim leading space after newlines
+    .replace(/ \n/g, "\n") // trim trailing space before newlines
+    .replace(/\n{3,}/g, "\n\n") // collapse 3+ newlines to 2
+    .trim();
+}

--- a/tests/unit/html-to-plaintext.spec.ts
+++ b/tests/unit/html-to-plaintext.spec.ts
@@ -1,49 +1,11 @@
 import { test, expect } from "@playwright/test";
+import { htmlToPlainText } from "../../src/main/util/html-to-text";
 
 /**
  * Unit tests for htmlToPlainText — the HTML-to-text converter used when
  * sending email bodies to AI agents. Preserves paragraph structure and
  * decodes numeric HTML entities so text is usable for LLM comprehension.
- *
- * Function is copied from src/main/db/index.ts because that file imports
- * Electron-only modules (same pattern as search.spec.ts).
  */
-
-function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
-      const cp = parseInt(hex, 16);
-      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
-    })
-    .replace(/&#(\d+);/g, (_, dec) => {
-      const cp = parseInt(dec, 10);
-      return cp <= 0x10ffff ? String.fromCodePoint(cp) : "\uFFFD";
-    })
-    .replace(/&[#\w]+;/gi, " ");
-}
-
-function htmlToPlainText(html: string): string {
-  return decodeHtmlEntities(
-    html
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
-      .replace(/<br\s*\/?>/gi, "\n")
-      .replace(/<\/(?:p|div|h[1-6]|li|tr|blockquote)>/gi, "\n")
-      .replace(/<(?:hr)\s*\/?>/gi, "\n---\n")
-      .replace(/<[^>]+>/g, ""),
-  )
-    .replace(/[ \t]+/g, " ")
-    .replace(/\n /g, "\n")
-    .replace(/ \n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
 
 test.describe("htmlToPlainText", () => {
   test.describe("tag stripping", () => {


### PR DESCRIPTION
## Summary
- Claude Agent tasks fail in the packaged app with `Cannot read properties of undefined (reading 'isPackaged')`, showing up as a red error card in the agent panel with a Retry button.
- Root cause: the agent worker runs in an Electron **utility process** where `electron.app` is `undefined`. `@electron-toolkit/utils` evaluates `!electron.app.isPackaged` at module load and throws. It gets loaded transitively because the worker's tool files import `htmlToPlainText` from `../../db`, which imports `data-dir.ts`, which imports `@electron-toolkit/utils`.
- Introduced in #85 (Strip HTML from email bodies before sending to agents) — before that, the worker never loaded `db/index.ts`.

## Fix
Moved `htmlToPlainText` + `decodeHtmlEntities` into a pure, dependency-free module so the worker stops dragging in the electron/sqlite dependency tree at load time.

## Changes
- Added `src/main/util/html-to-text.ts` with `htmlToPlainText` (+ private `decodeHtmlEntities`).
- Removed the duplicated functions from `src/main/db/index.ts`.
- Updated `src/main/agents/tools/email-tools.ts` and `src/main/agents/tools/analysis-tools.ts` to import from the new module.

## Verification
- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm run test:unit` — 1381 passed ✅
- Rebuilt the worker bundle: no more `@electron-toolkit` / data-dir require at worker load. Remaining `app.isPackaged` references in the worker are only inside `services/logger.ts`'s already-wrapped try/catch fallbacks.

## Test plan
- [ ] In a packaged build (or production-mode dev), trigger a Claude Agent task on an email and confirm it no longer fails with the `isPackaged` error.
- [ ] Confirm `read_email`/`read_thread`/`analyze_email`/`search_gmail` still return plain-text email bodies to agents.
- [ ] Confirm email rendering in the renderer is unchanged (still shows HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
