### PR TITLE
fix: Enter in / search fans out across all inboxes in unified view

### DIFF
--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -63,6 +63,7 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
   const {
     setSelectedEmailId,
     currentAccountId,
+    accounts,
     setActiveSearch,
     setViewMode,
     isOnline,
@@ -121,9 +122,14 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
     return () => clearTimeout(timer);
   }, [query, currentAccountId]);
 
-  // Perform full Gmail search and show results (local + remote in parallel)
+  // Perform full Gmail search and show results (local + remote in parallel).
+  // In unified ("all inboxes") mode, currentAccountId is null and we fan out
+  // across every connected account, merging results by email id.
   const performFullSearch = useCallback(() => {
-    if (!query.trim() || !currentAccountId) return;
+    if (!query.trim()) return;
+
+    const targetAccountIds = currentAccountId ? [currentAccountId] : accounts.map((a) => a.id);
+    if (targetAccountIds.length === 0) return;
 
     // Special handling for "in:draft" / "in:drafts" — switch to drafts view instead of searching
     const trimmed = query.trim().toLowerCase();
@@ -139,50 +145,94 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
     // setActiveSearch closes the modal, sets remoteSearchStatus: 'searching'.
     setActiveSearch(query, []);
 
-    // Fire local search — results stream into the store when ready
-    window.api.emails
-      .search(query, currentAccountId, 500)
-      .then((localResponse: IpcResponse<DashboardEmail[]>) => {
-        if (useAppStore.getState().activeSearchQuery !== query) return;
-        if (localResponse.success && localResponse.data) {
-          useAppStore.getState().setActiveSearchResults(localResponse.data);
+    const mergeUniqueById = (lists: DashboardEmail[][]): DashboardEmail[] => {
+      const seen = new Map<string, DashboardEmail>();
+      for (const list of lists) {
+        for (const email of list) {
+          if (!seen.has(email.id)) seen.set(email.id, email);
         }
-      })
-      .catch((error: unknown) => {
-        console.error("Local search failed:", error);
-      });
+      }
+      return Array.from(seen.values());
+    };
 
-    // Fire remote search (slow) — results stream into the store when ready
+    // Fire local search across every target account in parallel
+    Promise.all(
+      targetAccountIds.map((accountId) =>
+        window.api.emails
+          .search(query, accountId, 500)
+          .then((r: IpcResponse<DashboardEmail[]>) => (r.success && r.data ? r.data : []))
+          .catch((error: unknown) => {
+            console.error("Local search failed:", error);
+            return [];
+          }),
+      ),
+    ).then((perAccount) => {
+      if (useAppStore.getState().activeSearchQuery !== query) return;
+      useAppStore.getState().setActiveSearchResults(mergeUniqueById(perAccount));
+    });
+
+    // Fire remote search (slow) across every target account in parallel.
+    // Pagination is per-account, so when fanning out across multiple accounts
+    // we don't expose a nextPageToken — users can refine the query for more results.
     if (isOnline) {
-      window.api.emails
-        .searchRemote(query, currentAccountId, 500)
-        .then(
-          (response: {
-            success: boolean;
-            data?: { emails: DashboardEmail[]; nextPageToken?: string };
-            error?: string;
-          }) => {
-            if (useAppStore.getState().activeSearchQuery !== query) return;
-            if (response.success && response.data) {
-              setRemoteSearchResults(response.data.emails);
-              useAppStore
-                .getState()
-                .setRemoteSearchNextPageToken(response.data.nextPageToken ?? null);
-            } else {
-              setRemoteSearchError(response.error || "Gmail search failed");
-            }
-          },
-        )
-        .catch((err: unknown) => {
-          if (useAppStore.getState().activeSearchQuery !== query) return;
-          setRemoteSearchError(err instanceof Error ? err.message : "Gmail search failed");
-        });
+      type RemoteOutcome =
+        | { ok: true; emails: DashboardEmail[]; next: string | undefined }
+        | { ok: false; error: string };
+      Promise.all(
+        targetAccountIds.map(
+          (accountId): Promise<RemoteOutcome> =>
+            window.api.emails
+              .searchRemote(query, accountId, 500)
+              .then(
+                (
+                  response: IpcResponse<{
+                    emails: DashboardEmail[];
+                    nextPageToken?: string;
+                  }>,
+                ): RemoteOutcome => {
+                  if (response.success) {
+                    return {
+                      ok: true,
+                      emails: response.data.emails,
+                      next: response.data.nextPageToken,
+                    };
+                  }
+                  return { ok: false, error: response.error || "Gmail search failed" };
+                },
+              )
+              .catch(
+                (err: unknown): RemoteOutcome => ({
+                  ok: false,
+                  error: err instanceof Error ? err.message : "Gmail search failed",
+                }),
+              ),
+        ),
+      ).then((results) => {
+        if (useAppStore.getState().activeSearchQuery !== query) return;
+        const successes = results.filter(
+          (r): r is Extract<RemoteOutcome, { ok: true }> => r.ok,
+        );
+        if (successes.length === 0) {
+          const firstError = results.find(
+            (r): r is Extract<RemoteOutcome, { ok: false }> => !r.ok,
+          );
+          setRemoteSearchError(firstError ? firstError.error : "Gmail search failed");
+          return;
+        }
+        setRemoteSearchResults(mergeUniqueById(successes.map((r) => r.emails)));
+        useAppStore
+          .getState()
+          .setRemoteSearchNextPageToken(
+            targetAccountIds.length === 1 ? successes[0].next ?? null : null,
+          );
+      });
     } else {
       setRemoteSearchResults([]);
     }
   }, [
     query,
     currentAccountId,
+    accounts,
     isOnline,
     setActiveSearch,
     setRemoteSearchResults,

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -48,6 +48,16 @@ function decodeHtmlEntities(text: string): string {
   return textarea.value;
 }
 
+function mergeUniqueById(lists: DashboardEmail[][]): DashboardEmail[] {
+  const seen = new Map<string, DashboardEmail>();
+  for (const list of lists) {
+    for (const email of list) {
+      if (!seen.has(email.id)) seen.set(email.id, email);
+    }
+  }
+  return Array.from(seen.values());
+}
+
 interface SearchBarProps {
   isOpen: boolean;
   onClose: () => void;
@@ -145,16 +155,6 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
     // setActiveSearch closes the modal, sets remoteSearchStatus: 'searching'.
     setActiveSearch(query, []);
 
-    const mergeUniqueById = (lists: DashboardEmail[][]): DashboardEmail[] => {
-      const seen = new Map<string, DashboardEmail>();
-      for (const list of lists) {
-        for (const email of list) {
-          if (!seen.has(email.id)) seen.set(email.id, email);
-        }
-      }
-      return Array.from(seen.values());
-    };
-
     // Fire local search across every target account in parallel
     Promise.all(
       targetAccountIds.map((accountId) =>
@@ -166,10 +166,14 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
             return [];
           }),
       ),
-    ).then((perAccount) => {
-      if (useAppStore.getState().activeSearchQuery !== query) return;
-      useAppStore.getState().setActiveSearchResults(mergeUniqueById(perAccount));
-    });
+    )
+      .then((perAccount) => {
+        if (useAppStore.getState().activeSearchQuery !== query) return;
+        useAppStore.getState().setActiveSearchResults(mergeUniqueById(perAccount));
+      })
+      .catch((error: unknown) => {
+        console.error("Local search result processing failed:", error);
+      });
 
     // Fire remote search (slow) across every target account in parallel.
     // Pagination is per-account, so when fanning out across multiple accounts
@@ -207,21 +211,28 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
                 }),
               ),
         ),
