### PR TITLE
fix: sync inline reply editor when agent regenerates draft

### DIFF
--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1085,6 +1085,7 @@ function InlineReply({
   onBccChange,
   restoredDraft,
   draftEmailId,
+  watchedDraftEmailId,
   onDiscardDraft,
   nameMap: externalNameMap,
 }: {
@@ -1102,6 +1103,10 @@ function InlineReply({
   restoredDraft?: RestoredDraft | null;
   /** Email ID that owns the AI-generated draft (for refine/revert). */
   draftEmailId?: string;
+  /** Email ID to watch in the store for externally-saved drafts (e.g. agent regenerate).
+   *  Unlike draftEmailId, this is set even when the draft has status="edited" so that
+   *  the agent's update overrides the user's edits. */
+  watchedDraftEmailId?: string;
   /** Callback to discard the AI draft entirely. */
   onDiscardDraft?: () => void;
   /** Map of lowercase email → display name for rendering name chips */
@@ -1267,6 +1272,34 @@ function InlineReply({
   // is used to push new content into the editor, separate from bodyHtml which tracks
   // the latest editor value)
   const [editorInitialContent, setEditorInitialContent] = useState(restoredDraft?.bodyHtml || "");
+
+  // Watch the store for externally-saved drafts on the watched email (e.g. the agent
+  // regenerating via the right pane). When the draft's createdAt changes, push the new
+  // content into the editor. Without this, the agent updates the DB + Gmail but the
+  // inline reply keeps showing the previous body. Mirrors the watcher in ComposeNewEmail.
+  const externalDraft = useAppStore((s) =>
+    watchedDraftEmailId ? s.emails.find((e) => e.id === watchedDraftEmailId)?.draft : undefined,
+  );
+  const externalDraftCreatedAt = externalDraft?.createdAt;
+  const [lastSeenDraftCreatedAt, setLastSeenDraftCreatedAt] = useState(externalDraftCreatedAt);
+  useEffect(() => {
+    if (!externalDraft?.body) return;
+    if (externalDraftCreatedAt === lastSeenDraftCreatedAt) return;
+    setLastSeenDraftCreatedAt(externalDraftCreatedAt);
+    const newHtml = draftBodyToHtml(externalDraft.body);
+    setEditorInitialContent(newHtml);
+    form.handleEditorChange(newHtml, externalDraft.body);
+    onContentChange?.({ bodyHtml: newHtml, bodyText: externalDraft.body });
+    if (externalDraft.to && JSON.stringify(externalDraft.to) !== JSON.stringify(form.to)) {
+      form.setTo(externalDraft.to);
+    }
+    if (externalDraft.cc && JSON.stringify(externalDraft.cc) !== JSON.stringify(form.cc)) {
+      form.setCc(externalDraft.cc);
+    }
+    if (externalDraft.bcc && JSON.stringify(externalDraft.bcc) !== JSON.stringify(form.bcc)) {
+      form.setBcc(externalDraft.bcc);
+    }
+  }, [externalDraftCreatedAt]);
 
   const handleRefine = useCallback(async () => {
     if (!refineCritique.trim() || !draftEmailId || isRefining) return;
@@ -3634,6 +3667,7 @@ function EmailDetailInner({ isFullView = false }: EmailDetailProps) {
                         ? draftEmail.id
                         : undefined
                     }
+                    watchedDraftEmailId={draftEmail?.id}
                     onDiscardDraft={handleDiscardDraft}
                     nameMap={nameMap}
                   />

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1303,6 +1303,9 @@ function InlineReply({
     setEditorInitialContent(newHtml);
     form.handleEditorChange(newHtml, externalDraft.body);
     onContentChange?.({ bodyHtml: newHtml, bodyText: externalDraft.body });
+    // Clear any pre-refine snapshot — otherwise the "Revert" button would
+    // silently replace the freshly regenerated body with the old pre-refine one.
+    setPreRefineContent(null);
     if (externalDraft.to && JSON.stringify(externalDraft.to) !== JSON.stringify(form.to)) {
       form.setTo(externalDraft.to);
     }

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1277,15 +1277,28 @@ function InlineReply({
   // regenerating via the right pane). When the draft's createdAt changes, push the new
   // content into the editor. Without this, the agent updates the DB + Gmail but the
   // inline reply keeps showing the previous body. Mirrors the watcher in ComposeNewEmail.
+  //
+  // A ref tracks the last-seen createdAt so we never accidentally fire on a
+  // mount-time undefined→defined transition (e.g. watchedDraftEmailId resolves
+  // after mount). Refs also keep the latest form callbacks reachable without
+  // declaring every form method in the deps array; we intentionally only react
+  // to createdAt changes (the signal that an external save happened).
   const externalDraft = useAppStore((s) =>
     watchedDraftEmailId ? s.emails.find((e) => e.id === watchedDraftEmailId)?.draft : undefined,
   );
   const externalDraftCreatedAt = externalDraft?.createdAt;
-  const [lastSeenDraftCreatedAt, setLastSeenDraftCreatedAt] = useState(externalDraftCreatedAt);
+  const lastSeenDraftCreatedAtRef = useRef(externalDraftCreatedAt);
   useEffect(() => {
     if (!externalDraft?.body) return;
-    if (externalDraftCreatedAt === lastSeenDraftCreatedAt) return;
-    setLastSeenDraftCreatedAt(externalDraftCreatedAt);
+    if (externalDraftCreatedAt === lastSeenDraftCreatedAtRef.current) return;
+    // First sight of a draft (lastSeen undefined): if the editor already shows this
+    // body — initialized via restoredDraft on mount — just record createdAt and skip
+    // the push so we don't clobber any in-progress edits with the same content.
+    if (lastSeenDraftCreatedAtRef.current === undefined && form.bodyText === externalDraft.body) {
+      lastSeenDraftCreatedAtRef.current = externalDraftCreatedAt;
+      return;
+    }
+    lastSeenDraftCreatedAtRef.current = externalDraftCreatedAt;
     const newHtml = draftBodyToHtml(externalDraft.body);
     setEditorInitialContent(newHtml);
     form.handleEditorChange(newHtml, externalDraft.body);
@@ -1299,6 +1312,9 @@ function InlineReply({
     if (externalDraft.bcc && JSON.stringify(externalDraft.bcc) !== JSON.stringify(form.bcc)) {
       form.setBcc(externalDraft.bcc);
     }
+    // Deps intentionally limited to createdAt — the signal that an external save
+    // happened. Other values (form, onContentChange, externalDraft) are read from
+    // the latest render closure when the effect fires.
   }, [externalDraftCreatedAt]);
 
   const handleRefine = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Fixes #115: regenerating a reply draft via the agent panel updates Gmail and the DB but the inline reply editor in the main pane keeps showing the previous body.
- `InlineReply` only initialized its editor from `restoredDraft` on mount and never subscribed to store updates. The agent saves drafts via `create_draft` → `saveDraftAndSync` → fires `agent:draft-saved`, which correctly updates the Zustand store, but the inline reply never reads it.
- Mirrors the existing watcher pattern in `ComposeNewEmail` (for new-email compose, which already worked): subscribe to the store's draft on the watched email and, when `createdAt` changes externally, push the new body into the editor and sync `to`/`cc`/`bcc`.

## Changes
- `src/renderer/components/EmailDetail.tsx`
  - Added `watchedDraftEmailId` prop on `InlineReply` (set unconditionally from `draftEmail?.id`, even when `status === "edited"`, so an agent regenerate still overrides user edits if requested).
  - Added a `useEffect` that watches `externalDraft.createdAt` from the store and pushes new content into the editor via `setEditorInitialContent` + `form.handleEditorChange`, plus `setTo/setCc/setBcc` if the agent changed recipients.

## Test plan
- [ ] Open a thread with an AI-generated draft, then in the right pane give the agent feedback to regenerate. Confirm the new draft appears in the inline reply (not just in Gmail).
- [ ] Type some edits in the inline reply, then regenerate via the agent panel. Confirm typed content is replaced by the new draft.
- [ ] Send a normal draft refinement (purple "Refine" button) and confirm no regression — local editor still updates and store is untouched.
- [ ] Switch threads while regenerate is in flight; the inline reply on return should reflect the latest draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)