### PR TITLE
fix: include account display name in From when send-as alias has none

### DIFF
--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1663,6 +1663,7 @@ function InlineReply({
                   aliases={form.sendAsAliases}
                   selected={form.from}
                   onChange={form.setFrom}
+                  fallbackDisplayName={form.accountDisplayName}
                 />
               </div>
             )}
@@ -2149,6 +2150,7 @@ function NewEmailCompose({
                 aliases={form.sendAsAliases}
                 selected={form.from}
                 onChange={form.setFrom}
+                fallbackDisplayName={form.accountDisplayName}
               />
             </>
           )}

--- a/src/renderer/components/FromSelector.tsx
+++ b/src/renderer/components/FromSelector.tsx
@@ -1,9 +1,15 @@
 import { useState, useRef, useEffect } from "react";
 import type { SendAsAlias } from "../../shared/types";
 
-/** Format an alias as "Display Name <email>" or just "email" */
-function formatAlias(alias: SendAsAlias): string {
-  return alias.displayName ? `${alias.displayName} <${alias.email}>` : alias.email;
+/**
+ * Format an alias as "Display Name <email>" or just "email".
+ * Falls back to `fallbackName` when the alias has no display name configured —
+ * common for Workspace primary aliases where the name is set via OAuth profile,
+ * not Gmail send-as settings.
+ */
+export function formatAlias(alias: SendAsAlias, fallbackName?: string): string {
+  const name = alias.displayName || fallbackName;
+  return name ? `${name} <${alias.email}>` : alias.email;
 }
 
 /** Extract bare email from a potentially formatted "Name <email>" address. */
@@ -16,6 +22,8 @@ interface FromSelectorProps {
   aliases: SendAsAlias[];
   selected: string | undefined;
   onChange: (formatted: string) => void;
+  /** Used as the display-name fallback when an alias has none of its own. */
+  fallbackDisplayName?: string;
 }
 
 /**
@@ -23,7 +31,12 @@ interface FromSelectorProps {
  * Only renders when the account has 2+ aliases.
  * Uses a custom popover instead of native <select> to avoid OS chrome.
  */
-export function FromSelector({ aliases, selected, onChange }: FromSelectorProps) {
+export function FromSelector({
+  aliases,
+  selected,
+  onChange,
+  fallbackDisplayName,
+}: FromSelectorProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -67,7 +80,7 @@ export function FromSelector({ aliases, selected, onChange }: FromSelectorProps)
               key={alias.email}
               type="button"
               onClick={() => {
-                onChange(formatAlias(alias));
+                onChange(formatAlias(alias, fallbackDisplayName));
                 setOpen(false);
               }}
               className={`w-full text-left px-3 py-1.5 text-sm truncate transition-colors ${
@@ -76,7 +89,7 @@ export function FromSelector({ aliases, selected, onChange }: FromSelectorProps)
                   : "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700/50"
               }`}
             >
-              {alias.displayName ? `${alias.displayName} <${alias.email}>` : alias.email}
+              {formatAlias(alias, fallbackDisplayName)}
             </button>
           ))}
         </div>

