### PR TITLE
fix: preserve list focus when Esc'ing back from full-view email

### DIFF
--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -199,11 +199,13 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           return;
         }
         if (viewMode === "full") {
+          // Preserve selectedThreadId/selectedEmailId so the row the user was
+          // just viewing stays highlighted in the list and j/k resume from there.
+          // focusedThreadEmailId is full-view-only (which message inside a thread
+          // is focused), so it's still correct to clear that.
           e.preventDefault();
           useAppStore.setState({
             viewMode: "split",
-            selectedEmailId: null,
-            selectedThreadId: null,
             focusedThreadEmailId: null,
           });
           return;

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -621,15 +621,11 @@ test.describe("Archive - Click to Select", () => {
     });
     console.log("[DEBUG] Focus after click:", JSON.stringify(focusInfo));
 
-    // Press Escape to go back to split view. This intentionally clears selection,
-    // so reselect before using list-level archive shortcuts.
+    // Press Escape to go back to split view. Selection is preserved on the row
+    // we were just viewing, so 'e' can archive it directly without reselecting.
     await page.keyboard.press("Escape");
     await page.waitForTimeout(300);
-    await expect(page.locator("div[data-thread-id][data-selected='true']")).toHaveCount(0);
-    await page.keyboard.press("j");
-    await expect(page.locator("div[data-thread-id][data-selected='true']")).toBeVisible({
-      timeout: 3000,
-    });
+    await expect(page.locator("div[data-thread-id][data-selected='true']")).toHaveCount(1);
 
     // Now press 'e' to archive
     const focusBeforeE = await page.evaluate(() => {

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -95,24 +95,28 @@ test.describe("Sender Profile - Display", () => {
     await page.waitForTimeout(500);
   });
 
-  test("leaving full view clears sender sidebar and row selection", async () => {
+  test("leaving full view preserves row selection and sender sidebar", async () => {
     const selectedRow = page.locator("div[data-thread-id][data-selected='true']");
     await pressKeyUntilVisible(page, "j", selectedRow, { timeout: 15000 });
+    const selectedThreadIdBefore = await selectedRow.getAttribute("data-thread-id");
 
     const replyButton = page.locator("button[title='Reply All']").first();
     await pressKeyUntilVisible(page, "Enter", replyButton, { timeout: 10000 });
 
-    await expect(page.locator("[data-testid='sidebar-sender-name']")).toBeVisible({
-      timeout: 5000,
-    });
+    const senderName = page.locator("[data-testid='sidebar-sender-name']");
+    await expect(senderName).toBeVisible({ timeout: 5000 });
+    const senderBefore = await senderName.textContent();
 
     await page.keyboard.press("Escape");
 
+    // Full view is gone, but the row stays highlighted on the email we were
+    // just viewing so j/k resume from there. The preview sidebar keeps showing
+    // that email's sender.
     await expect(replyButton).toBeHidden({ timeout: 5000 });
-    await expect(selectedRow).toHaveCount(0);
-    await expect(page.locator("text=Select an email to see details")).toBeVisible({
-      timeout: 5000,
-    });
+    await expect(selectedRow).toHaveCount(1);
+    expect(await selectedRow.getAttribute("data-thread-id")).toBe(selectedThreadIdBefore);
+    await expect(senderName).toBeVisible({ timeout: 5000 });
+    expect(await senderName.textContent()).toBe(senderBefore);
   });
 });
 


### PR DESCRIPTION
## Summary
- When you j/k down a thread, hit **Enter** to open it, then press **Esc** to return to the list, the highlight is now preserved on the email you were just viewing — so the next `j`/`k` advances from there instead of jumping back to the top.
- The Esc-from-full handler was explicitly nulling `selectedThreadId` / `selectedEmailId`, which drives both the row highlight in `EmailList` and the current-index lookup in `navigateList`. Now only `focusedThreadEmailId` (full-view-only state for which message inside a thread is focused) gets cleared.

## Diff
```ts
// src/renderer/hooks/useKeyboardShortcuts.ts:201-212
if (viewMode === "full") {
  e.preventDefault();
  useAppStore.setState({
    viewMode: "split",
-   selectedEmailId: null,
-   selectedThreadId: null,
    focusedThreadEmailId: null,
  });
  return;
}
```

## Test plan
Verified live in the dev app via CDP automation against the seeded test inbox:
- [x] `j × 3` selects the 3rd thread (`data-selected="true"` on row 3)
- [x] `Enter` opens full view
- [x] `Esc` returns to split view — same thread still highlighted (verified by DOM query for `[data-thread-id][data-selected="true"]` returning the same id `19e237621beaef4f`)
- [x] Next `j` advances to row 4 (not row 1)
- [x] `tsc --noEmit` clean

The visual change is purely "the highlighted row persists after Esc"; the static-screenshot test plan above is the load-bearing evidence for this keystroke flow.

<!-- PRE-PR-REPORT-START SHA=364f5c3 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `364f5c3`
- generated: 2026-05-23T19:43:41.474Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.8s |
| eval:features | ✅ exit 0 | 36.2s |
| agentic-verify | ✅ exit 0 | 68.3s |
| real-gmail:cached | ✅ exit 0 | 7.9s |

<!-- PRE-PR-REPORT-END -->
