### PR TITLE
fix(evals): reminder-service fixture should expect needs_reply=true

### DIFF
--- a/tests/evals/fixtures/reminder-service.json
+++ b/tests/evals/fixtures/reminder-service.json
@@ -1,6 +1,6 @@
 {
   "id": "reminder-service-001",
-  "description": "Boomerang reminder service email — automated follow-up reminder, no reply needed",
+  "description": "Boomerang reminder service email — surfaces an unreplied thread from the director; the reminder exists because a reply IS needed on the original conversation",
   "email": {
     "id": "fixture-008",
     "threadId": "thread-008",
@@ -12,6 +12,6 @@
     "snippet": "This is a reminder from Boomerang. You asked to be reminded about..."
   },
   "expected": {
-    "needs_reply": false
+    "needs_reply": true
   }
 }


### PR DESCRIPTION
## Summary

Corrects a wrong eval fixture expectation. `reminder-service-001` expected `needs_reply: false` for a Boomerang reminder, but the analyzer returns `needs_reply: true` — and `true` is the product-correct answer. This brings the eval suite from 70/80 to **80/80**.

## Why the fixture was wrong (not the analyzer)

The fixture treated a Boomerang reminder like an automated notification ("no reply needed"). But:

- A Boomerang reminder exists **because** the user asked to be reminded to reply to the original thread — here, the director's *Q1 Planning Doc Review*, with the reminder body literally saying *"you haven't replied yet."* The reminder is a signal that a reply **is** outstanding on the underlying conversation.
- The app's own **reminder-detection feature** (`mail-ext-web-search` sender-lookup) detects reminder-service senders specifically to find the **original sender** in the thread and enrich/draft a reply for them — i.e. the product treats these as *actionable*, not as no-reply noise.
- Classifying the reminder as `needs_reply: false` files it under "Other", hiding it from prioritization and draft generation — defeating the very reason the user set the reminder.

The analyzer's reasoning matches this: *"Reminder about an unanswered email from director requesting Q1 planning doc review — original email likely required response."*

## Verification

- Ran the analyzer on this fixture 3× — stable `needs_reply: true` all three runs.
- `npm run eval` → **80/80 (100%)**, all 8 fixtures pass.

## Changes

- `tests/evals/fixtures/reminder-service.json` — `expected.needs_reply` `false → true`; description updated to reflect the corrected semantics.

## Notes

- This was flagged as a pre-existing failure during PR #173's pre-pr run (it's unrelated to that agentic-verify work), so it's fixed here on its own branch.
- The baseline (`tests/evals/baseline.json`) has empty `scores`, so there's no baseline entry to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=9522f18 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `9522f18`
- generated: 2026-06-12T18:31:24.438Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 23.9s |
| eval:features | ✅ exit 0 | 44.7s |
| agentic-verify | ✅ exit 0 | 338.4s |
| real-gmail:cached | ✅ exit 0 | 27.3s |

<!-- PRE-PR-REPORT-END -->
