### PR TITLE
fix: report EmailDetail render crashes and fix silent logger fallback

### DIFF
--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -133,12 +133,13 @@ export function getActiveLogPath(): string | null {
 // users always have *some* log file to attach to bug reports.
 function resolveWritableLogDir(): string {
   const primary = getLogDir();
+  const probe = join(primary, ".write-probe");
   try {
     mkdirSync(primary, { recursive: true });
-    const probe = join(primary, ".write-probe");
+    // Writability is determined by writeFileSync — once it succeeds the dir is
+    // good. Probe cleanup happens in the finally block so a failing unlink
+    // (e.g. EPERM) does not trigger a false-positive fallback.
     writeFileSync(probe, "");
-    unlinkSync(probe);
-    return primary;
   } catch (primaryErr) {
     const fallback = join(tmpdir(), "exo-logs");
     // eslint-disable-next-line no-console
@@ -154,7 +155,16 @@ function resolveWritableLogDir(): string {
       console.error(`[logger] Fallback log dir also failed (${fallback}):`, fallbackErr);
     }
     return fallback;
+  } finally {
+    // Best-effort probe cleanup. If unlink fails the orphaned empty file is
+    // harmless — cleanOldLogs only touches *.log entries.
+    try {
+      unlinkSync(probe);
+    } catch {
+      /* best effort */
+    }
   }
+  return primary;
 }
 
 function initLogger(): Logger {

--- a/src/main/services/logger.ts
+++ b/src/main/services/logger.ts
@@ -12,9 +12,17 @@
 import pino, { type Logger, multistream } from "pino";
 import { type SonicBoom } from "sonic-boom";
 import { join } from "path";
-import { mkdirSync, readdirSync, unlinkSync, statSync } from "fs";
+import { mkdirSync, readdirSync, unlinkSync, statSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { Writable } from "stream";
+import { createRequire } from "module";
+
+// This file uses CommonJS `require` to defer-load Electron so it can be
+// imported in non-Electron test contexts. In ESM mode `require` is undefined
+// unless we synthesize it via createRequire — without this, every Electron
+// access fell to the catch and the logger silently used tmpdir for both dev
+// and packaged builds.
+const requireFromHere = createRequire(import.meta.url);
 
 /**
  * Wraps a SonicBoom destination so that writes to a destroyed stream are
@@ -64,8 +72,7 @@ function getLogDir(): string {
     // Resolve the data directory inline to avoid a circular dependency
     // with data-dir.ts (which imports createLogger at module scope).
     // NOTE: Keep this path logic in sync with getDataDir() in data-dir.ts.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { app } = require("electron");
+    const { app } = requireFromHere("electron");
     // Use app.isPackaged directly — the previous isDev() wrapper used
     // require("@electron-toolkit/utils") which could fail and fall back
     // to NODE_ENV checks that incorrectly returned true in packaged apps.
@@ -79,8 +86,7 @@ function getLogDir(): string {
 
 function isDev(): boolean {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { app } = require("electron");
+    const { app } = requireFromHere("electron");
     return !app.isPackaged;
   } catch {
     return process.env.NODE_ENV !== "production";
@@ -112,21 +118,58 @@ let _logger: Logger | null = null;
 // SonicBoom (returned by pino.destination()) does.
 let _destinations: SonicBoom[] = [];
 
-function initLogger(): Logger {
-  const logDir = getLogDir();
+// Once resolved at init, callers (and IPC consumers) can read this to find logs.
+let _activeLogPath: string | null = null;
+
+export function getActiveLogPath(): string | null {
+  return _activeLogPath;
+}
+
+// Validates writability by probing the directory with a synchronous write.
+// pino's SonicBoom opens the destination asynchronously and surfaces fd
+// failures via an 'error' event that we silently swallow (issue #97). Without
+// this probe, a logger that has been completely dead for weeks looks identical
+// to a healthy one. If the primary dir is unwritable, fall back to tmpdir so
+// users always have *some* log file to attach to bug reports.
+function resolveWritableLogDir(): string {
+  const primary = getLogDir();
   try {
-    mkdirSync(logDir, { recursive: true });
-  } catch (e) {
-    // Don't silently swallow — leave a breadcrumb so we can debug startup
-    // failures like the fd=-1 crash in issue #97.
+    mkdirSync(primary, { recursive: true });
+    const probe = join(primary, ".write-probe");
+    writeFileSync(probe, "");
+    unlinkSync(probe);
+    return primary;
+  } catch (primaryErr) {
+    const fallback = join(tmpdir(), "exo-logs");
     // eslint-disable-next-line no-console
-    console.error("[logger] Failed to create log directory:", logDir, e);
+    console.error(
+      `[logger] Primary log dir is not writable (${primary}): ${
+        primaryErr instanceof Error ? primaryErr.message : String(primaryErr)
+      }. Falling back to ${fallback}`,
+    );
+    try {
+      mkdirSync(fallback, { recursive: true });
+    } catch (fallbackErr) {
+      // eslint-disable-next-line no-console
+      console.error(`[logger] Fallback log dir also failed (${fallback}):`, fallbackErr);
+    }
+    return fallback;
   }
+}
+
+function initLogger(): Logger {
+  const logDir = resolveWritableLogDir();
 
   cleanOldLogs(logDir);
 
   const today = new Date().toISOString().split("T")[0];
   const logFile = join(logDir, `${today}.log`);
+  _activeLogPath = logFile;
+  // Print to stderr so the path is visible in the dev terminal and in any
+  // captured stderr from packaged launches. Without this we have no way to
+  // tell where logs are actually going if the primary dir falls through.
+  // eslint-disable-next-line no-console
+  console.error(`[logger] Writing logs to ${logFile}`);
   const dev = isDev();
 
   // pino.destination() returns SonicBoom at runtime but is typed as DestinationStream.
@@ -154,8 +197,7 @@ function initLogger(): Logger {
   if (dev) {
     // In dev, also write pretty output to stdout
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const pinoPretty = require("pino-pretty");
+      const pinoPretty = requireFromHere("pino-pretty");
       const prettyStream = pinoPretty({ colorize: true });
       prettyStream.on("error", (err: Error) => {
         // eslint-disable-next-line no-console

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -33,7 +33,7 @@ import { THREAD_NAV_EVENT } from "../hooks/useKeyboardShortcuts";
 import type { ComposeFormState } from "../hooks/useComposeForm";
 import { ComposeToolbar } from "./ComposeToolbar";
 import { FromSelector } from "./FromSelector";
-import { trackEvent } from "../services/posthog";
+import { trackEvent, captureException } from "../services/posthog";
 import { draftBodyToHtml } from "../../shared/draft-utils";
 import { AnalysisPrioritySection } from "./AnalysisPrioritySection";
 
@@ -2227,8 +2227,18 @@ class EmailDetailErrorBoundary extends React.Component<
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error) {
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error("[EmailDetail] Render crash caught by error boundary:", error.message);
+    const { selectedEmailId, selectedThreadId, currentAccountId, currentSplitId } =
+      useAppStore.getState();
+    captureException(error, {
+      component: "EmailDetailErrorBoundary",
+      componentStack: errorInfo.componentStack,
+      selectedEmailId,
+      selectedThreadId,
+      currentAccountId,
+      currentSplitId,
+    });
     // Clear selection state so the user can recover by clicking another email
     useAppStore.setState({
       isInlineReplyOpen: false,

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -2229,16 +2229,22 @@ class EmailDetailErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error("[EmailDetail] Render crash caught by error boundary:", error.message);
-    const { selectedEmailId, selectedThreadId, currentAccountId, currentSplitId } =
-      useAppStore.getState();
-    captureException(error, {
-      component: "EmailDetailErrorBoundary",
-      componentStack: errorInfo.componentStack,
-      selectedEmailId,
-      selectedThreadId,
-      currentAccountId,
-      currentSplitId,
-    });
+    // Never let exception-reporting throw out of the error handler itself —
+    // React doesn't gracefully handle escapes from componentDidCatch.
+    try {
+      const { selectedEmailId, selectedThreadId, currentAccountId, currentSplitId } =
+        useAppStore.getState();
+      captureException(error, {
+        component: "EmailDetailErrorBoundary",
+        componentStack: errorInfo.componentStack,
+        selectedEmailId,
+        selectedThreadId,
+        currentAccountId,
+        currentSplitId,
+      });
+    } catch (reportErr) {
+      console.error("[EmailDetail] Failed to report error to PostHog:", reportErr);
+    }
     // Clear selection state so the user can recover by clicking another email
     useAppStore.setState({
       isInlineReplyOpen: false,


### PR DESCRIPTION
## Summary

Two diagnostic fixes that came out of investigating a user report ("Something went wrong displaying this email" when clicking a draft — no exception in PostHog, no log files on disk):

- **EmailDetail error boundary now reports to PostHog.** `componentDidCatch` was only calling `console.error`, so render crashes never surfaced anywhere we could see. It now calls `captureException` with `componentStack` and the relevant selection state (`selectedEmailId`, `selectedThreadId`, `currentAccountId`, `currentSplitId`).
- **Logger no longer silently falls back to tmpdir.** `getLogDir()` used `require("electron")`, which is undefined in this ESM project — every Electron access threw, the catch ran, and the logger silently used `tmpdir()/exo-logs/` for both dev and packaged builds. Nothing was ever written to `.dev-data/logs/` (dev) or `userData/logs/` (packaged) as documented. Bridge via `createRequire(import.meta.url)` so the lookup works. Added a synchronous `writeFileSync` probe + tmpdir fallback so a future regression is loud, plus `getActiveLogPath()` and a `[logger] Writing logs to <path>` stderr line at init.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on both files
- [x] `npx prettier --check` clean
- [x] `npm run dev` — verified `.dev-data/logs/2026-05-14.log` is now written (846KB of real pino JSON), stderr prints the resolved log path. Before the fix this dir was empty and logs went to `/var/folders/.../T/exo-logs/`.
- [ ] After merge: next time a user hits the EmailDetail error boundary we should see a `$exception` event in PostHog with full stack + selection context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)