### PR TITLE
evals: refuse to update baseline when fixtures hit infra errors

### DIFF
--- a/tests/evals/feature-evals.ts
+++ b/tests/evals/feature-evals.ts
@@ -321,8 +321,17 @@ async function main(): Promise<void> {
     reports.push(report);
     printReport(report);
     if (updateBaseline && report.fixturesRun > 0) {
-      saveBaseline(feature, report.results);
-      console.log(`  baseline updated → ${baselinePath(feature)}`);
+      // Refuse to persist a baseline when any fixture hit an infra error —
+      // saveBaseline would otherwise write score:0 placeholders, permanently
+      // muting those fixtures from the regression gate on future runs.
+      if (report.infraErrors.length > 0) {
+        console.error(
+          `  baseline NOT updated for ${feature}: ${report.infraErrors.length} fixture(s) had infrastructure errors. Fix those and re-run with --update-baseline.`,
+        );
+      } else {
+        saveBaseline(feature, report.results);
+        console.log(`  baseline updated → ${baselinePath(feature)}`);
+      }
     }
     if (report.regressions.length > 0) anyRegressions = true;
     if (report.infraErrors.length > 0) anyInfraErrors = true;


### PR DESCRIPTION
Fixes #128.

## Summary
- `--update-baseline` no longer persists `score:0` placeholders for fixtures that hit infrastructure errors
- When any fixture in the run threw, the baseline write is skipped entirely and the developer is told to fix the breakage and re-run

## Why
Previously, if `runFixture` threw on a fixture and the developer ran with `--update-baseline`, `saveBaseline` would persist a `score: 0` entry for that fixture. A subsequent judge score of 8 would compute delta +8 and pass the gate — permanently muting that fixture from regression detection.

The runner already exits non-zero on infra errors, so refusing the baseline write is the simpler "harder-to-footgun" path the issue author called out as the preference.

## Changes
- `tests/evals/feature-evals.ts`: guard the `saveBaseline` call on `report.infraErrors.length === 0`; otherwise log an error explaining the skip

## Test plan
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npx eslint tests/evals/feature-evals.ts`)
- [ ] Manual repro from the issue: temporarily break a runFixture, run `--update-baseline`, confirm baseline file is unchanged and the warning is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRE-PR-REPORT-START SHA=b6dd186 mode=full -->
**Pre-PR verdict**: FAIL

- mode: `full`
- sha: `b6dd186`
- generated: 2026-05-21T23:21:22.705Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 17.6s |
| eval:features | ❌ exit 1 | 31.4s |
| agentic-verify | ❌ exit 1 | 30.5s |
| real-gmail:cached | ❌ exit 1 | 152.9s |

### Failures

<details><summary>eval:features — exit 1</summary>

```
    A direct question with NO scheduling component — should detect hasSchedulingContext=false.
    judge: Correctly identifies no scheduling context despite EOD deadline.
  [9/10] ca-3-ambiguous-time +0.0
    Vague 'let's catch up sometime' email — borderline scheduling case.
    judge: Correctly identifies scheduling context and defers appropriately, though doesn't explicitly note the vagueness of 'sometime'.
[archive-ready-analyzer] running ar-1-resolved-thread...
[19:18:14.397] [33mWARN[39m (75015): [36mAnthropicService: database not initialized, skipping call recording[39m
    [35mns[39m: "anthropic"
[19:18:14.397] [32mINFO[39m (75015): [36m[ArchiveReady] Usage: input=495, output=39, cache_read=0, cache_create=0[39m
    [35mns[39m: "archive-ready"
[archive-ready-analyzer] running ar-2-open-question...
[19:18:16.469] [33mWARN[39m (75015): [36mAnthropicService: database not initialized, skipping call recording[39m
    [35mns[39m: "anthropic"
[19:18:17.844] [33mWARN[39m (75015): [36mAnthropicService: database not initialized, skipping call recording[39m
    [35mns[39m: "anthropic"
[19:18:17.845] [32mINFO[39m (75015): [36m[ArchiveReady] Usage: input=495, output=50, cache_read=0, cache_create=0[39m
    [35mns[39m: "archive-ready"

=== archive-ready-analyzer ===
Fixtures: 2
  [10/10] ar-1-resolved-thread +0.0
    A thread that ended with explicit agreement — should be marked archive-ready.
    judge: Correctly marks archive-ready with reasoning citing the explicit agreement.
  [10/10] ar-2-open-question +0.0
    A thread ending with an unanswered question — should NOT be archive-ready.
    judge: Correctly marks not archive-ready and cites the unanswered question and bump.

NOTE: 4 features still TODO:
  - sender-lookup
  - style-profiler
  - analysis-edit-learner
  - draft-edit-learner
[19:18:19.281] [33mWARN[39m (75015): [36mAnthropicService: database not initialized, skipping call recording[39m
    [35mns[39m: "anthropic"

Total fixtures run: 8
[logger] Writing logs to /var/folders/yr/s4m5xglx0k7d1yz5wt756lyw0000gn/T/exo-logs/2026-05-21.log

Eval FAILED: regressions detected vs baseline

```
</details>

<details><summary>agentic-verify — exit 1</summary>

```
[2026-05-21T23:18:19.550Z] Auto-selected CDP port: 9224
[2026-05-21T23:18:19.551Z] mode=verify-diff sha=b6dd186 action_budget=40 budget_usd=0.5
[2026-05-21T23:18:19.686Z] data mode: demo (diff is UI/scripts/tests only)
[2026-05-21T23:18:19.686Z] diff base=1d7a378e87d6e5b2790284655f30b3e5c4f4c6cb 1 file changed, 11 insertions(+), 2 deletions(-)
[2026-05-21T23:18:19.686Z] changed files:
tests/evals/feature-evals.ts
[2026-05-21T23:18:19.687Z] Launching Electron in demo mode with --remote-debugging-port=9224...
[2026-05-21T23:18:49.837Z] FATAL: Error: CDP at http://127.0.0.1:9224 not ready after 30000ms
    at waitForCdp (file:///Users/ankit/conductor/workspaces/mail-app/medan-v2/scripts/agentic-verify.mjs:270:9)
    at async main (file:///Users/ankit/conductor/workspaces/mail-app/medan-v2/scripts/agentic-verify.mjs:406:5)
[electron] vite v6.4.2 building SSR bundle for development...
[electron] transforming...

FATAL — see /Users/ankit/conductor/workspaces/mail-app/medan-v2/scripts/.agentic-runs/2026-05-21T23-18-19-495Z-verify-diff.log

```
</details>

<details><summary>real-gmail:cached — exit 1</summary>

```
[1A[2K[real-gmail] › tests/real-gmail/cached-mode.spec.ts:95:3 › Real-Gmail Layer 9a — cached .dev-data › inbox renders seeded emails (>= 1 visible thread)
[real-gmail 9a] runId=exo-test-mpg449pr

[1A[2K  1) [real-gmail] › tests/real-gmail/cached-mode.spec.ts:95:3 › Real-Gmail Layer 9a — cached .dev-data › inbox renders seeded emails (>= 1 visible thread) 

    [31m"beforeAll" hook timeout of 60000ms exceeded.[39m

      41 |   let runId: string;
      42 |
    > 43 |   test.beforeAll(async () => {
         |        ^
      44 |     // Verify auth works before booting Electron — fail fast on bad token.
      45 |     await pingAccount();
      46 |     runId = makeRunId();
        at /Users/ankit/conductor/workspaces/mail-app/medan-v2/tests/real-gmail/cached-mode.spec.ts:43:8

    TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.
    Call log:
    [2m  - waiting for locator('text=Exo') to be visible[22m


      70 |     page = await app.firstWindow();
      71 |     await page.waitForLoadState("domcontentloaded");
    > 72 |     await page.waitForSelector("text=Exo", { timeout: 30_000 });
         |                ^
      73 |   });
      74 |
      75 |   test.afterAll(async () => {
        at /Users/ankit/conductor/workspaces/mail-app/medan-v2/tests/real-gmail/cached-mode.spec.ts:72:16


[1A[2K[2/6] [real-gmail] › tests/real-gmail/cached-mode.spec.ts:103:3 › Real-Gmail Layer 9a — cached .dev-data › opening a thread shows the message body
[1A[2K[3/6] [real-gmail] › tests/real-gmail/cached-mode.spec.ts:113:3 › Real-Gmail Layer 9a — cached .dev-data › compose button opens compose view
[1A[2K[4/6] [real-gmail] › tests/real-gmail/cached-mode.spec.ts:121:3 › Real-Gmail Layer 9a — cached .dev-data › label tag round-trip — add and remove [exo-test-{runId}] via Gmail API
[1A[2K[5/6] [real-gmail] › tests/real-gmail/cached-mode.spec.ts:133:3 › Real-Gmail Layer 9a — cached .dev-data › search returns results
[1A[2K[6/6] [real-gmail] › tests/real-gmail/cached-mode.spec.ts:156:3 › Real-Gmail Layer 9a — cached .dev-data › settings panel opens without crashing
[1A[2K  1 failed
    [real-gmail] › tests/real-gmail/cached-mode.spec.ts:95:3 › Real-Gmail Layer 9a — cached .dev-data › inbox renders seeded emails (>= 1 visible thread) 
  5 did not run

```
</details>

<!-- PRE-PR-REPORT-END -->
