### PR TITLE
fix account status indicator jitter

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1762,34 +1762,36 @@ export default function App() {
                 </span>
                 {/* Sync status indicator */}
                 {isSyncing && (
-                  <svg
-                    className="w-4 h-4 text-blue-500 animate-spin"
-                    fill="none"
-                    viewBox="0 0 24 24"
+                  <span
+                    className="flex w-4 h-4 items-center justify-center flex-shrink-0"
+                    title="Syncing"
                   >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
+                    <span className="w-3 h-3 rounded-full border-2 border-blue-200 border-t-blue-500 animate-spin" />
+                  </span>
                 )}
                 {!isSyncing && !isCurrentAccountExpired && currentSyncStatus === "idle" && (
-                  <span className="w-2 h-2 rounded-full bg-green-500" title="Connected" />
+                  <span
+                    className="flex w-4 h-4 items-center justify-center flex-shrink-0"
+                    title="Connected"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-green-500" />
+                  </span>
                 )}
                 {isCurrentAccountExpired && (
-                  <span className="w-2 h-2 rounded-full bg-amber-500" title="Session expired" />
+                  <span
+                    className="flex w-4 h-4 items-center justify-center flex-shrink-0"
+                    title="Session expired"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-amber-500" />
+                  </span>
                 )}
                 {!isCurrentAccountExpired && currentSyncStatus === "error" && (
-                  <span className="w-2 h-2 rounded-full bg-red-500" title="Sync error" />
+                  <span
+                    className="flex w-4 h-4 items-center justify-center flex-shrink-0"
+                    title="Sync error"
+                  >
+                    <span className="w-2 h-2 rounded-full bg-red-500" />
+                  </span>
                 )}
                 <svg
                   className="w-4 h-4 text-gray-500 dark:text-gray-400"


### PR DESCRIPTION
## Summary

- Replace the oversized account selector spinner with a compact micro ring.
- Prevent the account selector from shifting when "All Inboxes" changes between idle and syncing.

## Root cause

The idle status used a `w-2 h-2` dot directly in the account selector row, while syncing used a `w-4 h-4` spinner in the same row. Switching between those states changed the flex item width and made the titlebar button jitter. The fix renders every status inside a stable `w-4 h-4` slot and uses a restrained `w-3 h-3` micro ring for syncing.

## Before

![Account selector status indicator jitter](https://github.com/mickn/exo-upstream-pr/releases/download/pr-181-account-status-jitter/ScreenShot.2026-07-08.at.12.01.30.gif)

## After

![Account selector status indicator after fix captured from the Electron app](https://github.com/mickn/exo-upstream-pr/releases/download/pr-181-account-status-jitter/account-status-jitter-after-real-app.gif)

## Validation

- `PATH=/Users/mick/.nvm/versions/node/v22.22.0/bin:$PATH npm run typecheck:web`
- `PATH=/Users/mick/.nvm/versions/node/v22.22.0/bin:$PATH npx eslint src/renderer/App.tsx`
- `PATH=/Users/mick/.nvm/versions/node/v22.22.0/bin:$PATH npx prettier --check src/renderer/App.tsx`
- Built the PR, launched the Electron app in demo/test mode, toggled the real sync status via `window.__ZUSTAND_STORE__`, and captured the after-state GIF from `BrowserWindow.webContents.capturePage()`. The selector rect stayed unchanged across idle and syncing: left `158.2109`, width `141.5703`.


<!-- PRE-PR-REPORT-START SHA=54aea4d mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `54aea4d`
- generated: 2026-07-16T02:10:29.946Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 21.1s |
| eval:features | ✅ exit 0 | 42.5s |
| agentic-verify | ✅ exit 0 | 129.7s |
| real-gmail:cached | ✅ exit 0 | 17.4s |

<!-- PRE-PR-REPORT-END -->
