### PR TITLE
Harden remote email image handling

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -7,7 +7,7 @@
          If you use a custom/self-hosted PostHog host, update these domains too. -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob: https://us-assets.i.posthog.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src * data: blob:; frame-src 'self' blob: data:; connect-src 'self' https://us.i.posthog.com https://eu.i.posthog.com https://us-assets.i.posthog.com https://eu-assets.i.posthog.com https://recorder.us.i.posthog.com https://recorder.eu.i.posthog.com"
+      content="default-src 'self'; script-src 'self' blob: https://us-assets.i.posthog.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; frame-src 'self' blob: data:; connect-src 'self' https://us.i.posthog.com https://eu.i.posthog.com https://us-assets.i.posthog.com https://eu-assets.i.posthog.com https://recorder.us.i.posthog.com https://recorder.eu.i.posthog.com"
     />
     <title>Exo</title>
   </head>

--- a/src/renderer/services/email-body-cache.ts
+++ b/src/renderer/services/email-body-cache.ts
@@ -1,4 +1,5 @@
 import DOMPurify from "dompurify";
+import { replaceRemoteImageSources } from "../../shared/email-image-privacy";
 
 /**
  * Checks if content appears to be HTML.
@@ -356,7 +357,8 @@ class EmailBodyCache {
 
     const needsPreLine = isPlainTextInHtml(stripped);
     const clean = DOMPurify.sanitize(stripped, SANITIZE_CONFIG);
-    const htmlContent = buildIframeHtml(clean, useLightMode, needsPreLine);
+    const privacySafe = replaceRemoteImageSources(clean, useLightMode);
+    const htmlContent = buildIframeHtml(privacySafe, useLightMode, needsPreLine);
 
     return { isHtml: true, htmlContent };
   }

--- a/src/shared/email-image-privacy.ts
+++ b/src/shared/email-image-privacy.ts
@@ -81,6 +81,7 @@ export function replaceRemoteImageSources(html: string, useLightMode: boolean): 
         /(\bsrc\s*=\s*["'])https?:\/\/[^"']+(["'])/i,
         `$1${placeholderSrc}$2`,
       );
+      replaced = replaced.replace(/\s+\bsrcset\s*=\s*(["'])[^"']*\1/i, "");
 
       const missingAttrs: string[] = [];
       if (!/\balt\s*=/.test(replaced)) {

--- a/src/shared/email-image-privacy.ts
+++ b/src/shared/email-image-privacy.ts
@@ -1,0 +1,99 @@
+const TRACKING_PIXEL_MAX_SIZE = 4;
+const DEFAULT_PLACEHOLDER_WIDTH = 320;
+const DEFAULT_PLACEHOLDER_HEIGHT = 72;
+const MAX_PLACEHOLDER_WIDTH = 640;
+const MAX_PLACEHOLDER_HEIGHT = 240;
+
+function extractNumericAttribute(tag: string, attr: "width" | "height"): number | null {
+  const attrMatch = tag.match(new RegExp(`\\b${attr}\\s*=\\s*["']?(\\d+)(?:px)?["']?`, "i"));
+  if (attrMatch) return Number(attrMatch[1]);
+
+  const styleMatch = tag.match(/\bstyle\s*=\s*["']([^"']+)["']/i);
+  if (!styleMatch) return null;
+
+  const styleValue = styleMatch[1];
+  const cssMatch = styleValue.match(new RegExp(`${attr}\\s*:\\s*(\\d+)(?:px)?`, "i"));
+  return cssMatch ? Number(cssMatch[1]) : null;
+}
+
+function clampDimension(value: number | null, fallback: number, max: number): number {
+  if (!value || Number.isNaN(value) || value <= 0) return fallback;
+  return Math.min(value, max);
+}
+
+function isLikelyTrackingPixel(tag: string): boolean {
+  const width = extractNumericAttribute(tag, "width");
+  const height = extractNumericAttribute(tag, "height");
+  return (
+    width !== null &&
+    height !== null &&
+    width <= TRACKING_PIXEL_MAX_SIZE &&
+    height <= TRACKING_PIXEL_MAX_SIZE
+  );
+}
+
+function buildPrivacyPlaceholderDataUri(
+  width: number,
+  height: number,
+  useLightMode: boolean,
+): string {
+  const fill = useLightMode ? "#f9fafb" : "#1f2937";
+  const stroke = useLightMode ? "#d1d5db" : "#4b5563";
+  const text = useLightMode ? "#6b7280" : "#9ca3af";
+  const safeWidth = Math.max(width, 160);
+  const safeHeight = Math.max(height, 48);
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${safeWidth}" height="${safeHeight}" viewBox="0 0 ${safeWidth} ${safeHeight}">` +
+    `<rect width="${safeWidth}" height="${safeHeight}" rx="8" fill="${fill}" stroke="${stroke}"/>` +
+    `<text x="${safeWidth / 2}" y="${Math.round(safeHeight / 2) + 5}" text-anchor="middle" fill="${text}" font-family="system-ui" font-size="13">` +
+    `Remote image blocked for privacy` +
+    `</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Replace remote <img src="https://..."> loads with a local placeholder.
+ * Tiny tracking pixels are removed outright.
+ */
+export function replaceRemoteImageSources(html: string, useLightMode: boolean): string {
+  if (!html.includes("<img")) return html;
+
+  return html.replace(
+    /<img\b[^>]*\bsrc\s*=\s*(["'])(https?:\/\/[^"']+)\1[^>]*>/gi,
+    (fullTag: string) => {
+      if (isLikelyTrackingPixel(fullTag)) {
+        return "";
+      }
+
+      const width = clampDimension(
+        extractNumericAttribute(fullTag, "width"),
+        DEFAULT_PLACEHOLDER_WIDTH,
+        MAX_PLACEHOLDER_WIDTH,
+      );
+      const height = clampDimension(
+        extractNumericAttribute(fullTag, "height"),
+        DEFAULT_PLACEHOLDER_HEIGHT,
+        MAX_PLACEHOLDER_HEIGHT,
+      );
+      const placeholderSrc = buildPrivacyPlaceholderDataUri(width, height, useLightMode);
+
+      let replaced = fullTag.replace(
+        /(\bsrc\s*=\s*["'])https?:\/\/[^"']+(["'])/i,
+        `$1${placeholderSrc}$2`,
+      );
+
+      const missingAttrs: string[] = [];
+      if (!/\balt\s*=/.test(replaced)) {
+        missingAttrs.push('alt="Remote image blocked for privacy"');
+      }
+      if (!/\btitle\s*=/.test(replaced)) {
+        missingAttrs.push('title="Remote image blocked for privacy"');
+      }
+      if (missingAttrs.length > 0) {
+        replaced = replaced.replace(/<img\b/i, `<img ${missingAttrs.join(" ")}`);
+      }
+
+      return replaced;
+    },
+  );
+}

--- a/tests/e2e/inline-images.spec.ts
+++ b/tests/e2e/inline-images.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page, ElectronApplication } from "@playwright/test";
 import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
-import { launchElectronApp, takeScreenshot , closeApp } from "./launch-helpers";
+import { launchElectronApp, takeScreenshot, closeApp } from "./launch-helpers";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -88,12 +88,12 @@ test.describe("Inline Images - Reading", () => {
     );
   });
 
