### PR TITLE
fix: musl-aware claude binary probe + one-time executable log

### DIFF
--- a/src/main/agents/providers/claude-agent-provider.ts
+++ b/src/main/agents/providers/claude-agent-provider.ts
@@ -117,7 +117,16 @@ const resolveClaudeCodeExecutable = (() => {
 function isMuslRuntime(): boolean {
   if (process.platform !== "linux") return false;
   if (typeof process.report?.getReport !== "function") return false;
-  const report = process.report.getReport();
+  // Isolate getReport() failures (hardened sandboxes, Node internals bugs) so
+  // a musl-detection error doesn't propagate to the outer resolver's catch
+  // and force the SDK-default fallback — better to assume glibc order than
+  // to drop the whole override.
+  let report: unknown;
+  try {
+    report = process.report.getReport();
+  } catch {
+    return false;
+  }
   // Node's ProcessReport type declares `header: object`, so narrow at the boundary.
   if (typeof report !== "object" || report === null) return false;
   if (!("header" in report)) return false;

--- a/src/main/agents/providers/claude-agent-provider.ts
+++ b/src/main/agents/providers/claude-agent-provider.ts
@@ -70,9 +70,13 @@ const resolveClaudeCodeExecutable = (() => {
         process.platform === "android"
           ? [`${base}-linux-${process.arch}-android`]
           : process.platform === "linux"
-            ? // Try musl and glibc; pick whichever the resolver finds. The SDK
-              // probes both regardless of detected libc, so we do too.
-              [`${base}-linux-${process.arch}`, `${base}-linux-${process.arch}-musl`]
+            ? // Match the SDK's K2 probe order: musl-first on a musl runtime,
+              // glibc-first on glibc. With both packages installed, the wrong
+              // ordering would land on an ELF that exec()s but fails to load
+              // its dynamic linker (musl-built binary on glibc, or vice versa).
+              isMuslRuntime()
+              ? [`${base}-linux-${process.arch}-musl`, `${base}-linux-${process.arch}`]
+              : [`${base}-linux-${process.arch}`, `${base}-linux-${process.arch}-musl`]
             : [`${base}-${process.platform}-${process.arch}`];
 
       for (const candidate of candidates) {
@@ -84,6 +88,9 @@ const resolveClaudeCodeExecutable = (() => {
           const unpacked = resolved.replace(/([\\/])app\.asar([\\/])/, "$1app.asar.unpacked$2");
           if (existsSync(unpacked)) {
             cached = unpacked;
+            // Log here (not at every run() call) so the diagnostic fires once
+            // per process when the path is first computed.
+            log.info(`[ClaudeAgent:executable] ${unpacked}`);
             return unpacked;
           }
         } catch {
@@ -95,9 +102,30 @@ const resolveClaudeCodeExecutable = (() => {
     }
 
     cached = null;
+    log.info(`[ClaudeAgent:executable] (SDK default)`);
     return undefined;
   };
 })();
+
+/**
+ * Mirror of the SDK's bx() musl detection. process.report.getReport() exposes
+ * `header.glibcVersionRuntime` only when the process is linked against glibc;
+ * its absence is the cheapest available signal that we're on musl (Alpine,
+ * Wolfi). Kept in lockstep with resolveClaudeCodeExecutable's K2 mirror so we
+ * land on the same binary the SDK would have chosen.
+ */
+function isMuslRuntime(): boolean {
+  if (process.platform !== "linux") return false;
+  if (typeof process.report?.getReport !== "function") return false;
+  const report = process.report.getReport();
+  // Node's ProcessReport type declares `header: object`, so narrow at the boundary.
+  if (typeof report !== "object" || report === null) return false;
+  if (!("header" in report)) return false;
+  const header = report.header;
+  if (typeof header !== "object" || header === null) return false;
+  // Present on glibc, absent on musl.
+  return !("glibcVersionRuntime" in header);
+}
 
 /**
  * Every env var Claude Code's CLI consults for model selection — discovered
@@ -303,8 +331,9 @@ export class ClaudeAgentProvider implements AgentProvider {
     // own resolver returns a path inside `app.asar` under packaged Electron,
     // which fails execve() with ENOTDIR (asar is a file, not a directory).
     // Resolve to the unpacked path ourselves and override the SDK's lookup.
+    // resolveClaudeCodeExecutable memoizes; the diagnostic log fires inside
+    // it on the first call rather than per run() invocation.
     const claudeCodeExecutable = resolveClaudeCodeExecutable();
-    log.info(`[ClaudeAgent:executable] ${claudeCodeExecutable ?? "(SDK default)"}`);
 
     const q = query({
       prompt,


### PR DESCRIPTION
## Summary

Two follow-up fixes to the resolveClaudeCodeExecutable() shim added in #158 — both flagged by Greptile in the review of that PR.

### 1. Detect musl when ordering the linux candidates

The original resolver hard-coded the glibc-first probe order:

```ts
[\`\${base}-linux-\${arch}\`, \`\${base}-linux-\${arch}-musl\`]
```

That matches the SDK's K2() resolver only on a glibc runtime. On a musl-based system (Alpine, Wolfi) with both optional packages installed, \`require.resolve()\` succeeds on the glibc package first, \`existsSync\` passes, and we hand back a glibc-linked ELF. exec() succeeds, but the dynamic linker then fails to load. The SDK itself flips the order based on a libc check; this PR mirrors that.

Adds \`isMuslRuntime()\` which replicates the SDK's \`bx()\` detection: \`process.report.getReport().header.glibcVersionRuntime\` is set on glibc and absent on musl. The candidate list is musl-first on musl, glibc-first on glibc — so we always land on the same binary the SDK would have chosen.

### 2. Log the resolved binary once, not per run()

\`resolveClaudeCodeExecutable()\` is memoized, but the \`[ClaudeAgent:executable] …\` log sat at the \`run()\` call site, so it fired on every agent invocation despite the underlying I/O happening once. PR #158's description called it a "one-time" log; this PR makes it actually so by hoisting it inside the resolver's first-computation branch.

## Test plan

- [x] \`npm run typecheck\` passes (no \`as\` assertions in the new helper — uses \`in\` narrowing)
- [x] \`npm run lint\` passes
- [x] macOS path unchanged: the linux branch and musl helper are unreachable on darwin
- [ ] \`npm run pre-pr\` (full)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=2b2ace7 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `2b2ace7`
- generated: 2026-05-26T07:08:24.789Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 15.8s |
| eval:features | ✅ exit 0 | 32.7s |
| agentic-verify | ✅ exit 0 | 141.0s |
| real-gmail:cached | ✅ exit 0 | 7.8s |

<!-- PRE-PR-REPORT-END -->
