### PR TITLE
fix(agentic-verify): run Electron headless during pre-pr

### DIFF
--- a/scripts/agentic-verify.mjs
+++ b/scripts/agentic-verify.mjs
@@ -306,10 +306,20 @@ function launchElectron(dataMode) {
   // test account using .dev-data/ tokens. Set EXO_DISABLE_PREFETCH so
   // the agent's run doesn't trigger background Claude analysis on every
   // seeded email (would burn $$).
+  //
+  // EXO_HEADLESS=true suppresses the visible BrowserWindow (src/main/window.ts
+  // creates it with `show: false` and skips the `ready-to-show` `.show()` call).
+  // CDP and IPC still work, so the chrome-devtools MCP agent is unaffected —
+  // the window just never paints, so pre-pr runs don't steal focus.
   const launchEnv =
     dataMode === "real"
-      ? { ...process.env, EXO_DEMO_MODE: "", EXO_DISABLE_PREFETCH: "true" }
-      : { ...process.env, EXO_DEMO_MODE: "true" };
+      ? {
+          ...process.env,
+          EXO_DEMO_MODE: "",
+          EXO_DISABLE_PREFETCH: "true",
+          EXO_HEADLESS: "true",
+        }
+      : { ...process.env, EXO_DEMO_MODE: "true", EXO_HEADLESS: "true" };
   log(
     `Launching Electron in ${dataMode} mode with --remote-debugging-port=${CDP_PORT}...`,
   );


### PR DESCRIPTION
## Summary

- `pre-pr` (specifically the agentic-verify phase) was popping up a visible Electron window every run, which stole focus during ~10-min runs.
- Every other test surface (unit/integration/e2e/real-gmail) already runs hidden because they set `NODE_ENV=test`, which trips the `isTestMode` check in `src/main/window.ts:16`.
- This adds `EXO_HEADLESS=true` to the env that `scripts/agentic-verify.mjs` passes when spawning `electron-vite dev`. That hits the same `isTestMode` branch: the `BrowserWindow` is created with `show: false` and the `ready-to-show` `.show()` call is skipped. CDP, IPC, and the renderer continue to work, so the chrome-devtools MCP agent is unaffected — the window just never paints.

## Why this is safe

- `EXO_HEADLESS` is the existing, purpose-built knob (`src/main/window.ts:16`) — same code path the e2e helpers use via `NODE_ENV=test`. No new state, no new branch in app code.
- `backgroundThrottling: false` is already set in the same `isTestMode` block so hidden-window setTimeout-based logic (e.g. undo-send auto-dismiss) still fires.
- Applies to both the `real` and `demo` data-mode branches in `launchElectron`.

## Test plan

- [x] Launch Electron manually with the new env (`EXO_HEADLESS=true EXO_DEMO_MODE=true npx electron-vite dev -- --remote-debugging-port=9223`) and confirm CDP responds, page loads, demo data ingests.
- [x] Query `CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly)` filtered by the Electron PID → **0 on-screen windows**.
- [ ] `npm run pre-pr` will be invoked by the standard PR flow; expectation is no visible window appears during the agentic-verify phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRE-PR-REPORT-START SHA=db2a6c1 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `db2a6c1`
- generated: 2026-05-23T20:50:23.493Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.4s |
| eval:features | ✅ exit 0 | 36.6s |
| agentic-verify | ✅ exit 0 | 85.9s |
| real-gmail:cached | ✅ exit 0 | 10.6s |

<!-- PRE-PR-REPORT-END -->