--- a/src/renderer/components/FromSelector.tsx
+++ b/src/renderer/components/FromSelector.tsx
@@ -1,16 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import type { SendAsAlias } from "../../shared/types";
-
-/**
- * Format an alias as "Display Name <email>" or just "email".
- * Falls back to `fallbackName` when the alias has no display name configured —
- * common for Workspace primary aliases where the name is set via OAuth profile,
- * not Gmail send-as settings.
- */
-export function formatAlias(alias: SendAsAlias, fallbackName?: string): string {
-  const name = alias.displayName || fallbackName;
-  return name ? `${name} <${alias.email}>` : alias.email;
-}
+import { formatAlias } from "../utils/alias-formatting";
 
 /** Extract bare email from a potentially formatted "Name <email>" address. */
 function extractEmail(addr: string): string {

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { useAppStore } from "../store";
 import { useSignature } from "./useSignature";
+import { formatAlias } from "../components/FromSelector";
 import type { ComposeAttachmentItem } from "../components/AttachmentList";
 import type {
   ReplyInfo,
@@ -135,6 +136,12 @@ export function useComposeForm({
   const [sendAsAliases, setSendAsAliases] = useState<SendAsAlias[]>([]);
   const [from, setFrom] = useState<string | undefined>(undefined);
 
+  // Account display name acts as the fallback for aliases without their own
+  // (common for Workspace primaries, where the name lives on the OAuth profile).
+  const accountDisplayName = useAppStore(
+    (state) => state.accounts.find((a) => a.id === accountId)?.displayName,
+  );
+
   // Fetch aliases on mount
   useEffect(() => {
     if (typeof window.api.compose.getSendAsAliases !== "function") return;
@@ -169,11 +176,7 @@ export function useComposeForm({
               allRecipients.includes(a.email.toLowerCase()),
             );
             if (matchingAlias) {
-              setFrom(
-                matchingAlias.displayName
-                  ? `${matchingAlias.displayName} <${matchingAlias.email}>`
-                  : matchingAlias.email,
-              );
+              setFrom(formatAlias(matchingAlias, accountDisplayName));
               return;
             }
           }
@@ -181,18 +184,14 @@ export function useComposeForm({
           // Default to the default alias
           const defaultAlias = result.data.find((a) => a.isDefault);
           if (defaultAlias) {
-            setFrom(
-              defaultAlias.displayName
-                ? `${defaultAlias.displayName} <${defaultAlias.email}>`
-                : defaultAlias.email,
-            );
+            setFrom(formatAlias(defaultAlias, accountDisplayName));
           }
         }
       })
       .catch(() => {
         // Silently fail — compose still works without aliases
       });
-  }, [accountId]);
+  }, [accountId, accountDisplayName]);
 
   // --- Send state ---
   const [isSending, setIsSending] = useState(false);
@@ -492,6 +491,7 @@ export function useComposeForm({
     sendAsAliases,
     from,
     setFrom,
+    accountDisplayName,
 
     // Content state
     subject,

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { useAppStore } from "../store";
 import { useSignature } from "./useSignature";
-import { formatAlias } from "../components/FromSelector";
+import { formatAlias } from "../utils/alias-formatting";
 import type { ComposeAttachmentItem } from "../components/AttachmentList";
 import type {
   ReplyInfo,
@@ -138,11 +138,15 @@ export function useComposeForm({
 
   // Account display name acts as the fallback for aliases without their own
   // (common for Workspace primaries, where the name lives on the OAuth profile).
+  // Subscribed so the FromSelector dropdown labels stay current.
   const accountDisplayName = useAppStore(
     (state) => state.accounts.find((a) => a.id === accountId)?.displayName,
   );
 
-  // Fetch aliases on mount
+  // Fetch aliases on mount.
+  // accountDisplayName is intentionally NOT a dependency: re-running this
+  // effect would clobber a manual alias selection. We read the latest value
+  // via getState() inside the effect instead.
   useEffect(() => {
     if (typeof window.api.compose.getSendAsAliases !== "function") return;
 
@@ -150,6 +154,10 @@ export function useComposeForm({
       .then((result) => {
         if (result.success && result.data.length > 0) {
           setSendAsAliases(result.data);
+
+          const fallbackName = useAppStore
+            .getState()
+            .accounts.find((a) => a.id === accountId)?.displayName;
 
           // Smart reply default: auto-select the alias that the original email was sent to.
           // replyInfo.to/cc only has the REPLY addresses (original sender for plain reply),
@@ -176,7 +184,7 @@ export function useComposeForm({
               allRecipients.includes(a.email.toLowerCase()),
             );
             if (matchingAlias) {
-              setFrom(formatAlias(matchingAlias, accountDisplayName));
+              setFrom(formatAlias(matchingAlias, fallbackName));
               return;
             }
           }
@@ -184,14 +192,14 @@ export function useComposeForm({
           // Default to the default alias
           const defaultAlias = result.data.find((a) => a.isDefault);
           if (defaultAlias) {
-            setFrom(formatAlias(defaultAlias, accountDisplayName));
+            setFrom(formatAlias(defaultAlias, fallbackName));
           }
         }
       })
       .catch(() => {
         // Silently fail — compose still works without aliases
       });
-  }, [accountId, accountDisplayName]);
+  }, [accountId]);
 
   // --- Send state ---
   const [isSending, setIsSending] = useState(false);

--- a/src/renderer/utils/alias-formatting.ts
+++ b/src/renderer/utils/alias-formatting.ts
@@ -2,11 +2,15 @@ import type { SendAsAlias } from "../../shared/types";
 
 /**
  * Format an alias as "Display Name <email>" or just "email".
- * Falls back to `fallbackName` when the alias has no display name configured —
- * common for Workspace primary aliases where the name is set via OAuth profile,
- * not Gmail send-as settings.
+ *
+ * Falls back to `fallbackName` (the account's OAuth display name) only for the
+ * primary/default alias. That's where the name lives on the OAuth profile
+ * rather than in Gmail's send-as settings, which is common for Workspace
+ * accounts. Secondary aliases without a display name are left bare on
+ * purpose — they may be shared mailboxes (support@, team@) where the account
+ * holder's personal name would be wrong.
  */
 export function formatAlias(alias: SendAsAlias, fallbackName?: string): string {
-  const name = alias.displayName || fallbackName;
+  const name = alias.displayName || (alias.isDefault ? fallbackName : undefined);
   return name ? `${name} <${alias.email}>` : alias.email;
 }

--- a/src/renderer/utils/alias-formatting.ts
+++ b/src/renderer/utils/alias-formatting.ts
@@ -1,0 +1,12 @@
+import type { SendAsAlias } from "../../shared/types";
+
+/**
+ * Format an alias as "Display Name <email>" or just "email".
+ * Falls back to `fallbackName` when the alias has no display name configured —
+ * common for Workspace primary aliases where the name is set via OAuth profile,
+ * not Gmail send-as settings.
+ */
+export function formatAlias(alias: SendAsAlias, fallbackName?: string): string {
+  const name = alias.displayName || fallbackName;
+  return name ? `${name} <${alias.email}>` : alias.email;
+}


### PR DESCRIPTION
## Summary

When sending mail from a Gmail account whose primary send-as alias has no display name configured (common for Workspace accounts where the name lives on the OAuth profile rather than in Gmail's send-as settings), outgoing messages were going out with a bare email in the From header — e.g. `ankit@ycombinator.com` instead of `Ankit Gupta <ankit@ycombinator.com>`.

## Root cause

`useComposeForm.ts` formatted the chosen alias as `displayName ? "Name <email>" : email` and passed that as `options.from` into the IPC. The backend's `GmailClient.sendMessage` does `options.from || this.getSenderAddress(...)`, so the bare-email From short-circuited the `accounts.display_name` fallback that already lives in `getSenderAddress`.

The `accounts.display_name` was correctly populated (`fetchDisplayName` already chains send-as → People API → OAuth userinfo), but the per-alias row stored what Gmail returned, which for the user's primary Workspace alias is empty.

## Changes

- `FromSelector.tsx` — exported `formatAlias(alias, fallback?)`, added a `fallbackDisplayName` prop, routed both rendered alias labels through the helper.
- `useComposeForm.ts` — pulled the current account's `displayName` from the store and passes it as the fallback in both the smart-reply-match and default-alias paths; also exposes `accountDisplayName` from the hook.
- `EmailDetail.tsx` — passed `fallbackDisplayName={form.accountDisplayName}` to both `<FromSelector>` instances.

## Test plan

- [ ] Compose a new email from `ankit@ycombinator.com` (account whose alias has empty Gmail display name) — From header should be `"Ankit Gupta" <ankit@ycombinator.com>`.
- [ ] Reply to a thread on a different alias whose Gmail display name *is* set — that name still wins (per-alias name takes priority over fallback).
- [ ] Open the FromSelector dropdown for a multi-alias account — labels for nameless aliases now show the account name.
- [ ] Compose from an account whose `accounts.display_name` is also null — From cleanly degrades to bare email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
