### PR TITLE
fix: upgrade Claude Agent SDK to 0.3.150 + close OAuth fallback for Ollama routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "src/extensions-private/*"
       ],
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.37",
-        "@anthropic-ai/sdk": "^0.71.2",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.150",
+        "@anthropic-ai/sdk": "^0.98.0",
         "@electron-toolkit/utils": "^4.0.0",
         "@floating-ui/dom": "^1.7.6",
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -290,59 +290,142 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.87",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.87.tgz",
-      "integrity": "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.150.tgz",
+      "integrity": "sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.74.0",
-        "@modelcontextprotocol/sdk": "^1.27.1"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.150"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
-      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.150.tgz",
+      "integrity": "sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.150.tgz",
+      "integrity": "sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.150.tgz",
+      "integrity": "sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.150.tgz",
+      "integrity": "sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.150.tgz",
+      "integrity": "sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.150.tgz",
+      "integrity": "sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.150.tgz",
+      "integrity": "sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.150.tgz",
+      "integrity": "sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.71.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
-      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "version": "0.98.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
+      "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1742,310 +1825,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
@@ -2366,10 +2145,11 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3258,6 +3038,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -7647,6 +7433,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -13219,6 +13011,16 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/stat-mode": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
       }
     ],
     "asarUnpack": [
-      "node_modules/@anthropic-ai/claude-agent-sdk/**"
+      "node_modules/@anthropic-ai/claude-agent-sdk/**",
+      "node_modules/@anthropic-ai/claude-agent-sdk-*/**"
     ],
     "files": [
       "out/**/*",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "pre-pr": "node scripts/pre-pr.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.37",
-    "@anthropic-ai/sdk": "^0.71.2",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.150",
+    "@anthropic-ai/sdk": "^0.98.0",
     "@electron-toolkit/utils": "^4.0.0",
     "@floating-ui/dom": "^1.7.6",
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/src/main/agents/agent-coordinator.ts
+++ b/src/main/agents/agent-coordinator.ts
@@ -1,6 +1,7 @@
 import { utilityProcess, MessageChannelMain, type BrowserWindow, net } from "electron";
 import path from "path";
 import { existsSync } from "fs";
+import { fileURLToPath } from "url";
 import type {
   AgentContext,
   AgentFrameworkConfig,
@@ -20,6 +21,10 @@ import { saveDraftAndSync } from "../services/gmail-draft-sync";
 import { DEFAULT_STYLE_PROMPT } from "../../shared/types";
 import { populatePrivateProviderConfig } from "./private-providers-main";
 import { createLogger } from "../services/logger";
+
+// __dirname is undefined in ESM. After the @anthropic-ai/claude-agent-sdk
+// 0.3.x upgrade, electron-vite emits the main bundle as ESM.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const log = createLogger("agent-coordinator");
 

--- a/src/main/agents/providers/claude-agent-provider.ts
+++ b/src/main/agents/providers/claude-agent-provider.ts
@@ -46,9 +46,22 @@ const MODEL_ENV_VARS = [
 ] as const;
 
 /**
- * Every var buildChildEnv sets for LLM routing. Used by buildMcpStdioEnv to
- * strip them all from MCP child processes (preventing credential leakage
- * and accidental redirection of MCP-server-internal Anthropic calls).
+ * Vars buildChildEnv sets for LLM routing that must be stripped from
+ * MCP child processes (preventing credential leakage and accidental
+ * redirection of MCP-server-internal Anthropic calls).
+ *
+ * Intentionally excludes `ANTHROPIC_API_KEY` even though buildChildEnv
+ * sets it in the Ollama branch (to the Ollama credential, to force the
+ * SDK off its Keychain OAuth fallback). MCP stdio servers inherit env
+ * from `process.env` — which holds the *user's real Anthropic API key* —
+ * so stripping that key here would break MCP servers that legitimately
+ * call api.anthropic.com. The crossover risk (Ollama credential leaking
+ * to an MCP server expecting an Anthropic key) only exists for our agent
+ * subprocess, which gets its env from buildChildEnv directly, not from
+ * this strip list. If you ever add `ANTHROPIC_API_KEY` here, also drop
+ * the re-add at the bottom of buildMcpStdioEnv — and remember Ollama-only
+ * users will then have no Anthropic credential to re-add, breaking any
+ * MCP server that calls api.anthropic.com.
  */
 const LLM_ROUTING_ENV_VARS = [
   "ANTHROPIC_BASE_URL",

--- a/src/main/agents/providers/claude-agent-provider.ts
+++ b/src/main/agents/providers/claude-agent-provider.ts
@@ -1,6 +1,4 @@
 import { type z } from "zod";
-import path from "path";
-import { spawn as cpSpawn } from "child_process";
 import {
   query,
   tool as sdkTool,
@@ -8,7 +6,6 @@ import {
   type SDKMessage,
   type Query,
   type McpServerConfig,
-  type SpawnOptions as SdkSpawnOptions,
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
   AgentProvider,
@@ -201,10 +198,18 @@ export class ClaudeAgentProvider implements AgentProvider {
     });
     mcpServerMap["mail-app-tools"] = mcpServer;
 
+    const resolvedModel = modelOverride ?? this.frameworkConfig.model;
+    const childEnv = this.buildChildEnv();
+    const redact = (v: string | undefined): string =>
+      v ? `${v.slice(0, 4)}…${v.slice(-4)} (len=${v.length})` : "(unset)";
+    log.info(
+      `[ClaudeAgent:route] model=${resolvedModel} base_url=${childEnv.ANTHROPIC_BASE_URL ?? "(unset)"} auth_token=${redact(childEnv.ANTHROPIC_AUTH_TOKEN)} api_key=${redact(childEnv.ANTHROPIC_API_KEY)} ollama_enabled=${!!this.frameworkConfig.ollamaCloud?.enabled} default_sonnet=${childEnv.ANTHROPIC_DEFAULT_SONNET_MODEL ?? "(unset)"}`,
+    );
+
     const q = query({
       prompt,
       options: {
-        model: modelOverride ?? this.frameworkConfig.model,
+        model: resolvedModel,
         systemPrompt,
         abortController,
         mcpServers: mcpServerMap,
@@ -232,24 +237,7 @@ export class ClaudeAgentProvider implements AgentProvider {
         settingSources: [],
         // Don't persist sessions for SDK calls from within the app
         persistSession: false,
-        env: this.buildChildEnv(),
-        // In packaged Electron apps, import.meta.url resolves inside app.asar but
-        // cli.js lives in app.asar.unpacked (native modules can't be inside asar).
-        // Without this, the SDK tries to spawn a path inside the asar archive and
-        // the child process fails with MODULE_NOT_FOUND.
-        pathToClaudeCodeExecutable: resolvedCliPath,
-        // Use Electron's built-in Node.js runtime instead of searching for `node`
-        // on the system PATH. This eliminates the requirement for users to have
-        // Node.js installed. ELECTRON_RUN_AS_NODE=1 makes the Electron binary
-        // behave as a plain Node.js runtime.
-        spawnClaudeCodeProcess: (opts: SdkSpawnOptions) => {
-          return cpSpawn(process.execPath, opts.args, {
-            cwd: opts.cwd,
-            env: { ...opts.env, ELECTRON_RUN_AS_NODE: "1" },
-            stdio: ["pipe", "pipe", "pipe"],
-            signal: opts.signal,
-          });
-        },
+        env: childEnv,
         // Capture stderr so subprocess errors are visible in logs
         stderr: (data: string) => {
           log.info(`[ClaudeAgent:stderr] ${data.trimEnd()}`);
@@ -423,7 +411,11 @@ export class ClaudeAgentProvider implements AgentProvider {
       // Point Claude Agent SDK at Ollama Cloud's Anthropic-compatible endpoint
       env.ANTHROPIC_BASE_URL = "https://ollama.com";
       env.ANTHROPIC_AUTH_TOKEN = ollama.apiKey;
-      delete env.ANTHROPIC_API_KEY;
+      // Setting ANTHROPIC_API_KEY explicitly forces the SDK to skip its
+      // Keychain OAuth fallback. Without this, Claude Code finds the
+      // "Claude Code-credentials" entry in macOS Keychain and uses an
+      // OAuth flow hardcoded to api.anthropic.com, ignoring our BASE_URL.
+      env.ANTHROPIC_API_KEY = ollama.apiKey;
       // Remap every model env var Claude Code might consult. Without this,
       // Claude Code subtasks (title gen, compaction, sub-agents) silently fall
       // back to hardcoded Anthropic model names which 404 on Ollama Cloud.
@@ -443,33 +435,21 @@ export class ClaudeAgentProvider implements AgentProvider {
     // Prevent cli.js from detecting a "nested session" if CLAUDECODE leaks into
     // the Electron process env (e.g. when launched from a Claude Code terminal).
     delete env.CLAUDECODE;
+
+    // Disable all Claude Code SDK telemetry / error reporting / non-essential
+    // network calls. Without these, every agent run fans out 5+ requests to
+    // api.anthropic.com (event_logging/batch) and 1 to datadoghq.com (error
+    // logs) regardless of inference destination — wasted bandwidth, latency,
+    // and a potential privacy concern when the user has explicitly routed
+    // inference to a third-party endpoint (Ollama Cloud).
+    env.DISABLE_TELEMETRY = "1";
+    env.DISABLE_ERROR_REPORTING = "1";
+    env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
+    env.DO_NOT_TRACK = "1";
+
     return env;
   }
 }
-
-/**
- * Resolve the CLI path for the Claude Agent SDK.
- *
- * In packaged Electron apps, the SDK is in `app.asar.unpacked/node_modules/`
- * (because it contains native binaries that can't be inside an asar archive).
- * The SDK's own resolution uses `import.meta.url` which points inside `app.asar`,
- * so we need to explicitly resolve the path to the unpacked location.
- *
- * In dev mode, `require.resolve` returns the normal filesystem path which works fine.
- */
-const resolvedCliPath = (() => {
-  // require.resolve finds the SDK's package.json entry point (sdk.mjs).
-  // cli.js sits alongside it in the same directory.
-  const sdkEntry = require.resolve("@anthropic-ai/claude-agent-sdk");
-  const sdkDir = path.dirname(sdkEntry);
-  let cliPath = path.join(sdkDir, "cli.js");
-
-  // In packaged apps, the path contains "app.asar" but the actual file is in
-  // "app.asar.unpacked". Replace the asar reference so Node can find the file.
-  cliPath = cliPath.replace(/app\.asar([/\\])/, "app.asar.unpacked$1");
-
-  return cliPath;
-})();
 
 /**
  * Convert an AgentToolSpec into an SdkMcpToolDefinition with result tracking.

--- a/src/main/agents/providers/claude-agent-provider.ts
+++ b/src/main/agents/providers/claude-agent-provider.ts
@@ -213,8 +213,14 @@ export class ClaudeAgentProvider implements AgentProvider {
 
     const resolvedModel = modelOverride ?? this.frameworkConfig.model;
     const childEnv = this.buildChildEnv();
-    const redact = (v: string | undefined): string =>
-      v ? `${v.slice(0, 4)}…${v.slice(-4)} (len=${v.length})` : "(unset)";
+    // For strings ≤8 chars the first-4/last-4 slices would overlap and reveal
+    // the whole secret. Anthropic/Ollama tokens are ≥50 chars in practice, but
+    // gate defensively in case redact() is ever reused for shorter values.
+    const redact = (v: string | undefined): string => {
+      if (!v) return "(unset)";
+      if (v.length <= 8) return `(redacted, len=${v.length})`;
+      return `${v.slice(0, 4)}…${v.slice(-4)} (len=${v.length})`;
+    };
     log.info(
       `[ClaudeAgent:route] model=${resolvedModel} base_url=${childEnv.ANTHROPIC_BASE_URL ?? "(unset)"} auth_token=${redact(childEnv.ANTHROPIC_AUTH_TOKEN)} api_key=${redact(childEnv.ANTHROPIC_API_KEY)} ollama_enabled=${!!this.frameworkConfig.ollamaCloud?.enabled} default_sonnet=${childEnv.ANTHROPIC_DEFAULT_SONNET_MODEL ?? "(unset)"}`,
     );
@@ -251,6 +257,15 @@ export class ClaudeAgentProvider implements AgentProvider {
         // Don't persist sessions for SDK calls from within the app
         persistSession: false,
         env: childEnv,
+        // We do NOT set `pathToClaudeCodeExecutable` or `spawnClaudeCodeProcess`.
+        // SDK 0.3.x replaced the separate `cli.js` subprocess with a bun-bundled
+        // `assistant.mjs` / `bridge.mjs` runtime extracted via `extractFromBunfs.js`.
+        // The bundled bun binary is self-contained, so the old workaround
+        // (overriding spawn to run via Electron's built-in node with
+        // `ELECTRON_RUN_AS_NODE=1`) is no longer needed for packaged apps
+        // without a system Node install. The `node_modules/@anthropic-ai/claude-agent-sdk/**`
+        // asarUnpack entry in package.json keeps the bun assets on a real filesystem
+        // so extraction at runtime works inside a packaged .app.
         // Capture stderr so subprocess errors are visible in logs
         stderr: (data: string) => {
           log.info(`[ClaudeAgent:stderr] ${data.trimEnd()}`);

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,7 +1,13 @@
 import { BrowserWindow, shell, nativeTheme, app } from "electron";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { is } from "@electron-toolkit/utils";
 import { getConfig } from "./ipc/settings.ipc";
+
+// __dirname is undefined in ESM. After the @anthropic-ai/claude-agent-sdk
+// 0.3.x upgrade, electron-vite emits the main bundle as ESM, so we resolve
+// the directory portably from import.meta.url.
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function getIconPath(): string {
   if (app.isPackaged) {


### PR DESCRIPTION
Closes #90 — the bundled Claude Code policy-version check ("version 1.0.77 needs update") was triggered by the old SDK shipping outdated cli.js. Bumping to @anthropic-ai/claude-agent-sdk@0.3.150 ships cli 2.1.150, well above the policy minimum, and removes the bundled-CLI version check path entirely (no separate cli.js subprocess anymore — see Summary below).

## Summary

The Agent worker was still hitting `api.anthropic.com` for inference even when users explicitly selected Ollama Cloud in Settings — only the non-SDK paths (analyzer, draft-generator) routed correctly. Diagnosed via a local CONNECT-logging proxy injected into the spawned subprocess. Two root causes, both fixed here:

1. **Old SDK (`0.2.87`) had a hardcoded `api.anthropic.com` fallback** in its telemetry exporter that ignored `ANTHROPIC_BASE_URL`. The new `0.3.150` ships a bun-bundled runtime (`assistant.mjs` / `bridge.mjs`) where URL resolution is centralized in one client constructor.
2. **macOS Keychain OAuth fallback** — the SDK's `cli.js` subprocess preferred the `Claude Code-credentials` entry in `login.keychain-db` over our `ANTHROPIC_BASE_URL` override. Fixed by setting `ANTHROPIC_API_KEY = ollama.apiKey` alongside `ANTHROPIC_AUTH_TOKEN` so the SDK takes the API-key path (which respects `ANTHROPIC_BASE_URL`).

## Changes

- **`package.json`** — bump `@anthropic-ai/claude-agent-sdk` `^0.2.37` → `^0.3.150`, `@anthropic-ai/sdk` `^0.71.2` → `^0.98.0` (new peer requirement).
- **`src/main/agents/providers/claude-agent-provider.ts`**:
  - Drop `pathToClaudeCodeExecutable` + `spawnClaudeCodeProcess` override + `resolvedCliPath` IIFE — new SDK manages its own runtime and spawn.
  - Set `env.ANTHROPIC_API_KEY = ollama.apiKey` in the Ollama branch of `buildChildEnv()` (closes the OAuth fallback).
  - Disable telemetry / error reporting / non-essential traffic: `DISABLE_TELEMETRY`, `DISABLE_ERROR_REPORTING`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DO_NOT_TRACK`. (Datadog log-batch traffic + SDK `/api/event_logging/batch` calls verified gone.)
  - Add `[ClaudeAgent:route]` log line printing the resolved model, `ANTHROPIC_BASE_URL`, and redacted auth-token / api-key on every query — so future routing regressions are diagnosable from `exo.log` without re-instrumenting.
- **`src/main/window.ts` + `src/main/agents/agent-coordinator.ts`** — add `__dirname` polyfill via `import.meta.url`. The peer-dep bump changed the rollup output to emit the main bundle as ESM, where `__dirname` is undefined; without the polyfill `getIconPath()` throws and the window never opens.

## Verification

End-to-end proof: a CONNECT-blocking proxy that rejects every `api.anthropic.com` connection lets the agent complete successfully via `ollama.com` only. The inference path no longer requires Anthropic.

```
Per-agent-run traffic (after fix, telemetry disabled):
  8  api.anthropic.com   (probes — not load-bearing; agent runs fine when host is blocked)
  2  ollama.com          (actual inference)
  0  datadoghq.com       (was 1+ pre-fix; DISABLE_ERROR_REPORTING took effect)
```

## Out of scope

Kimi K2 self-identifies as Claude in responses ("My CEO is Dario Amodei") because the Claude Code SDK injects a system preamble priming the model. Identity confusion, not routing.

The residual 8 api.anthropic.com probes per run are SDK internals not gated by any documented env-var kill switch. They're non-load-bearing (proven via the blocking proxy) and don't carry user data. Filing an upstream issue is the right next step; not blocking here.

## Test plan

- [ ] Restart dev with Ollama Cloud selected as the Agent provider for both `agentChat` and `agentDrafter`
- [ ] Hit Cmd+J, ask a question, confirm a reply comes back
- [ ] Check `~/Library/Application Support/exo/logs/<today>.log` for `[ClaudeAgent:route]` entries showing `base_url=https://ollama.com` and `ollama_enabled=true`
- [ ] Confirm `llm_calls` table shows ollama-cloud entries for fresh agent activity
- [ ] Confirm the app launches successfully (verifies the `__dirname` ESM polyfill works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=38013bc mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `38013bc`
- generated: 2026-05-26T05:23:53.550Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 17.6s |
| eval:features | ✅ exit 0 | 33.3s |
| agentic-verify | ✅ exit 0 | 103.2s |
| real-gmail:cached | ✅ exit 0 | 13.0s |

<!-- PRE-PR-REPORT-END -->

