### PR TITLE
feat(skill): make electron-devtools-testing run headless and parallel-safe

### DIFF
--- a/.claude/skills/electron-devtools-testing/SKILL.md
+++ b/.claude/skills/electron-devtools-testing/SKILL.md
@@ -105,6 +105,7 @@ import { writeFileSync } from "fs";
 const PORT = process.env.CDP_PORT;
 const list = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
 const page = list.find(p => p.type === "page");
+if (!page) throw new Error(`No page target on port ${PORT} yet — /json/version can succeed before the renderer registers; retry in a moment`);
 const ws = new WebSocket(page.webSocketDebuggerUrl);
 let id = 0; const pending = new Map();
 ws.addEventListener("message", e => { const m = JSON.parse(e.data); if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); } });

--- a/.claude/skills/electron-devtools-testing/SKILL.md
+++ b/.claude/skills/electron-devtools-testing/SKILL.md
@@ -14,33 +14,55 @@ Test the Exo Electron app interactively using Chrome DevTools Protocol (CDP) via
 
    Port `9223` (not the chrome-devtools-mcp default of `9222`) avoids conflicting
    with the user's main Chrome browser, which on this machine already runs with
-   `--remote-debugging-port=9222` for the browser-harness setup. If you change
-   the port here, you must change BOTH the MCP `--browser-url` AND the Electron
-   launch flag below to match.
+   `--remote-debugging-port=9222` for the browser-harness setup. The MCP is hard-wired
+   to this port — it reads `--browser-url` once at subprocess startup and never re-reads
+   it. If you have to launch Electron on a different port (see step 2), the MCP cannot
+   reach it; use direct CDP instead (see **Fallback** below).
 
-2. **App must be launched with remote debugging port**:
+2. **Pick a free debug port, then launch the app headless on it**:
+
    ```bash
-   EXO_DEMO_MODE=true npm run dev -- --remote-debugging-port=9223
+   PORT=9223
+   while lsof -ti:$PORT >/dev/null 2>&1; do PORT=$((PORT+1)); done
+   echo "Using CDP port $PORT"
+   EXO_DEMO_MODE=true EXO_HEADLESS=true npm run dev -- --remote-debugging-port=$PORT
    ```
-   This exposes CDP on port 9223 so the MCP can connect to Electron's renderer process.
-   `npm run dev` is preferred over `npx electron-vite dev` directly because the
-   `dev` script also runs `npm run build:worker` first — without that, the agent
-   sidebar fails to start with "Agent worker failed to start" since the bundled
-   utility-process worker file is missing.
+
+   - `EXO_HEADLESS=true` makes `createWindow` skip `mainWindow.show()` (see
+     `src/main/window.ts`) and hides the macOS dock icon, so the app does not
+     pop visibly or steal focus — the renderer is still fully alive and CDP-attachable.
+     Always pass it; there is no reason to run this skill non-headlessly.
+   - The port probe matters because **parallel sibling worktrees** (Conductor often has
+     2–10 agents running at once) can already hold 9223. Without the probe, your
+     `npm run dev` either fails to bind or, worse, your MCP attaches to the sibling's
+     Electron — you'd be inspecting and "fixing" their renderer, not yours.
+   - `npm run dev` is preferred over `npx electron-vite dev` directly because the
+     `dev` script also runs `npm run build:worker` first — without that, the agent
+     sidebar fails to start with "Agent worker failed to start" since the bundled
+     utility-process worker file is missing.
 
 ## How It Works
 
-- Electron exposes a CDP endpoint at `http://127.0.0.1:9223` when launched with `--remote-debugging-port=9223`
-- The `chrome-devtools` MCP connects to this endpoint and provides tools for page interaction
-- You can navigate, click, type, take screenshots, and inspect the DOM — just like Chrome DevTools
+- Electron exposes a CDP endpoint at `http://127.0.0.1:<PORT>` when launched with `--remote-debugging-port=<PORT>`
+- If `<PORT>` is 9223, the `chrome-devtools` MCP connects and you can use its tools
+- If `<PORT>` is anything else, the MCP can't reach it — use direct CDP from a small node script (see **Fallback**)
+- Either way you can navigate, click, type, take screenshots, and inspect the DOM
 
 ## Workflow
 
-1. **Start the app** (run in background so the terminal is free):
+1. **Start the app headless** on a free port (run in background so the terminal is free):
    ```bash
-   EXO_DEMO_MODE=true npm run dev -- --remote-debugging-port=9223
+   PORT=9223
+   while lsof -ti:$PORT >/dev/null 2>&1; do PORT=$((PORT+1)); done
+   EXO_DEMO_MODE=true EXO_HEADLESS=true npm run dev -- --remote-debugging-port=$PORT
    ```
