### PR TITLE
Remove right preview sidebar

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2256,7 +2256,6 @@ export default function App() {
 
         {/* Full mode: full email detail view */}
         {viewMode === "full" && <EmailDetail isFullView />}
-
       </div>
 
       {/* Keyboard hints bar */}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,7 +15,6 @@ import { SetupWizard } from "./components/SetupWizard";
 import { SearchBar } from "./components/SearchBar";
 import { CommandPalette } from "./components/CommandPalette";
 import { AgentCommandPalette } from "./components/AgentCommandPalette";
-import { AgentsSidebar } from "./components/AgentsSidebar";
 import { ShortcutHelp } from "./components/ShortcutHelp";
 import { KeyboardHints } from "./components/KeyboardHints";
 import { OfflineBanner } from "./components/OfflineBanner";
@@ -645,7 +644,6 @@ export default function App() {
   const isCommandPaletteOpen = useAppStore((s) => s.isCommandPaletteOpen);
   const isFindBarOpen = useAppStore((s) => s.isFindBarOpen);
   const isAgentPaletteOpen = useAppStore((s) => s.isAgentPaletteOpen);
-  const isAgentsSidebarOpen = useAppStore((s) => s.isAgentsSidebarOpen);
   const viewMode = useAppStore((s) => s.viewMode);
   const activeSearchQuery = useAppStore((s) => s.activeSearchQuery);
   const _activeSearchResults = useAppStore((s) => s.activeSearchResults);
@@ -2241,9 +2239,6 @@ export default function App() {
 
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Agents sidebar (collapsible left panel) */}
-        {isAgentsSidebarOpen && <AgentsSidebar />}
-
         {/* Search results view (shown when search is active and not viewing a specific email) */}
         {activeSearchQuery && viewMode !== "full" && <SearchResultsView />}
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,7 +10,6 @@ import {
 } from "./store";
 import { EmailList } from "./components/EmailList";
 import { EmailDetail } from "./components/EmailDetail";
-import { EmailPreviewSidebar } from "./components/EmailPreviewSidebar";
 import { SettingsPanel } from "./components/SettingsPanel";
 import { SetupWizard } from "./components/SetupWizard";
 import { SearchBar } from "./components/SearchBar";
@@ -2263,9 +2262,6 @@ export default function App() {
         {/* Full mode: full email detail view */}
         {viewMode === "full" && <EmailDetail isFullView />}
 
-        {/* Preview sidebar — kept mounted across view mode transitions to avoid
-            expensive unmount/remount of agent trace timelines */}
-        {(!activeSearchQuery || viewMode === "full") && <EmailPreviewSidebar />}
       </div>
 
       {/* Keyboard hints bar */}

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -576,13 +576,6 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 
       // --- Agents ---
       {
-        id: "open-agents-sidebar",
-        label: "Open Agents Sidebar",
-        category: "Agents",
-        icon: ICONS.settings,
-        execute: () => useAppStore.getState().toggleAgentsSidebar(),
-      },
-      {
         id: "run-with-agents",
         label: "Run with Selected Agents",
         category: "Agents",

--- a/src/renderer/components/KeyboardHints.tsx
+++ b/src/renderer/components/KeyboardHints.tsx
@@ -14,7 +14,6 @@ const DEFAULT_HINTS: Hint[] = [
   { key: "x", label: "select" },
   { key: "c", label: "compose" },
   { key: "/", label: "search" },
-  { key: "b", label: "sidebar" },
   { key: "\u2318K", label: "commands" },
 ];
 

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -251,7 +251,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
 
       // In compose mode, only handle Cmd+Enter for send — except when the
       // editor isn't focused (e.g. auto-opened draft without focus), where
-      // Enter should focus the editor and "b" should switch sidebar tabs.
+      // Enter should focus the editor.
       if (mode === "compose" && isInputFocused()) {
         return;
       }
@@ -674,19 +674,15 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
         return;
       }
 
-      // --- Shift+J/K/Arrow: extend selection up/down ---
-      if (
-        e.shiftKey &&
-        (e.key === "J" || e.key === "K" || e.key === "ArrowDown" || e.key === "ArrowUp") &&
-        !activeSearchQuery
-      ) {
+      // --- Shift+J/K: extend selection up/down ---
+      if (e.shiftKey && (e.key === "J" || e.key === "K") && !activeSearchQuery) {
         e.preventDefault();
         markNavigationActive();
         if (visibleThreads.length === 0) return;
         const currentIndex = visibleThreads.findIndex((t) => t.threadId === selectedThreadId);
         if (currentIndex < 0) return;
 
-        const direction = e.key === "J" || e.key === "ArrowDown" ? 1 : -1;
+        const direction = e.key === "J" ? 1 : -1;
         const nextIndex = currentIndex + direction;
         if (nextIndex < 0 || nextIndex >= visibleThreads.length) return;
 
@@ -768,11 +764,6 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
       switch (e.key) {
         // Navigation
         case "j":
-        case "ArrowDown":
-          // Skip Shift+Arrow — arrow keys don't change e.key when shift is held
-          // (unlike j→J), so without this guard Shift+ArrowDown would navigate
-          // instead of being a no-op like Shift+J in the switch.
-          if (e.shiftKey && e.key.startsWith("Arrow")) break;
           e.preventDefault();
           // Defer any pending sync-driven store updates while navigating
           markNavigationActive();
@@ -784,8 +775,6 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           break;
 
         case "k":
-        case "ArrowUp":
-          if (e.shiftKey && e.key.startsWith("Arrow")) break;
           e.preventDefault();
           markNavigationActive();
           if (activeSearchQuery) {

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -1076,12 +1076,6 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           }
           break;
 
-        // Switch sidebar tab
-        case "b":
-          e.preventDefault();
-          state.cycleSidebarTab();
-          break;
-
         // z: undo last action (Gmail only — no modifier needed)
         case "z":
           if (isGmail && !e.shiftKey) {
@@ -1201,7 +1195,6 @@ export function getKeyboardShortcuts(bindings: "superhuman" | "gmail") {
       { key: "Cmd+J", description: "Agent action palette" },
     ],
     other: [
-      { key: "b", description: "Switch sidebar tab" },
       { key: "Cmd+,", description: "Settings" },
       { key: "?", description: "Show shortcuts" },
     ],

--- a/tests/e2e/arrow-key-navigation.spec.ts
+++ b/tests/e2e/arrow-key-navigation.spec.ts
@@ -1,14 +1,5 @@
 import { test, expect, Page, ElectronApplication } from "@playwright/test";
-import { launchElectronApp , closeApp } from "./launch-helpers";
-
-/** Best-effort screenshot */
-async function screenshot(page: Page, name: string) {
-  const { mkdirSync } = await import("fs");
-  mkdirSync("tests/screenshots", { recursive: true });
-  await page.screenshot({ path: `tests/screenshots/${name}.png`, timeout: 5000 }).catch(() => {
-    console.log(`Screenshot '${name}' timed out, skipping`);
-  });
-}
+import { launchElectronApp, closeApp, waitForEmailListReady } from "./launch-helpers";
 
 /** Get the data-thread-id of the currently selected (highlighted) row */
 async function getSelectedThreadId(page: Page): Promise<string | null> {
@@ -19,7 +10,24 @@ async function getSelectedThreadId(page: Page): Promise<string | null> {
   return null;
 }
 
-test.describe("Arrow Key Navigation", () => {
+async function clearSelection(page: Page): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    if (!(await getSelectedThreadId(page))) return;
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(150);
+  }
+}
+
+async function selectFirstThread(page: Page): Promise<string> {
+  const selectedRow = page.locator("div[data-thread-id][data-selected='true']");
+  await page.keyboard.press("j");
+  await expect(selectedRow).toBeVisible({ timeout: 5000 });
+  const selectedThreadId = await getSelectedThreadId(page);
+  expect(selectedThreadId).not.toBeNull();
+  return selectedThreadId!;
+}
+
+test.describe("Arrow keys keep native scroll behavior", () => {
   test.describe.configure({ mode: "serial" });
   let electronApp: ElectronApplication;
   let page: Page;
@@ -42,109 +50,52 @@ test.describe("Arrow Key Navigation", () => {
     }
   });
 
-  test("ArrowDown selects first email, same as j", async () => {
-    await page.waitForTimeout(500);
-    await screenshot(page, "arrow-nav-01-initial");
-
-    // Press ArrowDown to select the first thread
-    await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(300);
-
-    const selectedAfterArrow = await getSelectedThreadId(page);
-    expect(selectedAfterArrow).not.toBeNull();
-
-    await screenshot(page, "arrow-nav-02-after-arrow-down");
-  });
-
-  test("ArrowDown and j navigate to the same positions", async () => {
-    // Start fresh: press Escape to deselect
-    await page.keyboard.press("Escape");
-    await page.waitForTimeout(300);
-
-    // Navigate down with j
-    await page.keyboard.press("j");
-    await page.waitForTimeout(300);
-    const afterJ1 = await getSelectedThreadId(page);
-
-    await page.keyboard.press("j");
-    await page.waitForTimeout(300);
-    const afterJ2 = await getSelectedThreadId(page);
-
-    // Go back up to the first position with k
-    await page.keyboard.press("k");
-    await page.waitForTimeout(300);
-
-    // Now navigate with ArrowDown from the same start position
-    const backToFirst = await getSelectedThreadId(page);
-    expect(backToFirst).toBe(afterJ1);
+  test("ArrowDown does not select or open mail from the inbox", async () => {
+    await waitForEmailListReady(page);
+    await clearSelection(page);
 
     await page.keyboard.press("ArrowDown");
     await page.waitForTimeout(300);
-    const afterArrow = await getSelectedThreadId(page);
 
-    // ArrowDown should land on the same thread as the second j press
-    expect(afterArrow).toBe(afterJ2);
-
-    await screenshot(page, "arrow-nav-03-arrow-matches-j");
+    expect(await getSelectedThreadId(page)).toBeNull();
+    await expect(page.locator("button[title='Reply All']").first()).toBeHidden({ timeout: 3000 });
+    await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
+    await expect(page.locator(".w-64.exo-preview-shell")).toBeHidden({ timeout: 3000 });
   });
 
-  test("ArrowUp navigates up, same as k", async () => {
-    // Navigate down a couple times first
-    await page.keyboard.press("Escape");
+  test("ArrowUp and ArrowDown do not move the highlighted inbox row", async () => {
+    await waitForEmailListReady(page);
+    await clearSelection(page);
+    const selectedBefore = await selectFirstThread(page);
+
+    await page.keyboard.press("ArrowDown");
     await page.waitForTimeout(300);
+    expect(await getSelectedThreadId(page)).toBe(selectedBefore);
 
-    await page.keyboard.press("j");
-    await page.waitForTimeout(200);
-    await page.keyboard.press("j");
-    await page.waitForTimeout(200);
-    await page.keyboard.press("j");
-    await page.waitForTimeout(200);
-    const thirdPosition = await getSelectedThreadId(page);
-
-    // Go up with k
-    await page.keyboard.press("k");
-    await page.waitForTimeout(300);
-    const afterK = await getSelectedThreadId(page);
-
-    // Go back down to third position
-    await page.keyboard.press("j");
-    await page.waitForTimeout(300);
-    expect(await getSelectedThreadId(page)).toBe(thirdPosition);
-
-    // Go up with ArrowUp
     await page.keyboard.press("ArrowUp");
     await page.waitForTimeout(300);
-    const afterArrowUp = await getSelectedThreadId(page);
+    expect(await getSelectedThreadId(page)).toBe(selectedBefore);
 
-    // Should match the k result
-    expect(afterArrowUp).toBe(afterK);
-
-    await screenshot(page, "arrow-nav-04-arrow-up-matches-k");
+    await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
+    await expect(page.locator(".w-64.exo-preview-shell")).toBeHidden({ timeout: 3000 });
   });
 
-  test("mixed arrow and j/k navigation works together", async () => {
-    await page.keyboard.press("Escape");
+  test("Arrow keys do not reveal a sidebar in full mail view", async () => {
+    await waitForEmailListReady(page);
+    await clearSelection(page);
+    await selectFirstThread(page);
+
+    await page.keyboard.press("Enter");
+    const replyButton = page.locator("button[title='Reply All']").first();
+    await expect(replyButton).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("ArrowUp");
     await page.waitForTimeout(300);
 
-    // j → ArrowDown → k → ArrowUp should return to start
-    await page.keyboard.press("j");
-    await page.waitForTimeout(200);
-    const start = await getSelectedThreadId(page);
-
-    await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(200);
-
-    await page.keyboard.press("k");
-    await page.waitForTimeout(200);
-    expect(await getSelectedThreadId(page)).toBe(start);
-
-    await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(200);
-
-    await page.keyboard.press("ArrowUp");
-    await page.waitForTimeout(200);
-    expect(await getSelectedThreadId(page)).toBe(start);
-
-    await screenshot(page, "arrow-nav-05-mixed-navigation");
+    await expect(replyButton).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
+    await expect(page.locator(".w-64.exo-preview-shell")).toBeHidden({ timeout: 3000 });
   });
 });

--- a/tests/e2e/keyboard-flow.spec.ts
+++ b/tests/e2e/keyboard-flow.spec.ts
@@ -85,28 +85,26 @@ test.describe("Keyboard Navigation - j/k Movement", () => {
     }
   });
 
-  test("ArrowDown works the same as j", async () => {
+  test("ArrowDown does not move the selected email", async () => {
     const before = await getSelectedThreadId(page);
+    expect(before).not.toBeNull();
 
     await page.keyboard.press("ArrowDown");
     await page.waitForTimeout(300);
 
     const after = await getSelectedThreadId(page);
-    expect(after).not.toBeNull();
+    expect(after).toBe(before);
   });
 
-  test("ArrowUp works the same as k", async () => {
-    // Move down first
-    await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(200);
-
+  test("ArrowUp does not move the selected email", async () => {
     const before = await getSelectedThreadId(page);
+    expect(before).not.toBeNull();
 
     await page.keyboard.press("ArrowUp");
     await page.waitForTimeout(300);
 
     const after = await getSelectedThreadId(page);
-    expect(after).not.toBeNull();
+    expect(after).toBe(before);
   });
 
   test("j at the bottom of list stays at last email", async () => {

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, Page, ElectronApplication } from "@playwright/test";
-import { launchElectronApp, pressKeyUntilVisible, closeApp } from "./launch-helpers";
+import {
+  launchElectronApp,
+  pressKeyUntilVisible,
+  closeApp,
+  waitForEmailListReady,
+} from "./launch-helpers";
 
 /**
  * E2E Tests for the sender profile panel.

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page, ElectronApplication } from "@playwright/test";
-import { launchElectronApp, pressKeyUntilVisible , closeApp } from "./launch-helpers";
+import { launchElectronApp, pressKeyUntilVisible, closeApp } from "./launch-helpers";
 
 /**
  * E2E Tests for the sender profile panel.

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -216,7 +216,7 @@ test.describe("Sender Profile - Sidebar Tab Cycling", () => {
     }
   });
 
-  test("pressing 'b' does not show the removed preview sidebar", async () => {
+  test("pressing 'b' does not show a sidebar", async () => {
     await expect(page.locator("text=Exo").first()).toBeVisible({ timeout: 10000 });
 
     // Select an email first
@@ -226,10 +226,12 @@ test.describe("Sender Profile - Sidebar Tab Cycling", () => {
     await page.keyboard.press("b");
     await page.waitForTimeout(500);
     await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
+    await expect(page.locator(".w-64.exo-preview-shell")).toBeHidden({ timeout: 3000 });
 
     await page.keyboard.press("b");
     await page.waitForTimeout(500);
     await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
+    await expect(page.locator(".w-64.exo-preview-shell")).toBeHidden({ timeout: 3000 });
   });
 });
 

--- a/tests/e2e/sender-profile.spec.ts
+++ b/tests/e2e/sender-profile.spec.ts
@@ -4,9 +4,8 @@ import { launchElectronApp, pressKeyUntilVisible , closeApp } from "./launch-hel
 /**
  * E2E Tests for the sender profile panel.
  *
- * Tests cover the sidebar panel that shows sender information
- * when an email is selected, profile display, switching between
- * emails and verifying the profile updates, and sidebar tab cycling.
+ * Tests cover sender information in email detail views and verify the
+ * deprecated right-side preview sidebar stays hidden.
  *
  * All tests run in DEMO_MODE with fake emails and mock sender profiles.
  */
@@ -73,8 +72,12 @@ test.describe("Sender Profile - Display", () => {
     expect(foundSender).toBe(true);
   });
 
-  test("sidebar panel is available when email is selected", async () => {
-    // Enter full view to see the sidebar
+  test("right preview sidebar is hidden when email is selected", async () => {
+    await waitForEmailListReady(page);
+    const selectedRow = page.locator("div[data-thread-id][data-selected='true']");
+    await pressKeyUntilVisible(page, "j", selectedRow, { timeout: 15000 });
+
+    // Enter full view.
     await page.keyboard.press("Enter");
     await page.waitForTimeout(800);
 
@@ -85,17 +88,20 @@ test.describe("Sender Profile - Display", () => {
       return;
     }
 
-    // Check for sender-related content (avatar, name, email)
-    // The SenderProfilePanel shows a circular avatar and sender details
-    const avatar = page.locator("[class*='rounded-full']").first();
-    await expect(avatar).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
+    await expect(page.locator("[data-testid='sidebar-sender-name']")).toBeHidden({
+      timeout: 3000,
+    });
 
     // Return to split view
     await page.keyboard.press("Escape");
     await page.waitForTimeout(500);
   });
 
-  test("leaving full view preserves row selection and sender sidebar", async () => {
+  test("leaving full view preserves row selection and keeps preview sidebar hidden", async () => {
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+    await waitForEmailListReady(page);
     const selectedRow = page.locator("div[data-thread-id][data-selected='true']");
     await pressKeyUntilVisible(page, "j", selectedRow, { timeout: 15000 });
     const selectedThreadIdBefore = await selectedRow.getAttribute("data-thread-id");
@@ -103,20 +109,20 @@ test.describe("Sender Profile - Display", () => {
     const replyButton = page.locator("button[title='Reply All']").first();
     await pressKeyUntilVisible(page, "Enter", replyButton, { timeout: 10000 });
 
+    const previewSidebar = page.locator(".w-96.exo-preview-shell");
     const senderName = page.locator("[data-testid='sidebar-sender-name']");
-    await expect(senderName).toBeVisible({ timeout: 5000 });
-    const senderBefore = await senderName.textContent();
+    await expect(previewSidebar).toBeHidden({ timeout: 5000 });
+    await expect(senderName).toBeHidden({ timeout: 5000 });
 
     await page.keyboard.press("Escape");
 
     // Full view is gone, but the row stays highlighted on the email we were
-    // just viewing so j/k resume from there. The preview sidebar keeps showing
-    // that email's sender.
+    // just viewing so j/k resume from there. The preview sidebar stays hidden.
     await expect(replyButton).toBeHidden({ timeout: 5000 });
     await expect(selectedRow).toHaveCount(1);
     expect(await selectedRow.getAttribute("data-thread-id")).toBe(selectedThreadIdBefore);
-    await expect(senderName).toBeVisible({ timeout: 5000 });
-    expect(await senderName.textContent()).toBe(senderBefore);
+    await expect(previewSidebar).toBeHidden({ timeout: 5000 });
+    await expect(senderName).toBeHidden({ timeout: 5000 });
   });
 });
 
@@ -210,31 +216,20 @@ test.describe("Sender Profile - Sidebar Tab Cycling", () => {
     }
   });
 
-  test("pressing 'b' cycles through sidebar tabs", async () => {
-    await expect(page.locator("text=Inbox").first()).toBeVisible({ timeout: 10000 });
+  test("pressing 'b' does not show the removed preview sidebar", async () => {
+    await expect(page.locator("text=Exo").first()).toBeVisible({ timeout: 10000 });
 
     // Select an email first
     await page.keyboard.press("j");
     await page.waitForTimeout(500);
 
-    // Get current page content
-    const contentBefore = await page.textContent("body");
-
-    // Press 'b' to cycle sidebar tab
     await page.keyboard.press("b");
     await page.waitForTimeout(500);
+    await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
 
-    // Content may change as a different sidebar tab is shown
-    // Just verify no crash
-    const contentAfter = await page.textContent("body");
-    expect(contentAfter).toBeTruthy();
-
-    // Press 'b' again to cycle to next tab
     await page.keyboard.press("b");
     await page.waitForTimeout(500);
-
-    const contentAfterSecond = await page.textContent("body");
-    expect(contentAfterSecond).toBeTruthy();
+    await expect(page.locator(".w-96.exo-preview-shell")).toBeHidden({ timeout: 3000 });
   });
 });
 

--- a/tests/e2e/sidebar-focused-email.spec.ts
+++ b/tests/e2e/sidebar-focused-email.spec.ts
@@ -1,25 +1,11 @@
 import { test, expect, Page, ElectronApplication } from "@playwright/test";
-import { launchElectronApp , closeApp } from "./launch-helpers";
+import { launchElectronApp, closeApp } from "./launch-helpers";
 
 /**
- * E2E test: sidebar reflects the focused email in a multi-sender thread.
- *
- * Uses the "Launch Readiness Review" thread which has 6 emails from 5 different
- * senders. Expanding each email should update the sidebar sender header to show
- * that email's sender.
+ * E2E test: the removed right preview sidebar stays hidden in a multi-sender thread.
  */
 
-// The multi-sender thread senders in chronological order.
-const THREAD_SENDERS = [
-  { id: "demo-multi-001", name: "Nicolas Dessaigne", email: "nicolas.d@acmecorp.com" },
-  { id: "demo-multi-002", name: "Pete Koomen", email: "pete.koomen@acmecorp.com" },
-  { id: "demo-multi-003", name: "Aaron Epstein", email: "aaron.epstein@acmecorp.com" },
-  { id: "demo-multi-004", name: "Brad Flora", email: "brad.flora@acmecorp.com" },
-  { id: "demo-multi-005", name: "Harj Taggar", email: "harj.taggar@acmecorp.com" },
-  { id: "demo-multi-006", name: "Nicolas Dessaigne", email: "nicolas.d@acmecorp.com" },
-];
-
-test.describe("Sidebar reflects focused email in thread", () => {
+test.describe("Preview sidebar is hidden in thread", () => {
   test.describe.configure({ mode: "serial" });
   let electronApp: ElectronApplication;
   let page: Page;
@@ -36,7 +22,7 @@ test.describe("Sidebar reflects focused email in thread", () => {
     }
   });
 
-  test("clicking different emails in a multi-sender thread updates the sidebar sender", async () => {
+  test("clicking different emails in a multi-sender thread does not show the preview sidebar", async () => {
     // Wait for inbox to load
     await expect(page.locator("text=Inbox").first()).toBeVisible({ timeout: 10000 });
 
@@ -50,25 +36,25 @@ test.describe("Sidebar reflects focused email in thread", () => {
       timeout: 5000,
     });
 
-    // Wait for the sidebar to settle after thread load
-    await page.waitForTimeout(1000);
-
-    // Ensure we're on the Sender tab (the sidebar may auto-switch to Agent
-    // tab for threads that have analysis results)
-    const senderTabButton = page.locator("button").filter({ hasText: "Sender" });
-    if (await senderTabButton.isVisible().catch(() => false)) {
-      await senderTabButton.click();
-      await page.waitForTimeout(300);
-    }
-
+    const previewSidebar = page.locator(".w-96.exo-preview-shell");
     const sidebarName = page.locator("[data-testid='sidebar-sender-name']");
     const sidebarEmail = page.locator("[data-testid='sidebar-sender-email']");
-    await expect(sidebarName).toBeVisible({ timeout: 5000 });
+    await expect(previewSidebar).toBeHidden({ timeout: 5000 });
+    await expect(sidebarName).toBeHidden({ timeout: 5000 });
+    await expect(sidebarEmail).toBeHidden({ timeout: 5000 });
 
-    // Click through each email in the thread and verify the sidebar updates.
+    // Click through each email in the thread and verify the right rail stays hidden.
     // Thread messages are rendered inside [data-email-id] wrappers.
-    for (const sender of THREAD_SENDERS) {
-      const emailWrapper = page.locator(`[data-email-id="${sender.id}"]`);
+    const emailIds = [
+      "demo-multi-001",
+      "demo-multi-002",
+      "demo-multi-003",
+      "demo-multi-004",
+      "demo-multi-005",
+      "demo-multi-006",
+    ];
+    for (const emailId of emailIds) {
+      const emailWrapper = page.locator(`[data-email-id="${emailId}"]`);
       await expect(emailWrapper).toBeVisible({ timeout: 3000 });
 
       // Click the message row to toggle expand/collapse
@@ -84,9 +70,9 @@ test.describe("Sidebar reflects focused email in thread", () => {
         await page.waitForTimeout(500);
       }
 
-      // Verify sidebar now shows this sender
-      await expect(sidebarName).toHaveText(sender.name, { timeout: 3000 });
-      await expect(sidebarEmail).toHaveText(sender.email, { timeout: 3000 });
+      await expect(previewSidebar).toBeHidden({ timeout: 3000 });
+      await expect(sidebarName).toBeHidden({ timeout: 3000 });
+      await expect(sidebarEmail).toBeHidden({ timeout: 3000 });
     }
   });
 });


### PR DESCRIPTION
## Summary
- remove the right EmailPreviewSidebar render path entirely
- remove keyboard and command-palette entry points that could surface sidebar state
- let ArrowUp/ArrowDown keep native scroll behavior instead of moving mail selection

## Verification
- npm run typecheck:web
- npm run build
- npx playwright test tests/e2e/sender-profile.spec.ts tests/e2e/sidebar-focused-email.spec.ts --project=e2e --workers=1
- npx playwright test tests/e2e/arrow-key-navigation.spec.ts tests/e2e/keyboard-flow.spec.ts --project=e2e --workers=1

## Release note
I attempted to publish v0.14.1 from the fork, but the release workflow failed at Apple signing because the fork has no Actions signing secrets (CSC_LINK / CSC_KEY_PASSWORD). The packaged updater points at the upstream repo, so this needs to land and be tagged from upstream to go live.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/exo/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->