### PR TITLE
fix: preserve display name when adding recipient via +mention

### DIFF
--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -36,7 +36,7 @@ interface ComposeEditorProps {
   className?: string;
   autoFocus?: boolean;
   /** Called when a contact is selected via @mention or +mention in the body */
-  onAddToCc?: (email: string) => void;
+  onAddToCc?: (email: string, name?: string) => void;
   /** Recipient email for snippet variable resolution */
   recipientEmail?: string;
 }
@@ -692,7 +692,7 @@ export function ComposeEditor({
     currentAccountRecord?.displayName || currentAccountRecord?.email?.split("@")[0];
 
   // Ref keeps the latest onAddToCc without recreating extensions
-  const onAddToCcRef = useRef<((email: string) => void) | null>(onAddToCc ?? null);
+  const onAddToCcRef = useRef<((email: string, name?: string) => void) | null>(onAddToCc ?? null);
   useEffect(() => {
     onAddToCcRef.current = onAddToCc ?? null;
   }, [onAddToCc]);

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1177,8 +1177,8 @@ function InlineReply({
 
   // When @mention adds to Cc, also reveal address fields
   const handleMentionAddToCc = useCallback(
-    (email: string) => {
-      form.handleMentionAddToCc(email);
+    (email: string, name?: string) => {
+      form.handleMentionAddToCc(email, name);
       setShowAddressFields(true);
     },
     [form.handleMentionAddToCc],

--- a/src/renderer/components/MentionSuggestion.tsx
+++ b/src/renderer/components/MentionSuggestion.tsx
@@ -148,7 +148,7 @@ function createSuggestionRender() {
 function createSuggestionConfig(
   char: string,
   pluginKey: PluginKey,
-  onAddToCcRef: React.RefObject<((email: string) => void) | null>,
+  onAddToCcRef: React.RefObject<((email: string, name?: string) => void) | null>,
 ): Omit<SuggestionOptions<ContactSuggestion>, "editor"> {
   return {
     char,
@@ -178,7 +178,7 @@ function createSuggestionConfig(
         .insertContent(firstName + " ")
         .run();
       // Side effect: add to CC
-      onAddToCcRef.current?.(item.email);
+      onAddToCcRef.current?.(item.email, item.name);
     },
 
     render: createSuggestionRender(),
@@ -191,7 +191,7 @@ const atPluginKey = new PluginKey("contactMentionAt");
 const plusPluginKey = new PluginKey("contactMentionPlus");
 
 interface ContactMentionOptions {
-  onAddToCcRef: React.RefObject<((email: string) => void) | null>;
+  onAddToCcRef: React.RefObject<((email: string, name?: string) => void) | null>;
 }
 
 /**

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -283,11 +283,18 @@ export function useComposeForm({
   }, []);
 
   // --- @mention → add to Cc ---
-  const handleMentionAddToCc = useCallback((email: string) => {
+  const handleMentionAddToCc = useCallback((email: string, name?: string) => {
     setCc((prev) => {
       if (prev.some((e) => e.toLowerCase() === email.toLowerCase())) return prev;
       return [...prev, email];
     });
+    if (name) {
+      setNameMap((prev) => {
+        const key = email.toLowerCase();
+        if (prev.get(key) === name) return prev;
+        return new Map(prev).set(key, name);
+      });
+    }
     setShowCcBcc(true);
   }, []);
 

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -288,11 +288,12 @@ export function useComposeForm({
       if (prev.some((e) => e.toLowerCase() === email.toLowerCase())) return prev;
       return [...prev, email];
     });
-    if (name) {
+    const trimmedName = name?.trim();
+    if (trimmedName) {
       setNameMap((prev) => {
         const key = email.toLowerCase();
-        if (prev.get(key) === name) return prev;
-        return new Map(prev).set(key, name);
+        if (prev.get(key) === trimmedName) return prev;
+        return new Map(prev).set(key, trimmedName);
       });
     }
     setShowCcBcc(true);

--- a/tests/e2e/body-mention-cc.spec.ts
+++ b/tests/e2e/body-mention-cc.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, Page, ElectronApplication } from "@playwright/test";
+import { launchElectronApp, closeApp } from "./launch-helpers";
+
+/**
+ * E2E tests for +mention / @mention inside the ProseMirror compose body.
+ *
+ * The mention callback adds the selected contact to Cc and — critically —
+ * populates nameMap so the chip renders the display name instead of the bare
+ * email. On send, nameMap becomes `recipientNames` and is used by
+ * formatAddressesWithNames to produce "Name <email>" MIME headers.
+ *
+ * Demo contacts (src/main/ipc/search.ipc.ts): Alice Johnson, Bob Smith.
+ */
+
+let electronApp: ElectronApplication;
+let page: Page;
+
+test.describe("Body +mention / @mention → Cc with display name", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(async ({}, testInfo) => {
+    const result = await launchElectronApp({ workerIndex: testInfo.workerIndex });
+    electronApp = result.app;
+    page = result.page;
+
+    page.on("console", (msg) => {
+      if (msg.type() === "error") console.error(`[Console Error]: ${msg.text()}`);
+    });
+  });
+
+  test.afterAll(async () => {
+    if (electronApp) await closeApp(electronApp);
+  });
+
+  async function openCompose() {
+    await page.locator("button:has-text('Compose')").click();
+    await expect(page.locator("text=New Message")).toBeVisible({ timeout: 5000 });
+  }
+
+  async function closeCompose() {
+    const discard = page.locator("button[title='Discard draft']");
+    if (await discard.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await discard.click();
+      await page.waitForTimeout(300);
+    }
+  }
+
+  test("+mention adds contact to Cc with display name in chip", async () => {
+    await openCompose();
+
+    const editor = page.locator(".ProseMirror").first();
+    await editor.click();
+    await editor.pressSequentially("+bob", { delay: 50 });
+
+    // Dropdown appears with Bob Smith
+    const dropdown = page.locator("[data-testid='mention-dropdown']");
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
+    await expect(dropdown.locator("text=Bob Smith")).toBeVisible();
+
+    // Confirm selection
+    await editor.press("Enter");
+    await expect(dropdown).not.toBeVisible({ timeout: 2000 });
+
+    // Cc field reveals with Bob's chip showing his NAME (not the bare email)
+    const ccChip = page
+      .locator("[data-testid='address-input-cc'] [data-testid='address-chip']")
+      .first();
+    await expect(ccChip).toBeVisible({ timeout: 2000 });
+    await expect(ccChip).toHaveText("Bob Smith");
+    await expect(ccChip).not.toContainText("bob@example.com");
+
+    await closeCompose();
+  });
+
+  test("@mention also populates nameMap (not just +)", async () => {
+    await openCompose();
+
+    const editor = page.locator(".ProseMirror").first();
+    await editor.click();
+    await editor.pressSequentially("@ali", { delay: 50 });
+
+    const dropdown = page.locator("[data-testid='mention-dropdown']");
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
+    await expect(dropdown.locator("text=Alice Johnson")).toBeVisible();
+
+    await editor.press("Enter");
+    await expect(dropdown).not.toBeVisible({ timeout: 2000 });
+
+    const ccChip = page
+      .locator("[data-testid='address-input-cc'] [data-testid='address-chip']")
+      .first();
+    await expect(ccChip).toBeVisible({ timeout: 2000 });
+    await expect(ccChip).toHaveText("Alice Johnson");
+
+    await closeCompose();
+  });
+
+});


### PR DESCRIPTION
## Summary

When typing `+Kelley` (or `@Kelley`) in the compose editor to inline-add a recipient, the outgoing email was addressed to the bare email only (e.g. `kelley@example.com`) instead of `"Kelley Smith" <kelley@example.com>`.

## Root cause

The mention pipeline resolves contacts with both `name` and `email`, but the `command` callback in `MentionSuggestion.tsx` only passed the email back to the compose form. The compose form maintains a `nameMap` that gets serialized as `recipientNames` on send — `formatAddressesWithNames` uses this to produce RFC-compliant `"Name" <email>` MIME headers. Because `nameMap` was never populated for mention-added recipients, they went out as bare emails.

## Changes

- `MentionSuggestion.tsx` — callback signature now `(email, name?) => void`; passes `item.name` from the resolved contact.
- `ComposeEditor.tsx` — `onAddToCc` prop and internal ref type updated to match.
- `useComposeForm.ts` — `handleMentionAddToCc` now writes `name` into `nameMap` when present, guarded against redundant state updates.
- `EmailDetail.tsx` — pass-through wrapper forwards `name`.

## Test plan

- [ ] In a reply, type `+` and pick a contact from suggestions — verify Cc chip appears and the sent email's Cc header is `"Name" <email>`, not just `email`.
- [ ] Same with `@` trigger.
- [ ] Pick a contact that has no stored `name` — verify it still works (just adds the email, no regression).
- [ ] Re-pick the same contact — verify no redundant state churn (`nameMap` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
