### PR TITLE
a11y: add accessible names to icon buttons and selects (#127)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"384d28ae-e957-4844-a383-7e51db064164","pid":39618,"procStart":"Fri May 22 01:06:48 2026","acquiredAt":1779412676329}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"384d28ae-e957-4844-a383-7e51db064164","pid":39618,"procStart":"Fri May 22 01:06:48 2026","acquiredAt":1779412676329}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ release/
 *.swp
 *.swo
 
+# Claude Code harness runtime state
+.claude/scheduled_tasks.lock
+
 # SQLite database (stored in user data directory, but just in case)
 *.db
 *.db-journal

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1736,6 +1736,7 @@ export default function App() {
             onClick={openSearch}
             className="p-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center gap-1"
             title="Search (/)"
+            aria-label="Search"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -1886,6 +1887,7 @@ export default function App() {
             onClick={() => setShowSettings(true)}
             className="p-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors focus:outline-none"
             title="Settings"
+            aria-label="Settings"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -1907,6 +1909,7 @@ export default function App() {
             disabled={isFetching || isSyncing}
             className="p-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50"
             title="Refresh"
+            aria-label="Refresh"
           >
             <svg
               className={`w-5 h-5 ${isFetching || isSyncing ? "animate-spin" : ""}`}
@@ -2013,6 +2016,7 @@ export default function App() {
               onClick={() => removeExtensionAuthRequired(extId)}
               className="p-1 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 transition-colors"
               title="Dismiss"
+              aria-label="Dismiss"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -2071,6 +2075,7 @@ export default function App() {
               onClick={() => removeAgentAuthRequired(providerId)}
               className="p-1 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 transition-colors"
               title="Dismiss"
+              aria-label="Dismiss"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2016,7 +2016,7 @@ export default function App() {
               onClick={() => removeExtensionAuthRequired(extId)}
               className="p-1 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 transition-colors"
               title="Dismiss"
-              aria-label="Dismiss"
+              aria-label={`Dismiss ${displayName} authentication notice`}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -2075,7 +2075,7 @@ export default function App() {
               onClick={() => removeAgentAuthRequired(providerId)}
               className="p-1 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 transition-colors"
               title="Dismiss"
-              aria-label="Dismiss"
+              aria-label={`Dismiss ${displayName} authentication notice`}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path

--- a/src/renderer/components/ComposeToolbar.tsx
+++ b/src/renderer/components/ComposeToolbar.tsx
@@ -42,6 +42,7 @@ export function ComposeToolbar({
         onClick={onPickFiles}
         className="p-1.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
         title="Attach file"
+        aria-label="Attach file"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
@@ -57,6 +58,7 @@ export function ComposeToolbar({
         <select
           value={activeSignatureId ?? ""}
           onChange={(e) => onSignatureChange(e.target.value || null)}
+          aria-label="Signature"
           className="ml-auto text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300"
         >
           <option value="">No signature</option>

--- a/src/renderer/components/EmailList.tsx
+++ b/src/renderer/components/EmailList.tsx
@@ -581,6 +581,7 @@ export function EmailList() {
           <button
             onClick={cycleDensity}
             title={`Density: ${densityLabels[inboxDensity]}`}
+            aria-label={`Density: ${densityLabels[inboxDensity]}`}
             className="p-1 rounded text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
           >
             <svg

--- a/src/renderer/components/MemoriesTab.tsx
+++ b/src/renderer/components/MemoriesTab.tsx
@@ -316,6 +316,7 @@ export function MemoriesTab({
                     setNewScope(e.target.value as MemoryScope);
                     setNewScopeValue("");
                   }}
+                  aria-label="Memory scope"
                   className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded text-sm"
                 >
                   {(Object.keys(SCOPE_LABELS) as MemoryScope[]).map((s) => (

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -724,6 +724,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         </div>
         <button
           onClick={onClose}
+          aria-label="Close settings"
           className="titlebar-no-drag p-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1075,6 +1076,9 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     </p>
                   </div>
                   <button
+                    role="switch"
+                    aria-checked={isDefaultMailApp}
+                    aria-label="Set as default mail app"
                     disabled={isDefaultMailAppLoading}
                     onClick={async () => {
                       if (isDefaultMailAppLoading) return;
@@ -1189,6 +1193,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                             setModelConfig((prev) => ({ ...prev, [key]: tier as ModelTier }));
                           }
                         }}
+                        aria-label={`Model tier for ${label}`}
                         className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       >
                         {MODEL_TIERS.map((tier) => (
@@ -1348,6 +1353,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                   <button
                     role="switch"
                     aria-checked={allowPrereleaseUpdates}
+                    aria-label="Pre-release updates"
                     onClick={() => setAllowPrereleaseUpdates(!allowPrereleaseUpdates)}
                     className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                       allowPrereleaseUpdates
@@ -1377,6 +1383,9 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     </p>
                   </div>
                   <button
+                    role="switch"
+                    aria-checked={enableSenderLookup}
+                    aria-label="Enable sender lookup"
                     onClick={() => setEnableSenderLookup(!enableSenderLookup)}
                     className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                       enableSenderLookup
@@ -1416,6 +1425,9 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     </p>
                   </div>
                   <button
+                    role="switch"
+                    aria-checked={syncDraftsToGmail}
+                    aria-label="Sync drafts to Gmail"
                     onClick={() => setSyncDraftsToGmail(!syncDraftsToGmail)}
                     className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                       syncDraftsToGmail
@@ -1857,6 +1869,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                             accountId: e.target.value || undefined,
                           })
                         }
+                        aria-label="Signature account"
                         className="w-full p-3 border border-gray-300 dark:border-gray-500 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:text-gray-100"
                       >
                         <option value="">All accounts (global)</option>

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1079,7 +1079,8 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     role="switch"
                     aria-checked={isDefaultMailApp}
                     aria-label="Set as default mail app"
-                    disabled={isDefaultMailAppLoading}
+                    aria-disabled={isDefaultMailAppLoading}
+                    aria-busy={isDefaultMailAppLoading}
                     onClick={async () => {
                       if (isDefaultMailAppLoading) return;
                       setIsDefaultMailAppLoading(true);

--- a/src/renderer/components/SplitConfigEditor.tsx
+++ b/src/renderer/components/SplitConfigEditor.tsx
@@ -24,6 +24,7 @@ function ConditionEditor({ condition, onChange, onRemove }: ConditionEditorProps
       <select
         value={condition.type}
         onChange={(e) => onChange({ ...condition, type: e.target.value as SplitCondition["type"] })}
+        aria-label="Condition type"
         className="text-sm border rounded px-2 py-1 w-24 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
       >
         {CONDITION_TYPES.map((t) => (
@@ -55,6 +56,7 @@ function ConditionEditor({ condition, onChange, onRemove }: ConditionEditorProps
         onClick={onRemove}
         className="text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-400 p-1 shrink-0"
         title="Remove condition"
+        aria-label="Remove condition"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
@@ -161,6 +163,7 @@ function SplitEditor({ split, onSave, onCancel, existingCount }: SplitEditorProp
             <select
               value={conditionLogic}
               onChange={(e) => setConditionLogic(e.target.value as "and" | "or")}
+              aria-label="Condition match logic"
               className="text-xs border rounded px-2 py-1 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
             >
               <option value="or">Match ANY</option>
@@ -558,6 +561,7 @@ export function SplitConfigEditor() {
                   disabled={index === 0 || isSaving}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
                   title="Move up"
+                  aria-label="Move up"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -573,6 +577,7 @@ export function SplitConfigEditor() {
                   disabled={index === sortedSplits.length - 1 || isSaving}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
                   title="Move down"
+                  aria-label="Move down"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -588,6 +593,7 @@ export function SplitConfigEditor() {
                   disabled={isSaving || !!editingSplit}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-30"
                   title="Edit"
+                  aria-label="Edit split"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -603,6 +609,7 @@ export function SplitConfigEditor() {
                   disabled={isSaving}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-30"
                   title="Delete"
+                  aria-label="Delete split"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path

--- a/src/renderer/components/SplitConfigEditor.tsx
+++ b/src/renderer/components/SplitConfigEditor.tsx
@@ -561,7 +561,7 @@ export function SplitConfigEditor() {
                   disabled={index === 0 || isSaving}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
                   title="Move up"
-                  aria-label="Move up"
+                  aria-label={`Move "${split.name}" up`}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -577,7 +577,7 @@ export function SplitConfigEditor() {
                   disabled={index === sortedSplits.length - 1 || isSaving}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
                   title="Move down"
-                  aria-label="Move down"
+                  aria-label={`Move "${split.name}" down`}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -593,7 +593,7 @@ export function SplitConfigEditor() {
                   disabled={isSaving || !!editingSplit}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-30"
                   title="Edit"
-                  aria-label="Edit split"
+                  aria-label={`Edit split "${split.name}"`}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
@@ -609,7 +609,7 @@ export function SplitConfigEditor() {
                   disabled={isSaving}
                   className="p-1 text-gray-400 dark:text-gray-500 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-30"
                   title="Delete"
-                  aria-label="Delete split"
+                  aria-label={`Delete split "${split.name}"`}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path

--- a/tests/e2e/helpers/a11y.ts
+++ b/tests/e2e/helpers/a11y.ts
@@ -76,7 +76,11 @@ export async function checkA11y(page: Page, options: CheckA11yOptions = {}): Pro
   if (blocking.length === 0) return;
 
   const summary = blocking
-    .map((v) => `  - [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`)
+    .map(
+      (v) =>
+        `  - [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))\n` +
+        v.nodes.map((n) => `      • ${n.target.join(" ")}`).join("\n"),
+    )
     .join("\n");
   throw new Error(
     `Accessibility violations (>= ${failOn}) detected:\n${summary}\n` +

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -73,11 +73,8 @@ test.describe("Visual regression — Linux-only", () => {
 
     await checkA11y(page, {
       exclude: ["[data-testid='email-date']"],
-      // Tracked product debt — re-enable once the markup/palette pass lands.
-      //   color-contrast: #126 (tailwind text-gray-300/400 on white)
-      //   button-name:    #127 (icon-only toolbar buttons missing aria-label)
-      //   select-name:    #127 (account/EA selects missing accessible names)
-      disableRules: ["color-contrast", "button-name", "select-name"],
+      // color-contrast still tracked under #126 (tailwind text-gray-300/400 on white).
+      disableRules: ["color-contrast"],
     });
   });
 
@@ -118,11 +115,9 @@ test.describe("Visual regression — Linux-only", () => {
       maxDiffPixelRatio: 0.01,
     });
 
-    // Settings overlays the inbox, so the same titlebar buttons + selects
-    // are still in the DOM. Tracked product debt — re-enable once #126
-    // and #127 are fixed.
+    // color-contrast still tracked under #126.
     await checkA11y(page, {
-      disableRules: ["color-contrast", "button-name", "select-name"],
+      disableRules: ["color-contrast"],
     });
 
     await page.keyboard.press("Escape");


### PR DESCRIPTION
## Summary

Fixes #127. Adds `aria-label` (and `role="switch"` / `aria-checked` on toggle-switch buttons) so axe-core's `button-name` and `select-name` rules pass on the inbox + Settings views. The two rules are now re-enabled in `tests/e2e/visual-regression.spec.ts`; `color-contrast` stays disabled under #126.

## Changes

- **Titlebar (`App.tsx`)**: aria-labels on Search / Settings / Refresh / Dismiss buttons.
- **Settings panel (`SettingsPanel.tsx`)**: aria-label on Close button; converted 4 General-tab toggles (Default mail app, Pre-release updates, Sender lookup, Sync drafts to Gmail) into proper switches with `role="switch"` + `aria-checked` + `aria-label`; aria-label on the model-tier and signature-account selects.
- **EmailList**: aria-label on the density-toggle icon button.
- **SplitConfigEditor**: aria-label on Move up / Move down / Edit / Delete / Remove-condition icon buttons and the condition-type / condition-logic selects.
- **MemoriesTab**: aria-label on scope select.
- **ComposeToolbar**: aria-label on Attach file button and signature select.
- **`tests/e2e/visual-regression.spec.ts`**: re-enable `button-name` and `select-name` in the inbox + settings `checkA11y` calls.
- **`tests/e2e/helpers/a11y.ts`**: include the failing node selectors in the error summary so future violations are easier to localize.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run pre-pr` (full, not `--quick`) — Verdict: PASS (after merging origin/main and seeding `.dev-data/`)
- [x] Verified locally via a one-off Playwright spec that ran `checkA11y` against the inbox view and the Settings panel with `button-name` + `select-name` enabled — both pass after these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRE-PR-REPORT-START SHA=56cc100 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `56cc100`
- generated: 2026-05-22T01:17:05.551Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.9s |
| eval:features | ✅ exit 0 | 30.2s |
| agentic-verify | ✅ exit 0 | 142.3s |
| real-gmail:cached | ✅ exit 0 | 11.4s |

<!-- PRE-PR-REPORT-END -->
