### PR TITLE
fix: prune in-memory emails when removing an account

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -894,15 +894,25 @@ export const useAppStore = create<AppState>((set, get) => ({
       const newAccounts = state.accounts.filter((a) => a.id !== accountId);
       const newSyncStatuses = new Map(state.syncStatuses);
       newSyncStatuses.delete(accountId);
+      const newBackgroundSyncProgress = new Map(state.backgroundSyncProgress);
+      newBackgroundSyncProgress.delete(accountId);
       // If removing current account, switch to primary or first
       let newCurrentId = state.currentAccountId;
       if (state.currentAccountId === accountId) {
         newCurrentId = newAccounts.find((a) => a.isPrimary)?.id || newAccounts[0]?.id || null;
       }
+      // Drop in-memory emails/sent emails for the removed account. The DB
+      // cleanup in main happens in removeAccount(accountId), but state.emails
+      // is the source of truth for the unified ("All Inboxes") view, so
+      // without this the removed account's threads keep rendering until the
+      // app restarts.
       return {
         accounts: newAccounts,
         currentAccountId: newCurrentId,
         syncStatuses: newSyncStatuses,
+        backgroundSyncProgress: newBackgroundSyncProgress,
+        emails: state.emails.filter((e) => e.accountId !== accountId),
+        sentEmails: state.sentEmails.filter((e) => e.accountId !== accountId),
       };
     }),
   setCurrentAccountId: (accountId) => {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -954,6 +954,15 @@ export const useAppStore = create<AppState>((set, get) => ({
         state.lastSelectedThreadId && removedThreadIds.has(state.lastSelectedThreadId)
           ? null
           : state.lastSelectedThreadId;
+      // Drain pending undo queues for the removed account. UndoActionToast's
+      // error-recovery path on a failed batch IPC calls addEmails(failedEmails),
+      // which would re-insert this account's emails after the DB is gone.
+      // Drop both queues' entries so timers fire on a no-op and the toast
+      // never tries to restore them.
+      const newUndoActionQueue = state.undoActionQueue.filter((i) => i.accountId !== accountId);
+      const newUndoSendQueue = state.undoSendQueue.filter(
+        (i) => i.sendOptions.accountId !== accountId,
+      );
       return {
         accounts: newAccounts,
         currentAccountId: newCurrentId,
@@ -980,6 +989,8 @@ export const useAppStore = create<AppState>((set, get) => ({
           state.selectedDraftId && removedDraftIds.has(state.selectedDraftId)
             ? null
             : state.selectedDraftId,
+        undoActionQueue: newUndoActionQueue,
+        undoSendQueue: newUndoSendQueue,
       };
     }),
   setCurrentAccountId: (accountId) => {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -906,13 +906,45 @@ export const useAppStore = create<AppState>((set, get) => ({
       // is the source of truth for the unified ("All Inboxes") view, so
       // without this the removed account's threads keep rendering until the
       // app restarts.
+      const remainingEmails: DashboardEmail[] = [];
+      const removedEmailIds = new Set<string>();
+      const removedThreadIds = new Set<string>();
+      for (const e of state.emails) {
+        if (e.accountId === accountId) {
+          removedEmailIds.add(e.id);
+          if (e.threadId) removedThreadIds.add(e.threadId);
+        } else {
+          remainingEmails.push(e);
+        }
+      }
+      // Clear selection slices that pointed at the removed account's emails/
+      // threads. In unified mode currentAccountId stays null after removal,
+      // so the setCurrentAccountId selection-reset path never fires and the
+      // right pane would otherwise render a ghost thread.
+      const newSelectedThreadIds = new Set<string>();
+      for (const tid of state.selectedThreadIds) {
+        if (!removedThreadIds.has(tid)) newSelectedThreadIds.add(tid);
+      }
       return {
         accounts: newAccounts,
         currentAccountId: newCurrentId,
         syncStatuses: newSyncStatuses,
         backgroundSyncProgress: newBackgroundSyncProgress,
-        emails: state.emails.filter((e) => e.accountId !== accountId),
+        emails: remainingEmails,
         sentEmails: state.sentEmails.filter((e) => e.accountId !== accountId),
+        selectedEmailId:
+          state.selectedEmailId && removedEmailIds.has(state.selectedEmailId)
+            ? null
+            : state.selectedEmailId,
+        selectedThreadId:
+          state.selectedThreadId && removedThreadIds.has(state.selectedThreadId)
+            ? null
+            : state.selectedThreadId,
+        focusedThreadEmailId:
+          state.focusedThreadEmailId && removedEmailIds.has(state.focusedThreadEmailId)
+            ? null
+            : state.focusedThreadEmailId,
+        selectedThreadIds: newSelectedThreadIds,
       };
     }),
   setCurrentAccountId: (accountId) => {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -947,6 +947,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       for (const tid of state.selectedThreadIds) {
         if (!removedThreadIds.has(tid)) newSelectedThreadIds.add(tid);
       }
+      // lastSelectedThreadId is the shift-click range anchor. If the anchor
+      // belonged to the removed account, a subsequent shift-click would
+      // anchor against a thread that no longer exists.
+      const newLastSelectedThreadId =
+        state.lastSelectedThreadId && removedThreadIds.has(state.lastSelectedThreadId)
+          ? null
+          : state.lastSelectedThreadId;
       return {
         accounts: newAccounts,
         currentAccountId: newCurrentId,
@@ -968,6 +975,7 @@ export const useAppStore = create<AppState>((set, get) => ({
             ? null
             : state.focusedThreadEmailId,
         selectedThreadIds: newSelectedThreadIds,
+        lastSelectedThreadId: newLastSelectedThreadId,
         selectedDraftId:
           state.selectedDraftId && removedDraftIds.has(state.selectedDraftId)
             ? null

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -901,14 +901,19 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (state.currentAccountId === accountId) {
         newCurrentId = newAccounts.find((a) => a.isPrimary)?.id || newAccounts[0]?.id || null;
       }
-      // Drop in-memory emails/sent emails for the removed account. The DB
-      // cleanup in main happens in removeAccount(accountId), but state.emails
-      // is the source of truth for the unified ("All Inboxes") view, so
-      // without this the removed account's threads keep rendering until the
-      // app restarts.
+      // Drop in-memory emails/sent emails/local drafts for the removed
+      // account. The DB cleanup in main happens in removeAccount(accountId),
+      // but state.emails / state.sentEmails / state.localDrafts are the
+      // source of truth for what the UI renders, so without this the removed
+      // account's threads keep rendering until the app restarts.
       const remainingEmails: DashboardEmail[] = [];
+      const remainingSentEmails: DashboardEmail[] = [];
       const removedEmailIds = new Set<string>();
       const removedThreadIds = new Set<string>();
+      // Walk both emails and sentEmails: a sent-only thread (outgoing
+      // message with no reply yet) only exists in sentEmails, so building
+      // the removed id sets from state.emails alone would leave its
+      // selection pointers stale.
       for (const e of state.emails) {
         if (e.accountId === accountId) {
           removedEmailIds.add(e.id);
@@ -917,10 +922,27 @@ export const useAppStore = create<AppState>((set, get) => ({
           remainingEmails.push(e);
         }
       }
+      for (const e of state.sentEmails) {
+        if (e.accountId === accountId) {
+          removedEmailIds.add(e.id);
+          if (e.threadId) removedThreadIds.add(e.threadId);
+        } else {
+          remainingSentEmails.push(e);
+        }
+      }
+      const remainingLocalDrafts: LocalDraft[] = [];
+      const removedDraftIds = new Set<string>();
+      for (const d of state.localDrafts) {
+        if (d.accountId === accountId) {
+          removedDraftIds.add(d.id);
+        } else {
+          remainingLocalDrafts.push(d);
+        }
+      }
       // Clear selection slices that pointed at the removed account's emails/
-      // threads. In unified mode currentAccountId stays null after removal,
-      // so the setCurrentAccountId selection-reset path never fires and the
-      // right pane would otherwise render a ghost thread.
+      // threads/drafts. In unified mode currentAccountId stays null after
+      // removal, so the setCurrentAccountId selection-reset path never fires
+      // and the right pane would otherwise render a ghost thread or draft.
       const newSelectedThreadIds = new Set<string>();
       for (const tid of state.selectedThreadIds) {
         if (!removedThreadIds.has(tid)) newSelectedThreadIds.add(tid);
@@ -931,7 +953,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         syncStatuses: newSyncStatuses,
         backgroundSyncProgress: newBackgroundSyncProgress,
         emails: remainingEmails,
-        sentEmails: state.sentEmails.filter((e) => e.accountId !== accountId),
+        sentEmails: remainingSentEmails,
+        localDrafts: remainingLocalDrafts,
         selectedEmailId:
           state.selectedEmailId && removedEmailIds.has(state.selectedEmailId)
             ? null
@@ -945,6 +968,10 @@ export const useAppStore = create<AppState>((set, get) => ({
             ? null
             : state.focusedThreadEmailId,
         selectedThreadIds: newSelectedThreadIds,
+        selectedDraftId:
+          state.selectedDraftId && removedDraftIds.has(state.selectedDraftId)
+            ? null
+            : state.selectedDraftId,
       };
     }),
   setCurrentAccountId: (accountId) => {


### PR DESCRIPTION
## Summary
Removing an account from Settings left its emails visible in the unified "All Inboxes" view until the next app restart. The DB cleanup was already correct (`removeAccount` in `src/main/db/index.ts:1803`), but the renderer store action only pruned `accounts` and `syncStatuses` — `state.emails` retained the removed account's rows, and `useThreadedEmails`'s unified branch (`currentAccountId === null`) returns all emails unfiltered.

## Changes
- `src/renderer/store/index.ts:892` — `removeAccount` now also drops `state.emails` / `state.sentEmails` belonging to the removed account, and clears its `backgroundSyncProgress` entry for symmetry.

## Repro / verification
1. Add two accounts.
2. Switch to "All Inboxes". Confirm threads from both render.
3. Settings → remove one account.
4. Before this fix: threads from the removed account stayed visible until app restart. After: they disappear immediately.

## Test plan
- [ ] Unified view stops showing the removed account's threads without a restart
- [ ] Per-account views are unaffected
- [ ] Re-adding the removed account re-syncs cleanly (DB was already wiped, so this was the pre-existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRE-PR-REPORT-START SHA=724c9d7 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `724c9d7`
- generated: 2026-05-26T00:58:22.455Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.7s |
| eval:features | ✅ exit 0 | 29.9s |
| agentic-verify | ✅ exit 0 | 240.7s |
| real-gmail:cached | ✅ exit 0 | 10.1s |

<!-- PRE-PR-REPORT-END -->
