### PR TITLE
fix: migrate persisted Ollama default kimi-k2.6 → glm-5.2

### DIFF
--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -138,6 +138,20 @@ export function getConfig(): Config {
     getStore().set("config", config);
   }
 
+  // v3 migration: GLM 5.2 replaced kimi-k2.6 as the default Ollama model. Existing
+  // installs persisted ollamaCloud.defaultModel under the old constant (SetupWizard
+  // and ExtensionsTab write DEFAULT_OLLAMA_MODEL on save), so the stored value would
+  // otherwise pin them to kimi-k2.6 forever — making the new default a no-op for
+  // anyone who already enabled Ollama. Flip the old default to the new one; leave any
+  // other (explicitly chosen) model untouched.
+  if ((config.configVersion ?? 0) < 3) {
+    if (config.ollamaCloud?.defaultModel === "kimi-k2.6:cloud") {
+      config.ollamaCloud = { ...config.ollamaCloud, defaultModel: DEFAULT_OLLAMA_MODEL };
+    }
+    config.configVersion = 3;
+    getStore().set("config", config);
+  }
+
   return config;
 }
 

--- a/src/main/ipc/settings.ipc.ts
+++ b/src/main/ipc/settings.ipc.ts
@@ -76,7 +76,10 @@ function getStore(): Store<{ config: Config }> {
           // a version-aware default so pre-existing installs (configVersion < 2)
           // are not silently opted in to analytics + session replay.
           keyboardBindings: "superhuman" as const,
-          configVersion: 2,
+          // Keep in sync with the latest migration version in getConfig() so a
+          // fresh install starts current and doesn't trigger a no-op migration
+          // write on first load.
+          configVersion: 3,
         },
       },
     });


### PR DESCRIPTION
## Summary

Follow-up to #175 (make GLM 5.2 the default Ollama model). That PR changed `DEFAULT_OLLAMA_MODEL`, but the change is a **no-op for anyone who had already enabled Ollama** — so the Settings UI and the agent both kept using `kimi-k2.6:cloud`.

## Root cause

`DEFAULT_OLLAMA_MODEL` is only the *fallback* when `ollamaCloud.defaultModel` is unset. But `SetupWizard` and `ExtensionsTab` **persist** `DEFAULT_OLLAMA_MODEL` into `ollamaCloud.defaultModel` whenever Ollama is set up/saved, and `resolveAgentOllamaConfig` resolves the agent model as `featureModels.agentDrafter ?? oc.defaultModel ?? DEFAULT_OLLAMA_MODEL` — so the persisted `kimi-k2.6:cloud` wins over the new constant. Existing installs therefore stay pinned to kimi-k2.6 (reported: the "Default Model" field still shows `kimi-k2.6:cloud` after #175).

## Fix

A `configVersion` 3 migration in `getConfig()` that flips a persisted `ollamaCloud.defaultModel` of **exactly** `"kimi-k2.6:cloud"` (the old default) to the new `DEFAULT_OLLAMA_MODEL` (`glm-5.2:cloud`). Any explicitly-chosen model is left untouched. Mirrors the existing legacy-`model` migration pattern in the same function.

## Verification

Launched dev with a config persisted at `kimi-k2.6:cloud` → after launch, `settings.get()` returns `configVersion: 3` and `ollamaCloud.defaultModel: "glm-5.2:cloud"`. The Settings "Default Model" field now shows GLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- PRE-PR-REPORT-START SHA=1e20bfb mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `1e20bfb`
- generated: 2026-06-16T22:31:37.864Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 13.4s |
| eval:features | ✅ exit 0 | 29.7s |
| agentic-verify | ✅ exit 0 | 78.3s |
| real-gmail:cached | ✅ exit 0 | 8.0s |

<!-- PRE-PR-REPORT-END -->
