### PR TITLE
ci: switch release build to new OAuth client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Build
         env:
-          MAIN_VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID_BACKUP }}
-          MAIN_VITE_GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET_BACKUP }}
+          MAIN_VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID_BACKUP_2 }}
+          MAIN_VITE_GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET_BACKUP_2 }}
           VITE_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           VITE_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: npm run build


### PR DESCRIPTION
## Summary
- Switches the release workflow's `MAIN_VITE_GOOGLE_CLIENT_ID` / `_SECRET` env vars from `GOOGLE_CLIENT_ID_BACKUP` / `GOOGLE_CLIENT_SECRET_BACKUP` to the new `_BACKUP_2` variants.
- The previous OAuth client lived in the `gmail-drafter-testing` GCP project and ran out of test users. The new one is in the `exo-testing-2` project.
- Repo secrets `GOOGLE_CLIENT_ID_BACKUP_2` and `GOOGLE_CLIENT_SECRET_BACKUP_2` have been added in repo settings (not overwriting the originals, in case we need to roll back).
- Verified by building locally with the new credentials baked in (unsigned arm64 dmg) and confirming OAuth flow works.

## Test plan
- [x] Local packaged build (`npm run build && npm run dist -- --mac --arm64`) succeeds with the new env vars
- [x] OAuth flow against the new client works end-to-end
- [ ] First release build off `main` after merge produces a working signed dmg

🤖 Generated with [Claude Code](https://claude.com/claude-code)