-  test("rich HTML email with external image also displays", async () => {
+  test("rich HTML email replaces external images with privacy placeholders", async () => {
     // Navigate back to inbox (press Escape to deselect current email)
     await page.keyboard.press("Escape");
     await page.waitForTimeout(500);
 
-    // Click the Q3 report email which has an external image (https://via.placeholder.com)
+    // Click the Q3 report email which contains a remote image in the HTML body
     const emailItem = page
       .locator("button")
       .filter({ hasText: /Garry|Q3 Quarterly/i })
@@ -108,17 +108,24 @@ test.describe("Inline Images - Reading", () => {
     const frame = iframe.contentFrame();
     expect(frame).not.toBeNull();
 
-    // This email has the TechCorp logo image
+    // The remote image should be replaced with a local placeholder
     const images = frame!.locator("img");
     const imgCount = await images.count();
     console.log(`Found ${imgCount} images in the Q3 report email`);
     expect(imgCount).toBeGreaterThanOrEqual(1);
 
+    const src = await images.first().getAttribute("src");
+    expect(src).toBeTruthy();
+    expect(src!.startsWith("data:image/")).toBe(true);
+
+    const title = await images.first().getAttribute("title");
+    expect(title).toContain("Remote image blocked for privacy");
+
     await takeScreenshot(
       electronApp,
       page,
-      "inline-images-external",
-      "Email with external image (TechCorp logo)",
+      "inline-images-external-blocked",
+      "Email with external image replaced by a privacy placeholder",
     );
   });
 });

--- a/tests/unit/email-image-privacy.spec.ts
+++ b/tests/unit/email-image-privacy.spec.ts
@@ -29,4 +29,15 @@ test.describe("replaceRemoteImageSources", () => {
 
     expect(output).toBe(input);
   });
+
+  test("removes remote srcset when replacing a remote image", () => {
+    const input =
+      '<img src="https://cdn.example.com/photo.jpg" srcset="https://cdn.example.com/photo@2x.jpg 2x" width="200">';
+    const output = replaceRemoteImageSources(input, true);
+
+    expect(output).not.toContain("https://cdn.example.com/photo.jpg");
+    expect(output).not.toContain("https://cdn.example.com/photo@2x.jpg");
+    expect(output).not.toContain("srcset=");
+    expect(output).toContain("data:image/svg+xml,");
+  });
 });