-      ).then((results) => {
-        if (useAppStore.getState().activeSearchQuery !== query) return;
-        const successes = results.filter((r): r is Extract<RemoteOutcome, { ok: true }> => r.ok);
-        if (successes.length === 0) {
-          const firstError = results.find((r): r is Extract<RemoteOutcome, { ok: false }> => !r.ok);
-          setRemoteSearchError(firstError ? firstError.error : "Gmail search failed");
-          return;
-        }
-        setRemoteSearchResults(mergeUniqueById(successes.map((r) => r.emails)));
-        useAppStore
-          .getState()
-          .setRemoteSearchNextPageToken(
-            targetAccountIds.length === 1 ? (successes[0].next ?? null) : null,
-          );
-      });
+      )
+        .then((results) => {
+          if (useAppStore.getState().activeSearchQuery !== query) return;
+          const successes = results.filter((r): r is Extract<RemoteOutcome, { ok: true }> => r.ok);
+          if (successes.length === 0) {
+            const firstError = results.find(
+              (r): r is Extract<RemoteOutcome, { ok: false }> => !r.ok,
+            );
+            setRemoteSearchError(firstError ? firstError.error : "Gmail search failed");
+            return;
+          }
+          setRemoteSearchResults(mergeUniqueById(successes.map((r) => r.emails)));
+          useAppStore
+            .getState()
+            .setRemoteSearchNextPageToken(
+              targetAccountIds.length === 1 ? (successes[0].next ?? null) : null,
+            );
+        })
+        .catch((error: unknown) => {
+          if (useAppStore.getState().activeSearchQuery !== query) return;
+          setRemoteSearchError(error instanceof Error ? error.message : "Gmail search failed");
+        });
     } else {
       setRemoteSearchResults([]);
     }

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -209,13 +209,9 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
         ),
       ).then((results) => {
         if (useAppStore.getState().activeSearchQuery !== query) return;
-        const successes = results.filter(
-          (r): r is Extract<RemoteOutcome, { ok: true }> => r.ok,
-        );
+        const successes = results.filter((r): r is Extract<RemoteOutcome, { ok: true }> => r.ok);
         if (successes.length === 0) {
-          const firstError = results.find(
-            (r): r is Extract<RemoteOutcome, { ok: false }> => !r.ok,
-          );
+          const firstError = results.find((r): r is Extract<RemoteOutcome, { ok: false }> => !r.ok);
           setRemoteSearchError(firstError ? firstError.error : "Gmail search failed");
           return;
         }
@@ -223,7 +219,7 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
         useAppStore
           .getState()
           .setRemoteSearchNextPageToken(
-            targetAccountIds.length === 1 ? successes[0].next ?? null : null,
+            targetAccountIds.length === 1 ? (successes[0].next ?? null) : null,
           );
       });
     } else {


### PR DESCRIPTION
## Summary
- In the "all inboxes" (unified) view, pressing `/` → typing → Enter only ever showed the as-you-type local index results. The "Search all mail for ..." affordance and the Gmail remote search were silent no-ops.
- Root cause: `performFullSearch` in `SearchBar.tsx` had `if (!query.trim() || !currentAccountId) return;`, and `currentAccountId` is `null` in unified mode.

## Fix
- Pull `accounts` from the store alongside `currentAccountId`.
- Build `targetAccountIds`: `[currentAccountId]` when one inbox is selected, otherwise every account id.
- Fan out **both** `emails:search` (local FTS) and `emails:searchRemote` (Gmail API) across every target account in parallel, merging results by email id (so a thread present in multiple accounts isn't duplicated).
- Remote error is surfaced only when *every* per-account remote search failed.
- Pagination `nextPageToken` is only exposed in single-account mode — per-account tokens don't compose, so multi-account simply doesn't paginate (first page is already 500 per account; refine the query if you need more).
- Single-account behavior is unchanged.

## Files
- `src/renderer/components/SearchBar.tsx` — `performFullSearch` fan-out + merge.

## Test plan
- [ ] Unified view: `/` → type → Enter → SearchResultsView opens, local results stream in for every account, Gmail results stream in for every account, errors only show if all accounts fail.
- [ ] Single inbox: `/` → type → Enter still works exactly as before, including pagination via `nextPageToken`.
- [ ] `in:draft` shortcut still switches to drafts view in both modes.
- [ ] No regression in the as-you-type debounced search (uses the existing `search.query` path which already supports `accountId?: undefined`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=6699df9 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `6699df9`
- generated: 2026-05-26T22:12:34.830Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.6s |
| eval:features | ✅ exit 0 | 32.7s |
| agentic-verify | ✅ exit 0 | 259.3s |
| real-gmail:cached | ✅ exit 0 | 10.5s |

<!-- PRE-PR-REPORT-END -->