-   Wait for the dev server to be ready (look for "dev server running" or similar output).
+   Wait for CDP to come up before doing anything else (the dev-server log is unreliable
+   — wait on the CDP endpoint itself):
+   ```bash
+   until curl -sf http://127.0.0.1:$PORT/json/version >/dev/null 2>&1; do sleep 1; done
+   ```
+   The renderer process runs normally and is reachable over CDP; only the visible
+   window and dock icon are suppressed.
 
 2. **List available pages**:
    Use `mcp__chrome-devtools__list_pages` to see Electron's renderer windows.
@@ -70,12 +92,73 @@ Test the Exo Electron app interactively using Chrome DevTools Protocol (CDP) via
 | Close Settings | Click "X" or press Escape |
 | Switch accounts | Click account selector in the sidebar |
 
+## Fallback: direct CDP when port ≠ 9223
+
+The MCP only attaches to whatever port it was configured with at startup (9223 here).
+If the port probe picked something else (9224, 9225, …) because a sibling worktree
+already had 9223, the MCP tools won't work for this run. Drive CDP directly from a
+small node script — no install needed, Node 22+ ships a global `WebSocket`:
+
+```js
+// /tmp/cdp.mjs — run with `CDP_PORT=<port> node /tmp/cdp.mjs`
+import { writeFileSync } from "fs";
+const PORT = process.env.CDP_PORT;
+const list = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
+const page = list.find(p => p.type === "page");
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+let id = 0; const pending = new Map();
+ws.addEventListener("message", e => { const m = JSON.parse(e.data); if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); } });
+const send = (method, params = {}) => new Promise(r => { const i = ++id; pending.set(i, r); ws.send(JSON.stringify({ id: i, method, params })); });
+await new Promise(r => ws.addEventListener("open", r, { once: true }));
+await send("Runtime.enable");
+
+// CDP comes up before React has painted. Poll for a known-rendered marker
+// before doing anything — otherwise your first screenshot is a blank canvas.
+const deadline = Date.now() + 30000;
+while (Date.now() < deadline) {
+  const r = await send("Runtime.evaluate", {
+    expression: `document.body && document.body.innerText.includes("Compose")`,
+    returnByValue: true,
+  });
+  if (r.result?.result?.value === true) break;
+  await new Promise(x => setTimeout(x, 250));
+}
+
+// example: click a button by visible text, then screenshot the result
+await send("Runtime.evaluate", {
+  expression: `Array.from(document.querySelectorAll('button')).find(b => /compose/i.test(b.textContent || ""))?.click()`,
+});
+await new Promise(r => setTimeout(r, 500));
+const shot = await send("Page.captureScreenshot", { format: "png" });
+writeFileSync(".context/shot.png", Buffer.from(shot.result.data, "base64"));
+ws.close();
+```
+
+`Runtime.evaluate`, `Page.captureScreenshot`, `Input.dispatchKeyEvent`, and
+`Input.dispatchMouseEvent` cover everything the MCP would have given you.
+Do NOT `import { WebSocket } from "ws"` — the `ws` package isn't a project
+dependency, and only resolves accidentally from random parent `node_modules`.
+
 ## Notes
 
 - **Demo mode**: When launched with `EXO_DEMO_MODE=true`, the app uses mock data and makes no real Gmail API calls. Useful for testing UI without credentials.