--- a/tests/unit/email-image-privacy.spec.ts
+++ b/tests/unit/email-image-privacy.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { replaceRemoteImageSources } from "../../src/shared/email-image-privacy";
+
+test.describe("replaceRemoteImageSources", () => {
+  test("replaces remote image URLs with local privacy placeholders", () => {
+    const input =
+      '<div><img src="https://tracker.example.com/logo.png" width="120" height="40"></div>';
+    const output = replaceRemoteImageSources(input, true);
+
+    expect(output).not.toContain("https://tracker.example.com/logo.png");
+    expect(output).toContain("data:image/svg+xml,");
+    expect(output).toContain('alt="Remote image blocked for privacy"');
+    expect(output).toContain('title="Remote image blocked for privacy"');
+  });
+
+  test("removes likely tracking pixels entirely", () => {
+    const input =
+      '<div>Hello</div><img src="https://tracker.example.com/open.gif" width="1" height="1">';
+    const output = replaceRemoteImageSources(input, true);
+
+    expect(output).not.toContain("<img");
+    expect(output).toContain("<div>Hello</div>");
+  });
+
+  test("leaves local and inline image sources untouched", () => {
+    const input =
+      '<img src="data:image/png;base64,abc"><img src="cid:image001@domain"><img src="/local.png">';
+    const output = replaceRemoteImageSources(input, false);
+
+    expect(output).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- split the remote image privacy work out of #92 into a focused PR
- block external email image loads by replacing remote image URLs with local privacy placeholders
- strip remote `srcset` candidates as part of the same replacement so the placeholder renders consistently

## Changes
- add `replaceRemoteImageSources` in the shared email image privacy helper
- tighten renderer email image handling to use privacy placeholders for remote images while preserving inline and local sources
- add unit coverage for placeholder replacement, tracking pixel removal, and `srcset` stripping
- keep the existing inline image e2e coverage aligned with the privacy behavior

## Tests
- `npx tsc --noEmit`
- `npm run test:unit`

Split from #92.