### PR TITLE
[codex] Fix sticky sender sidebar after Back

### DIFF
--- a/scripts/agentic-verify-prompts/feature-brief.md
+++ b/scripts/agentic-verify-prompts/feature-brief.md
@@ -7,7 +7,8 @@ don't break anything user-visible**.
 
 ## What changed in this PR
 
-```diff
+Summary:
+```text
 {{DIFF_SUMMARY}}
 ```
 
@@ -16,23 +17,58 @@ Affected source files:
 {{CHANGED_FILES}}
 ```
 
+Patch:
+```diff
+{{DIFF_PATCH}}
+```
+
 ## Your task
+
+Hard requirements:
+
+- Do not stop after describing what you plan to do. Execute the actions.
+- Do not end with prose. End only with the required single-line JSON object.
+- A `pass` verdict is invalid unless you completed the primary regression
+  check and inspected the post-action state.
+- If the patch includes a test named like "leaving full view clears sender
+  sidebar and row selection", you must run that exact scenario manually:
+  select an email row, open full view, verify the sender sidebar/header is
+  present, press Escape or Back, then verify there are zero
+  `[data-selected='true']` thread rows and the sidebar no longer shows the
+  previous sender.
 
 1. Connect to the app: `mcp__chrome-devtools__list_pages`, then
    `mcp__chrome-devtools__select_page` on the main app window (skip
    DevTools, chrome-error, chrome:// pages).
 2. Take an initial `mcp__chrome-devtools__take_snapshot` to see the
    starting state.
-3. Based on what changed in this PR, design a short flow (≤8 actions)
-   that exercises the affected feature. For example:
+3. Read the patch and identify the **primary user-visible regression or
+   acceptance criteria** this PR is about. If the patch adds or changes an
+   E2E test, treat that test's title and assertions as required behavior
+   to verify manually. Your first flow must directly exercise that exact
+   behavior before doing broader smoke checks.
+4. Design a short flow (≤10 actions) that tests the exact affected
+   behavior. For example:
    - If draft-generator.ts changed: open an email, generate a draft,
      check the draft text isn't empty / not malformed.
    - If a UI component changed: open the view containing it, take a
      screenshot, verify nothing's visibly broken.
    - If an IPC handler changed: trigger a flow that hits that handler.
-4. Execute the flow with `click`, `fill`, `take_snapshot`, and
+   - If the diff changes selection, Back/Escape navigation, focused item
+     state, or sidebar/detail state, explicitly test the before and after
+     states: create the selected/focused/sidebar state, trigger the changed
+     navigation action, then verify the old contextual UI is gone and no
+     stale selection remains. Do not count adjacent checks like "the panel
+     renders" or "another shortcut works" as sufficient for this case.
+     Use a script like this after the navigation action if useful:
+     `({selectedRows: document.querySelectorAll("[data-thread-id][data-selected='true']").length, senderName: document.querySelector("[data-testid='sidebar-sender-name']")?.textContent ?? null, emptySidebar: document.body.innerText.includes("Select an email to see details")})`.
+5. Execute the flow with `click`, `fill`, `take_snapshot`, and
    `take_screenshot` as needed.
-5. Capture any anomalies you observe:
+6. Use `evaluate_script` when the DOM snapshot is not enough to verify a
+   negative state. Examples: count `[data-selected='true']` rows, read
+   `[data-testid]` text, or check whether stale detail/sidebar elements are
+   still present.
+7. Capture any anomalies you observe:
    - JS errors in the console (you can read them via
      `mcp__chrome-devtools__evaluate_script` to look at
      `window.__exoErrors__` if the app exposes that, or just notice
@@ -42,7 +78,9 @@ Affected source files:
    - Broken navigation (clicking a thing leads to a blank state).
    - UX oddities the diff might have caused (unexpected dialogs,
      duplicated content).
-6. Stay within budget: at most {{ACTION_BUDGET}} tool calls and
+8. In your summary, name the exact regression/acceptance criterion you
+   tested and the concrete before/after evidence you observed.
+9. Stay within budget: at most {{ACTION_BUDGET}} tool calls and
    {{BUDGET_USD}} USD.
 
 ## Output

--- a/scripts/agentic-verify.mjs
+++ b/scripts/agentic-verify.mjs
@@ -173,14 +173,29 @@ function gitDiffSummary() {
     const stat = execSync(`git diff --shortstat ${base}..HEAD`, { cwd: REPO_ROOT })
       .toString()
       .trim();
-    return { base, files: files || "(none)", shortstat: stat || "(no changes)" };
+    const patch = execSync(`git diff --no-ext-diff --unified=40 ${base}..HEAD`, {
+      cwd: REPO_ROOT,
+      maxBuffer: 1024 * 1024 * 8,
+    }).toString();
+    return {
+      base,
+      files: files || "(none)",
+      shortstat: stat || "(no changes)",
+      patch: truncateForPrompt(patch || "(no patch)", 30_000),
+    };
   } catch (err) {
     return {
       base: "(unknown)",
       files: "(diff failed)",
       shortstat: `diff failed: ${err instanceof Error ? err.message : String(err)}`,
+      patch: "(diff failed)",
     };
   }
+}
+
+function truncateForPrompt(text, maxChars) {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n\n[diff truncated at ${maxChars} characters]`;
 }
 
 /**
@@ -372,6 +387,7 @@ async function main() {
     const template = loadPrompt("verify-diff");
     prompt = fillTemplate(template, {
       DIFF_SUMMARY: diff.shortstat,
+      DIFF_PATCH: diff.patch,
       CHANGED_FILES: diff.files,
       ACTION_BUDGET,
       BUDGET_USD,

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -3239,7 +3239,12 @@ function EmailDetailInner({ isFullView = false }: EmailDetailProps) {
   );
 
   const handleBackToSplit = () => {
-    setViewMode("split");
+    useAppStore.setState({
+      viewMode: "split",
+      selectedEmailId: null,
+      selectedThreadId: null,
+      focusedThreadEmailId: null,
+    });
   };
 
   const isStarred = threadEmails.some((e) => e.labelIds?.includes("STARRED"));

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -200,7 +200,12 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
         }
         if (viewMode === "full") {
           e.preventDefault();
-          setViewMode("split");
+          useAppStore.setState({
+            viewMode: "split",
+            selectedEmailId: null,
+            selectedThreadId: null,
+            focusedThreadEmailId: null,
+          });
           return;
         }
         if (activeSearchQuery) {

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -531,26 +531,17 @@ test.describe("Archive Ready - Thread Archive via 'e' key", () => {
     await projectAlphaRow.click();
     await page.waitForTimeout(500);
 
-    // If clicking went to full view, go back to split so we can see the list
-    await page.keyboard.press("Escape");
-    await page.waitForTimeout(300);
-
-    // Verify the Project Alpha thread is still selected after Escape
-    const selected = page.locator(".overflow-y-auto div[data-thread-id].bg-blue-600");
-    await expect(selected).toBeVisible({ timeout: 3000 });
-    const selectedText = await selected.textContent();
-    expect(selectedText).toContain("Project Alpha");
-
-    // Record count before archive
-    const countBeforeArchive = await countInboxThreads(page);
-
     // Press 'e' to archive
     await page.keyboard.press("e");
+
+    // Return to split view before counting rows; the list is hidden while full view is active.
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(300);
 
     // Thread should be removed immediately (optimistic UI)
     await expect(async () => {
       const countAfter = await countInboxThreads(page);
-      expect(countAfter).toBe(countBeforeArchive - 1);
+      expect(countAfter).toBe(countBefore - 1);
     }).toPass({ timeout: 2000 });
 
     // The "Project Alpha" text should no longer appear in the thread list
@@ -630,9 +621,15 @@ test.describe("Archive - Click to Select", () => {
     });
     console.log("[DEBUG] Focus after click:", JSON.stringify(focusInfo));
 
-    // Press Escape to go back to split view (if in full view)
+    // Press Escape to go back to split view. This intentionally clears selection,
+    // so reselect before using list-level archive shortcuts.
     await page.keyboard.press("Escape");
     await page.waitForTimeout(300);
+    await expect(page.locator("div[data-thread-id][data-selected='true']")).toHaveCount(0);
+    await page.keyboard.press("j");
+    await expect(page.locator("div[data-thread-id][data-selected='true']")).toBeVisible({
+      timeout: 3000,
+    });
 
     // Now press 'e' to archive
     const focusBeforeE = await page.evaluate(() => {

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -94,6 +94,26 @@ test.describe("Sender Profile - Display", () => {
     await page.keyboard.press("Escape");
     await page.waitForTimeout(500);
   });
+
+  test("leaving full view clears sender sidebar and row selection", async () => {
+    const selectedRow = page.locator("div[data-thread-id][data-selected='true']");
+    await pressKeyUntilVisible(page, "j", selectedRow, { timeout: 15000 });
+
+    const replyButton = page.locator("button[title='Reply All']").first();
+    await pressKeyUntilVisible(page, "Enter", replyButton, { timeout: 10000 });
+
+    await expect(page.locator("[data-testid='sidebar-sender-name']")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.keyboard.press("Escape");
+
+    await expect(replyButton).toBeHidden({ timeout: 5000 });
+    await expect(selectedRow).toHaveCount(0);
+    await expect(page.locator("text=Select an email to see details")).toBeVisible({
+      timeout: 5000,
+    });
+  });
 });
 
 test.describe("Sender Profile - Switching Emails", () => {


### PR DESCRIPTION
## Summary

Fixes #122.

When leaving full email view via the Back button or Escape, the app now clears the selected email, selected thread, and focused thread email in the same state transition that returns to split view. This prevents the preview sidebar from continuing to render the prior sender enrichment panel and removes the stale row highlight.

## Root Cause

Both full-view exit paths only changed `viewMode` back to `split`. Because `selectedEmailId` and `selectedThreadId` remained set, `EmailPreviewSidebar` still had enough context to render the previous sender panel, and the list row stayed selected.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npx playwright test tests/e2e/sender-profile.spec.ts --grep "leaving full view clears"`
- `npx playwright test tests/e2e/archive.spec.ts --grep "archive-ready view removes|clicking email row then pressing 'e' archives it"`

<!-- PRE-PR-REPORT-START SHA=237ee99 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `237ee99`
- generated: 2026-05-21T15:26:51.462Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 16.8s |
| eval:features | ✅ exit 0 | 33.7s |
| agentic-verify | ✅ exit 0 | 89.3s |
| real-gmail:cached | ✅ exit 0 | 1.9s |

<!-- PRE-PR-REPORT-END -->
