### PR TITLE
fix: show Hostler settings save feedback

### DIFF
--- a/src/renderer/components/ExtensionsTab.tsx
+++ b/src/renderer/components/ExtensionsTab.tsx
@@ -72,19 +72,42 @@ export function ExtensionsTab() {
   const [hostlerApiKey, setHostlerApiKey] = useState("");
   const [hostlerHarness, setHostlerHarness] = useState(DEFAULT_HOSTLER_HARNESS);
   const [hostlerModel, setHostlerModel] = useState("");
+  const [hostlerSaveState, setHostlerSaveState] = useState<"idle" | "saving" | "saved" | "error">(
+    "idle",
+  );
+  const [hostlerSaveError, setHostlerSaveError] = useState("");
 
   // Blank fields are sent as undefined so the settings deep-merge preserves
   // stored values — e.g. flipping the toggle before the async config load
   // populates local state must not blank a stored API key.
   const saveHostlerSettings = async (enabled: boolean) => {
-    await window.api.settings.set({
-      hostler: {
-        enabled,
-        apiKey: hostlerApiKey || undefined,
-        harness: hostlerHarness || DEFAULT_HOSTLER_HARNESS,
-        model: hostlerModel || undefined,
-      },
-    });
+    setHostlerSaveState("saving");
+    setHostlerSaveError("");
+    try {
+      const result = (await window.api.settings.set({
+        hostler: {
+          enabled,
+          apiKey: hostlerApiKey || undefined,
+          harness: hostlerHarness || DEFAULT_HOSTLER_HARNESS,
+          model: hostlerModel || undefined,
+        },
+      })) as { success: boolean; error?: string } | undefined;
+
+      if (!result?.success) {
+        setHostlerSaveState("error");
+        setHostlerSaveError(result?.error || "Could not save Hostler settings.");
+        return false;
+      }
+
+      setHostlerSaveState("saved");
+      return true;
+    } catch (error) {
+      setHostlerSaveState("error");
+      setHostlerSaveError(
+        error instanceof Error ? error.message : "Could not save Hostler settings.",
+      );
+      return false;
+    }
   };
 
   const loadExtensions = useCallback(async () => {
@@ -908,10 +931,13 @@ export function ExtensionsTab() {
               type="checkbox"
               className="sr-only peer"
               checked={hostlerEnabled}
+              disabled={hostlerSaveState === "saving"}
               onChange={async (e) => {
                 const val = e.target.checked;
+                const previous = hostlerEnabled;
                 setHostlerEnabled(val);
-                await saveHostlerSettings(val);
+                const saved = await saveHostlerSettings(val);
+                if (!saved) setHostlerEnabled(previous);
               }}
             />
             <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:after:border-gray-600 peer-checked:bg-blue-600" />
@@ -929,7 +955,12 @@ export function ExtensionsTab() {
                 className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400"
                 placeholder="cpk_..."
                 value={hostlerApiKey}
-                onChange={(e) => setHostlerApiKey(e.target.value)}
+                disabled={hostlerSaveState === "saving"}
+                onChange={(e) => {
+                  setHostlerApiKey(e.target.value);
+                  setHostlerSaveState("idle");
+                  setHostlerSaveError("");
+                }}
               />
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Mint one at hostler.dev → Settings → API keys (shown exactly once).
@@ -946,7 +977,12 @@ export function ExtensionsTab() {
                   className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400"
                   placeholder="opencode"
                   value={hostlerHarness}
-                  onChange={(e) => setHostlerHarness(e.target.value)}
+                  disabled={hostlerSaveState === "saving"}
+                  onChange={(e) => {
+                    setHostlerHarness(e.target.value);
+                    setHostlerSaveState("idle");
+                    setHostlerSaveError("");
+                  }}
                 />
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   Hostler currently hosts &quot;pi&quot;, &quot;opencode&quot;, and
@@ -962,7 +998,12 @@ export function ExtensionsTab() {
                   className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400"
                   placeholder="openai/glm-5.2"
                   value={hostlerModel}
-                  onChange={(e) => setHostlerModel(e.target.value)}
+                  disabled={hostlerSaveState === "saving"}
+                  onChange={(e) => {
+                    setHostlerModel(e.target.value);
+                    setHostlerSaveState("idle");
+                    setHostlerSaveError("");
+                  }}
                 />
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   Bare model id (pairs with Anthropic) or &quot;provider/model&quot; from
@@ -973,10 +1014,19 @@ export function ExtensionsTab() {
 
             <div className="flex items-center gap-3">
               <button
-                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 dark:bg-blue-500 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors"
+                className={`px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors disabled:opacity-50 ${
+                  hostlerSaveState === "saved"
+                    ? "bg-green-600 dark:bg-green-500"
+                    : "bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600"
+                }`}
+                disabled={hostlerSaveState === "saving"}
                 onClick={() => saveHostlerSettings(hostlerEnabled)}
               >
-                Save
+                {hostlerSaveState === "saving"
+                  ? "Saving..."
+                  : hostlerSaveState === "saved"
+                    ? "Saved"
+                    : "Save"}
               </button>
               <p className="text-xs text-gray-500 dark:text-gray-400">
                 Cloud sandboxes take ~10-30s to launch and are kept warm for 5 minutes after a
@@ -984,6 +1034,11 @@ export function ExtensionsTab() {
               </p>
             </div>
           </div>
+        )}
+        {hostlerSaveState === "error" && (
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400" role="alert">
+            {hostlerSaveError}
+          </p>
         )}
       </div>
 

--- a/tests/e2e/hostler-settings.spec.ts
+++ b/tests/e2e/hostler-settings.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { closeApp, launchElectronApp } from "./launch-helpers";
+
+test.describe("Settings - Hostler", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let originalHostlerConfig:
+    | { enabled: boolean; apiKey: string; harness: string; model?: string }
+    | undefined;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const launched = await launchElectronApp({ workerIndex: testInfo.workerIndex });
+    electronApp = launched.app;
+    page = launched.page;
+
+    const current = (await page.evaluate(() => window.api.settings.get())) as {
+      data?: { hostler?: typeof originalHostlerConfig };
+    };
+    originalHostlerConfig = current.data?.hostler;
+
+    await page.getByTitle("Settings").click();
+    await page.getByRole("button", { name: "Extensions" }).click();
+  });
+
+  test.afterAll(async () => {
+    if (electronApp) await closeApp(electronApp);
+  });
+
+  test("save confirms success and persists Hostler settings", async () => {
+    const heading = page.getByRole("heading", { name: "Hostler Agent (cloud)", exact: true });
+    await heading.scrollIntoViewIfNeeded();
+    const card = heading.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+    try {
+      const toggle = card.getByRole("checkbox");
+
+      if (await toggle.isChecked()) {
+        await toggle.evaluate((element) => element.click());
+        await expect
+          .poll(async () => {
+            const result = (await page.evaluate(() => window.api.settings.get())) as {
+              data?: { hostler?: { enabled: boolean } };
+            };
+            return result.data?.hostler?.enabled;
+          })
+          .toBe(false);
+        await expect(toggle).toBeEnabled();
+      }
+
+      await toggle.evaluate((element) => element.click());
+      await expect
+        .poll(async () => {
+          const result = (await page.evaluate(() => window.api.settings.get())) as {
+            data?: { hostler?: { enabled: boolean } };
+          };
+          return result.data?.hostler?.enabled;
+        })
+        .toBe(true);
+      await expect(toggle).toBeChecked();
+
+      const apiKeyInput = card.getByPlaceholder("cpk_...");
+      await apiKeyInput.fill("");
+      await apiKeyInput.fill("cpk_e2e_test");
+      await card.getByPlaceholder("opencode").fill("codex");
+      await card.getByPlaceholder("openai/glm-5.2").fill("openai/test-model");
+
+      await card.getByRole("button", { name: "Save", exact: true }).click();
+      await expect(card.getByRole("button", { name: "Saved", exact: true })).toBeVisible();
+
+      const result = (await page.evaluate(() => window.api.settings.get())) as {
+        success: boolean;
+        data?: {
+          hostler?: { enabled: boolean; apiKey: string; harness: string; model?: string };
+        };
+      };
+      expect(result).toMatchObject({
+        success: true,
+        data: {
+          hostler: {
+            enabled: true,
+            apiKey: "cpk_e2e_test",
+            harness: "codex",
+            model: "openai/test-model",
+          },
+        },
+      });
+
+      await page.keyboard.press("Escape");
+      await page.getByTitle("Settings").click();
+      await page.getByRole("button", { name: "Extensions" }).click();
+      await heading.scrollIntoViewIfNeeded();
+
+      await expect(card.getByPlaceholder("cpk_...")).toHaveValue("cpk_e2e_test");
+      await expect(card.getByPlaceholder("opencode")).toHaveValue("codex");
+      await expect(card.getByPlaceholder("openai/glm-5.2")).toHaveValue("openai/test-model");
+    } finally {
+      const restored = (await page.evaluate(
+        (hostler) => window.api.settings.set({ hostler }),
+        originalHostlerConfig,
+      )) as { success: boolean };
+      expect(restored.success).toBe(true);
+    }
+  });
+
+  test("save reports IPC failures and prevents duplicate submissions", async () => {
+    await electronApp.evaluate(({ ipcMain }) => {
+      const pending: Array<(result: { success: false; error: string }) => void> = [];
+      const globals = globalThis as typeof globalThis & { releaseHostlerSave?: () => boolean };
+      globals.releaseHostlerSave = () => {
+        const resolve = pending.shift();
+        if (!resolve) return false;
+        resolve({ success: false, error: "Test settings write failed" });
+        return true;
+      };
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle(
+        "settings:set",
+        () =>
+          new Promise<{ success: false; error: string }>((resolve) => {
+            pending.push(resolve);
+          }),
+      );
+    });
+
+    const heading = page.getByRole("heading", { name: "Hostler Agent (cloud)", exact: true });
+    const card = heading.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+    const toggle = card.getByRole("checkbox");
+
+    await toggle.evaluate((element) => element.click());
+    await expect(toggle).toBeDisabled();
+    await expect
+      .poll(() =>
+        electronApp.evaluate(() => {
+          const globals = globalThis as typeof globalThis & { releaseHostlerSave?: () => boolean };
+          return globals.releaseHostlerSave?.() ?? false;
+        }),
+      )
+      .toBe(true);
+    await expect(toggle).toBeChecked();
+    await expect(card.getByRole("alert")).toHaveText("Test settings write failed");
+
+    await card.getByPlaceholder("opencode").fill("opencode");
+    await expect(card.getByRole("alert")).toHaveCount(0);
+
+    await card.getByRole("button", { name: /^Save(?:d)?$/ }).click();
+    const savingButton = card.getByRole("button", { name: "Saving...", exact: true });
+    await expect(savingButton).toBeDisabled();
+    await expect(toggle).toBeDisabled();
+    await expect(card.getByPlaceholder("cpk_...")).toBeDisabled();
+    await expect(card.getByPlaceholder("opencode")).toBeDisabled();
+    await expect(card.getByPlaceholder("openai/glm-5.2")).toBeDisabled();
+    await expect
+      .poll(() =>
+        electronApp.evaluate(() => {
+          const globals = globalThis as typeof globalThis & { releaseHostlerSave?: () => boolean };
+          const released = globals.releaseHostlerSave?.() ?? false;
+          if (released) delete globals.releaseHostlerSave;
+          return released;
+        }),
+      )
+      .toBe(true);
+    await expect(card.getByRole("alert")).toHaveText("Test settings write failed");
+    await expect(card.getByRole("button", { name: "Save", exact: true })).toBeEnabled();
+
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle("settings:set", () => ({ success: true }));
+    });
+    await toggle.evaluate((element) => element.click());
+    await expect(toggle).not.toBeChecked();
+
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle("settings:set", () => ({ success: false, error: "Enable failed" }));
+    });
+    await toggle.evaluate((element) => element.click());
+    await expect(toggle).not.toBeChecked();
+    await expect(card.getByRole("alert")).toHaveText("Enable failed");
+
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle("settings:set", () => ({ success: true }));
+    });
+    await toggle.evaluate((element) => element.click());
+    await expect(toggle).toBeChecked();
+  });
+
+  test("save uses a fallback error for a malformed IPC response", async () => {
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle("settings:set", () => undefined);
+    });
+
+    const heading = page.getByRole("heading", { name: "Hostler Agent (cloud)", exact: true });
+    const card = heading.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+    await card.getByRole("button", { name: /^Save(?:d)?$/ }).click();
+    await expect(card.getByRole("alert")).toHaveText("Could not save Hostler settings.");
+  });
+
+  test("save reports rejected IPC calls and can be retried", async () => {
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle("settings:set", () => {
+        throw new Error("Test IPC rejection");
+      });
+    });
+
+    const heading = page.getByRole("heading", { name: "Hostler Agent (cloud)", exact: true });
+    const card = heading.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+    await card.getByRole("button", { name: /^Save(?:d)?$/ }).click();
+    await expect(card.getByRole("alert")).toContainText("Test IPC rejection");
+
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler("settings:set");
+      ipcMain.handle("settings:set", () => ({ success: true }));
+    });
+    await card.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(card.getByRole("button", { name: "Saved", exact: true })).toBeVisible();
+    await expect(card.getByRole("alert")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- show clear Saving, Saved, and failure feedback when Hostler settings are submitted
- prevent overlapping edits while a save is in flight and roll back toggle changes when persistence fails
- add Electron E2E coverage for persistence, toggle autosave, failure rollback, malformed responses, rejected IPC, and retry

## Review

- pre-landing review: clean; no actionable P0/P1/P2 findings
- test coverage audit: 98% / very high confidence; no actionable gaps
- design review: save feedback uses the existing settings-card visual language and exposes failures with an accessible alert
- scope drift: clean; two files changed, both directly related to Hostler settings save behavior
- plan completion: no project plan was associated with this fix

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test tests/e2e/hostler-settings.spec.ts --project=e2e --workers=1` (4 passed)
- [x] `npm test` unit phase (1,467 passed); Hostler E2E passed in the full run
- [x] full pre-PR gate, including evals, agentic UI verification, and cached real-Gmail smoke

<!-- PRE-PR-REPORT-START SHA=3db694e mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `3db694e`
- generated: 2026-07-15T17:13:03.475Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 1034.3s |
| eval:features | ✅ exit 0 | 46.8s |
| agentic-verify | ✅ exit 0 | 330.2s |
| real-gmail:cached | ✅ exit 0 | 118.5s |
<!-- PRE-PR-REPORT-END -->

Generated by Codex.