-- **Port conflicts**: If port 9223 is already in use, pick another port and update BOTH the launch flag AND the MCP `--browser-url` (then restart Claude Code so the MCP config takes effect — the MCP subprocess only reads its args at startup).
-- **Stale Electron processes**: `pkill -f "electron-vite dev"` doesn't always kill all child Electron processes from prior dev sessions. If the MCP attaches to a stale Electron whose source code is out of date with the disk, code changes will appear to silently no-op. Use `pkill -9 -f "managua-v1.*Electron.app"` and `pkill -9 -f "electron-vite dev.*--remote-debugging-port=9223"` to be sure, then verify with `ps aux | grep -E "Electron.app\|electron-vite" | grep managua | grep -v grep | wc -l` returning 0.
-- **Multiple windows**: Electron may open multiple pages (main window, DevTools, etc). Always select the correct renderer page before interacting.
+- **Sanity-check which Electron you attached to**: before trusting any screenshot or
+  click result, confirm the CDP endpoint actually belongs to this worktree.
+  `lsof -ti:$PORT` gives the PID; `ps -p <pid> -o command=` should show a path under
+  this worktree (e.g. `.../casablanca/node_modules/electron/...`). If it points at a
+  sibling worktree, something raced past the port probe — pick the next port and relaunch.
+- **Stale Electron processes**: `pkill -f "electron-vite dev"` doesn't always kill all
+  child Electron processes from prior dev sessions. If you attach to a stale Electron
+  whose source code is out of date with the disk, code changes will appear to silently
+  no-op. Scope the kill to **this worktree's path and your chosen port** so you don't
+  nuke sibling agents:
+  ```bash
+  WORKTREE=$(basename "$PWD")
+  pkill -9 -f "$WORKTREE.*Electron.app" 2>/dev/null
+  pkill -9 -f "$WORKTREE.*electron-vite dev.*--remote-debugging-port=$PORT" 2>/dev/null
+  ```
+  Then verify with `lsof -ti:$PORT` returning empty.
+- **Multiple windows**: Electron may open multiple pages (main window, DevTools, etc). Always select the correct renderer page (`type === "page"`, not `"background_page"` or `"other"`) before interacting.
 - **Hot reload**: `electron-vite dev` supports HMR for the renderer. After main-process code changes, you must restart the app — main-process code does NOT hot-reload.
 - **Worker bundle is separate**: `src/main/agents/agent-worker.ts` and code it imports get bundled into `out/worker/agent-worker.cjs` by `npm run build:worker`. After changes to the agent worker, the bundle must rebuild — `npm run dev` does this automatically; `npx electron-vite dev` does NOT.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -432,9 +432,15 @@ app.whenReady().then(async () => {
   // Set app user model id for windows
   electronApp.setAppUserModelId("com.exo.app");
 
-  // Set dock icon on macOS (especially for dev mode where packaged icon isn't used)
+  // Set dock icon on macOS (especially for dev mode where packaged icon isn't used).
+  // In headless mode, hide the dock icon entirely so launching the app for CDP-based
+  // testing doesn't pop a dock icon or steal focus from the user.
   if (process.platform === "darwin" && app.dock) {
-    app.dock.setIcon(getIconPath());
+    if (process.env.EXO_HEADLESS === "true" || process.env.NODE_ENV === "test") {
+      app.dock.hide();
+    } else {
+      app.dock.setIcon(getIconPath());
+    }
   }
 
   // Initialize network monitor


### PR DESCRIPTION
## Summary

Two real annoyances with the `electron-devtools-testing` skill:

1. It launched a visible Electron window that popped to the foreground, stole focus, and pushed an icon to the dock — disruptive when an agent is just poking the UI in the background.
2. It hardcoded debug port 9223, which silently collides with sibling Conductor worktrees doing the same thing. Worst case: the MCP attaches to a sibling's Electron and you "fix" their renderer instead of yours.

This PR makes the skill headless by default and parallel-safe.

## Changes

### `src/main/index.ts`
- When `EXO_HEADLESS=true` (or `NODE_ENV=test`), call `app.dock.hide()` instead of `app.dock.setIcon(...)`. The existing `EXO_HEADLESS=true` path in `src/main/window.ts` already kept the BrowserWindow invisible via `show: false`; this closes the focus-steal gap so launching the app for CDP-based testing is truly invisible.

### `.claude/skills/electron-devtools-testing/SKILL.md`
- Always pass `EXO_HEADLESS=true`.
- Probe for a free port starting at 9223 (`while lsof -ti:\$PORT; do PORT=\$((PORT+1)); done`) instead of hardcoding, so parallel worktrees don't collide.
- Wait on the CDP `/json/version` endpoint instead of dev-server log lines.
- Document a zero-deps direct-CDP fallback (using Node 22+'s built-in `WebSocket` global) for when the probe picks a non-default port. The chrome-devtools MCP only reads `--browser-url` at subprocess startup and can't follow the port.
- Call out NOT to import `ws` — it isn't a project dep and only resolves accidentally from stray parent `node_modules` (true gotcha I hit during verification).
- Add a "which Electron did you attach to?" sanity check.
- Scope the stale-process `pkill` to `\$(basename "\$PWD")` so it doesn't nuke siblings; replaces the stale `managua-v1` reference.
- Note that the first screenshot after CDP comes up will be blank because React hasn't painted yet — include a `Runtime.evaluate` polling pattern in the fallback example. (Caught by my own re-verification.)

## How I verified

End-to-end ran the doc's exact instructions while a sibling worktree (`mail-app/saskatoon`) held port 9223 with a non-headless launch — perfect natural A/B:

| | `EXO_HEADLESS` | On-screen window (CGWindowList) | Dock policy |
|---|---|---|---|
| casablanca (this PR) | `true` | none | `1` (accessory, no dock) |
| saskatoon (control) | unset | 1200×800 visible | `0` (regular) |

The doc's port probe correctly fell through 9223 → 9224. Direct-CDP fallback script screenshotted the inbox and clicked Compose successfully despite no visible window. Screenshots in `.context/` (gitignored).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Manual end-to-end: probe → headless launch → CDP screenshot → CDP click → screenshot of post-click state → teardown
- [x] A/B verified casablanca window invisible while sibling's visible
- [x] Dock policy verified via `NSWorkspace.runningApplications`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=59a6552 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `59a6552`
- generated: 2026-05-26T06:33:34.508Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 12.7s |
| eval:features | ✅ exit 0 | 35.3s |
| agentic-verify | ✅ exit 0 | 124.2s |
| real-gmail:cached | ✅ exit 0 | 10.4s |

<!-- PRE-PR-REPORT-END -->
