### PR TITLE
fix: remove hardcoded Ollama Cloud API key fallback

### DIFF
--- a/scripts/compare-analysis-models-retry.mjs
+++ b/scripts/compare-analysis-models-retry.mjs
@@ -20,9 +20,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DB_PATH = join(__dirname, "..", ".dev-data", "data", "exo.db");
 const RESULTS_PATH = join(__dirname, "..", "analysis-benchmark-results.json");
 
-const OLLAMA_KEY =
-  process.env.OLLAMA_API_KEY ||
-  "a589a8cd79304dda84dee97199b99617.HLABcYbmAkUL40JuaXph4OED";
+const OLLAMA_KEY = process.env.OLLAMA_API_KEY;
+
+if (!OLLAMA_KEY) {
+  console.error("OLLAMA_API_KEY env var is required");
+  process.exit(1);
+}
 
 const ANALYSIS_SYSTEM_PROMPT = `Analyze this email and decide if it requires a reply from me.
 

--- a/scripts/compare-analysis-models.mjs
+++ b/scripts/compare-analysis-models.mjs
@@ -31,10 +31,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DB_PATH = join(__dirname, "..", ".dev-data", "data", "exo.db");
 const RESULTS_PATH = join(__dirname, "..", "analysis-benchmark-results.json");
 
-const OLLAMA_KEY =
-  process.env.OLLAMA_API_KEY ||
-  "a589a8cd79304dda84dee97199b99617.HLABcYbmAkUL40JuaXph4OED";
+const OLLAMA_KEY = process.env.OLLAMA_API_KEY;
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
+
+if (!OLLAMA_KEY) {
+  console.error("OLLAMA_API_KEY env var is required");
+  process.exit(1);
+}
 
 const ANALYSIS_SYSTEM_PROMPT = `Analyze this email and decide if it requires a reply from me.
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded Ollama Cloud API key fallback from `scripts/compare-analysis-models.mjs` and `scripts/compare-analysis-models-retry.mjs`.
- key has been rotated.
- Scripts now exit with an error if `OLLAMA_API_KEY` is not set in the environment.

## Context
The key was introduced in #111 (commit 084d231) and is already public in git history on `main`. **The key is being rotated separately** — this PR only stops the bleed at HEAD.

## Test plan
- [ ] Run `node scripts/compare-analysis-models.mjs` without `OLLAMA_API_KEY` — should exit with error.
- [ ] Run with `OLLAMA_API_KEY=<new-rotated-key>` — should work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=b699be9 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `b699be9`
- generated: 2026-05-26T05:10:53.173Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.6s |
| eval:features | ✅ exit 0 | 33.8s |
| agentic-verify | ✅ exit 0 | 64.2s |
| real-gmail:cached | ✅ exit 0 | 10.2s |

<!-- PRE-PR-REPORT-END -->
