### PR TITLE
Consolidate background agent provider selection into General settings

### DIFF
--- a/src/renderer/components/ExtensionsTab.tsx
+++ b/src/renderer/components/ExtensionsTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type {
   InstalledExtensionInfo,
   ExtensionManifest,
@@ -19,6 +20,11 @@ interface ExtensionListResult {
  * Shows bundled and installed extensions, with install/uninstall controls.
  */
 export function ExtensionsTab() {
+  // Provider gates saved here (opencode.enabled, hostler.enabled/apiKey) feed
+  // the Agent Drafter runtime options in the General tab, which read from the
+  // "general-config" query — invalidate it at each save site so those options
+  // enable/disable without reopening Settings.
+  const queryClient = useQueryClient();
   const [installedExtensions, setInstalledExtensions] = useState<InstalledExtensionInfo[]>([]);
   const [bundledExtensions, setBundledExtensions] = useState<ExtensionManifest[]>([]);
   const [isInstalling, setIsInstalling] = useState(false);
@@ -100,6 +106,7 @@ export function ExtensionsTab() {
       }
 
       setHostlerSaveState("saved");
+      queryClient.invalidateQueries({ queryKey: ["general-config"] });
       return true;
     } catch (error) {
       setHostlerSaveState("error");
@@ -859,12 +866,18 @@ export function ExtensionsTab() {
               onChange={async (e) => {
                 const val = e.target.checked;
                 setOpencodeEnabled(val);
-                await window.api.settings.set({
+                const result = (await window.api.settings.set({
                   opencode: {
                     enabled: val,
                     model: opencodeModel || undefined,
                   },
-                });
+                })) as { success: boolean } | undefined;
+                if (!result?.success) {
+                  // Revert so the toggle doesn't show a state that didn't persist
+                  setOpencodeEnabled(!val);
+                  return;
+                }
+                queryClient.invalidateQueries({ queryKey: ["general-config"] });
               }}
             />
             <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:after:border-gray-600 peer-checked:bg-blue-600" />
@@ -892,12 +905,15 @@ export function ExtensionsTab() {
               <button
                 className="px-4 py-2 text-sm font-medium text-white bg-blue-600 dark:bg-blue-500 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors"
                 onClick={async () => {
-                  await window.api.settings.set({
+                  const result = (await window.api.settings.set({
                     opencode: {
                       enabled: opencodeEnabled,
                       model: opencodeModel || undefined,
                     },
-                  });
+                  })) as { success: boolean } | undefined;
+                  if (result?.success) {
+                    queryClient.invalidateQueries({ queryKey: ["general-config"] });
+                  }
                 }}
               >
                 Save

--- a/src/renderer/components/ExtensionsTab.tsx
+++ b/src/renderer/components/ExtensionsTab.tsx
@@ -18,8 +18,14 @@ interface ExtensionListResult {
 /**
  * Extensions management tab in Settings.
  * Shows bundled and installed extensions, with install/uninstall controls.
+ *
+ * onOllamaCloudDisabled: disabling Ollama Cloud rewrites featureProviders —
+ * a field the General tab stages locally (hydrated once per panel session).
+ * The parent uses this callback to apply the same reset to its staged copy,
+ * otherwise Save Changes would republish stale ollama-cloud routes with the
+ * now-cleared API key.
  */
-export function ExtensionsTab() {
+export function ExtensionsTab({ onOllamaCloudDisabled }: { onOllamaCloudDisabled?: () => void }) {
   // Provider gates saved here (opencode.enabled, hostler.enabled/apiKey) feed
   // the Agent Drafter runtime options in the General tab, which read from the
   // "general-config" query — invalidate it at each save site so those options
@@ -646,6 +652,8 @@ export function ExtensionsTab() {
                     ollamaCloud: { apiKey: "", defaultModel: ollamaCloudModel },
                     featureProviders: reset,
                   });
+                  queryClient.invalidateQueries({ queryKey: ["general-config"] });
+                  onOllamaCloudDisabled?.();
                 }
               }}
             />
@@ -755,6 +763,7 @@ export function ExtensionsTab() {
                     gatewayToken: openclawGatewayToken,
                   },
                 });
+                queryClient.invalidateQueries({ queryKey: ["general-config"] });
               }}
             />
             <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:after:border-gray-600 peer-checked:bg-blue-600" />
@@ -803,6 +812,7 @@ export function ExtensionsTab() {
                       gatewayToken: openclawGatewayToken,
                     },
                   });
+                  queryClient.invalidateQueries({ queryKey: ["general-config"] });
                   setOpenclawTesting(true);
                   setOpenclawTestResult(null);
                   const result = (await window.api.settings.testOpenclawConnection()) as {
@@ -826,6 +836,7 @@ export function ExtensionsTab() {
                       gatewayToken: openclawGatewayToken,
                     },
                   });
+                  queryClient.invalidateQueries({ queryKey: ["general-config"] });
                 }}
               >
                 Save

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -25,6 +25,8 @@ import {
   DEFAULT_OLLAMA_MODEL,
   DEFAULT_BACKGROUND_AGENT_PROVIDER,
   resolveBackgroundAgentProviderId,
+  applyAgentDrafterSelection,
+  isAgentRuntimeAvailable,
   type BlockedSender,
 } from "../../shared/types";
 import { useAppStore, type Account, type SettingsTab } from "../store";
@@ -104,6 +106,8 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [featureProviders, setFeatureProviders] = useState<Record<string, LlmProvider>>({});
   const [ollamaModels, setOllamaModels] = useState<Record<string, string>>({});
   const [isSavingGeneral, setIsSavingGeneral] = useState(false);
+  // "saved" for transient success feedback, any other string is an error message
+  const [generalSaveResult, setGeneralSaveResult] = useState<string | null>(null);
   const [isExportingLogs, setIsExportingLogs] = useState(false);
   const [exportLogsError, setExportLogsError] = useState<string | null>(null);
   const [isDefaultMailApp, setIsDefaultMailApp] = useState(false);
@@ -160,7 +164,6 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   const [posthogEnabled, setPosthogEnabled] = useState(false);
   const [isSavingAnalytics, setIsSavingAnalytics] = useState(false);
   const [analyticsSaveResult, setAnalyticsSaveResult] = useState<string | null>(null);
-  const analyticsInitialized = useRef(false);
 
   // Custom MCP servers state
   const [mcpServers, setMcpServers] = useState<Record<string, McpServerConfig>>({});
@@ -224,12 +227,17 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   // What the main process will actually launch for background drafts, given
   // the current provider gates — the same resolver prefetch/rerun use, so the
   // fallback warning under the Agent Drafter row can't drift from real behavior.
-  const effectiveBackgroundProvider = resolveBackgroundAgentProviderId({
-    backgroundAgentProvider,
+  const runtimeGates = {
     opencode: generalConfig?.opencode,
     hostler: generalConfig?.hostler,
     openclaw: generalConfig?.openclaw,
+  };
+  const effectiveBackgroundProvider = resolveBackgroundAgentProviderId({
+    backgroundAgentProvider,
+    ...runtimeGates,
   });
+  const opencodeRuntimeAvailable = isAgentRuntimeAvailable("opencode", runtimeGates);
+  const hostlerRuntimeAvailable = isAgentRuntimeAvailable("hostler", runtimeGates);
 
   useEffect(() => {
     if (prompts) {
@@ -259,8 +267,16 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       .catch(() => {});
   }, []);
 
+  // Hydrate staged General-tab state ONCE from the first config load. Later
+  // refetches (Extensions-tab saves invalidate general-config; window-focus
+  // refetch after staleTime) must not rewrite staged fields — that silently
+  // reverts unsaved edits, which the user then persists without noticing.
+  // Live gate reads (e.g. the Agent Drafter runtime options) use generalConfig
+  // directly, so they stay fresh without this effect re-running.
+  const generalInitialized = useRef(false);
   useEffect(() => {
-    if (generalConfig) {
+    if (generalConfig && !generalInitialized.current) {
+      generalInitialized.current = true;
       setEnableSenderLookup(generalConfig.enableSenderLookup ?? true);
       setSenderLookupProvider(generalConfig.senderLookupProvider ?? "anthropic");
       setExaApiKey(generalConfig.exaApiKey ?? "");
@@ -286,13 +302,9 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       setBackgroundAgentProvider(
         generalConfig.backgroundAgentProvider || DEFAULT_BACKGROUND_AGENT_PROVIDER,
       );
-      // PostHog analytics config — only set once to avoid clobbering unsaved edits on refetch
-      if (!analyticsInitialized.current) {
-        analyticsInitialized.current = true;
-        const ph = generalConfig.posthog;
-        if (ph) {
-          setPosthogEnabled(ph.enabled);
-        }
+      const ph = generalConfig.posthog;
+      if (ph) {
+        setPosthogEnabled(ph.enabled);
       }
     }
   }, [generalConfig]);
@@ -333,14 +345,6 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
     return cleanup;
   }, []);
-
-  // Refetch config when the General tab is shown so provider gates flipped in
-  // the Extensions tab (OpenCode/Hostler enablement) are reflected in the
-  // Agent Drafter runtime options without reopening Settings.
-  useEffect(() => {
-    if (activeTab !== "general") return;
-    queryClient.invalidateQueries({ queryKey: ["general-config"] });
-  }, [activeTab, queryClient]);
 
   // Check Claude CLI availability and auth status when Agents tab is shown.
   useEffect(() => {
@@ -438,8 +442,9 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   const handleSaveGeneral = async () => {
     setIsSavingGeneral(true);
+    setGeneralSaveResult(null);
     try {
-      await window.api.settings.set({
+      const result = (await window.api.settings.set({
         enableSenderLookup,
         senderLookupProvider,
         exaApiKey: exaApiKey || undefined,
@@ -456,8 +461,16 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         ollamaCloud: { featureModels: ollamaModels },
         githubToken: githubToken || undefined,
         allowPrereleaseUpdates,
-      });
+      })) as { success: boolean; error?: string } | undefined;
+      if (result?.success) {
+        setGeneralSaveResult("saved");
+        setTimeout(() => setGeneralSaveResult(null), 2000);
+      } else {
+        setGeneralSaveResult(result?.error || "Could not save settings.");
+      }
       queryClient.invalidateQueries({ queryKey: ["general-config"] });
+    } catch (error) {
+      setGeneralSaveResult(error instanceof Error ? error.message : "Could not save settings.");
     } finally {
       setIsSavingGeneral(false);
     }
@@ -1317,8 +1330,8 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 <div className="mb-3">
                   <h3 className="font-semibold text-gray-900 dark:text-gray-100">AI Models</h3>
                   <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                    Choose which Claude model to use for each feature. Haiku is fastest and
-                    cheapest, Opus is most capable.
+                    Choose which provider and model runs each feature. For Anthropic, Haiku is
+                    fastest and cheapest, Opus is most capable.
                   </p>
                 </div>
                 <div className="space-y-3">
@@ -1369,10 +1382,14 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     // picker: OpenCode/Hostler route background drafts to that agent
                     // provider (backgroundAgentProvider, model configured in the
                     // Extensions tab), while Anthropic/Ollama keep the built-in
-                    // Claude agent and pick which model it uses.
+                    // Claude agent and pick which model it uses. While an external
+                    // runtime is selected, featureProviders.agentDrafter is hidden
+                    // but still saved — it keeps gating resolveAgentOllamaConfig
+                    // (the shared agent worker's Ollama routing) alongside agentChat.
                     const isBackgroundAgentRow = key === "agentDrafter";
                     const externalRuntime =
-                      isBackgroundAgentRow && backgroundAgentProvider !== "claude";
+                      isBackgroundAgentRow &&
+                      backgroundAgentProvider !== DEFAULT_BACKGROUND_AGENT_PROVIDER;
                     return (
                       <div
                         key={key}
@@ -1392,14 +1409,17 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                               value={externalRuntime ? backgroundAgentProvider : provider}
                               onChange={(e) => {
                                 const p = e.target.value;
-                                if (isBackgroundAgentRow && (p === "opencode" || p === "hostler")) {
-                                  setBackgroundAgentProvider(p);
+                                if (isBackgroundAgentRow) {
+                                  const sel = applyAgentDrafterSelection(p);
+                                  if (!sel) return;
+                                  setBackgroundAgentProvider(sel.backgroundAgentProvider);
+                                  const llm = sel.agentDrafterProvider;
+                                  if (llm) {
+                                    setFeatureProviders((prev) => ({ ...prev, [key]: llm }));
+                                  }
                                   return;
                                 }
                                 if ((LLM_PROVIDERS as readonly string[]).includes(p)) {
-                                  if (isBackgroundAgentRow) {
-                                    setBackgroundAgentProvider(DEFAULT_BACKGROUND_AGENT_PROVIDER);
-                                  }
                                   setFeatureProviders((prev) => ({
                                     ...prev,
                                     [key]: p as LlmProvider,
@@ -1420,28 +1440,34 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                               )}
                               {isBackgroundAgentRow && (
                                 <>
-                                  <option
-                                    value="opencode"
-                                    disabled={!generalConfig?.opencode?.enabled}
-                                  >
+                                  <option value="opencode" disabled={!opencodeRuntimeAvailable}>
                                     OpenCode
                                   </option>
-                                  <option
-                                    value="hostler"
-                                    disabled={
-                                      !generalConfig?.hostler?.enabled ||
-                                      !generalConfig?.hostler?.apiKey
-                                    }
-                                  >
+                                  <option value="hostler" disabled={!hostlerRuntimeAvailable}>
                                     Hostler (cloud)
                                   </option>
+                                  {/* A hand-edited or installed provider id has no fixed
+                                      option — render it so the select reflects the saved
+                                      value the fallback warning references, instead of
+                                      showing a blank control. */}
+                                  {externalRuntime &&
+                                    backgroundAgentProvider !== "opencode" &&
+                                    backgroundAgentProvider !== "hostler" && (
+                                      <option value={backgroundAgentProvider} disabled>
+                                        {backgroundAgentProvider}
+                                      </option>
+                                    )}
                                 </>
                               )}
                             </select>
                             {externalRuntime ? (
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
+                              <button
+                                type="button"
+                                onClick={() => setActiveTab("extensions")}
+                                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                              >
                                 Model set in Extensions
-                              </span>
+                              </button>
                             ) : provider === "anthropic" ? (
                               <select
                                 value={modelConfig[key]}
@@ -1478,10 +1504,19 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                           effectiveBackgroundProvider !== backgroundAgentProvider && (
                             <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
                               {backgroundAgentProvider === "opencode"
-                                ? "OpenCode is disabled — background drafts fall back to Claude until it's re-enabled."
+                                ? "OpenCode is disabled — background drafts fall back to the built-in agent until it's re-enabled."
                                 : backgroundAgentProvider === "hostler"
-                                  ? `Hostler is ${generalConfig?.hostler?.enabled ? "missing an API key" : "disabled"} — background drafts fall back to Claude until it's configured.`
-                                  : `"${backgroundAgentProvider}" isn't available — background drafts fall back to Claude until it's configured.`}
+                                  ? `Hostler is ${generalConfig?.hostler?.enabled ? "missing an API key" : "disabled"} — background drafts fall back to the built-in agent until it's configured.`
+                                  : `"${backgroundAgentProvider}" isn't available — background drafts fall back to the built-in agent until it's configured.`}
+                            </p>
+                          )}
+                        {isBackgroundAgentRow &&
+                          generalConfig &&
+                          !opencodeRuntimeAvailable &&
+                          !hostlerRuntimeAvailable && (
+                            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                              Enable OpenCode or Hostler in Settings → Extensions to run background
+                              drafts through them.
                             </p>
                           )}
                       </div>
@@ -1761,14 +1796,26 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 )}
               </div>
 
-              {/* Save button */}
-              <div className="flex justify-end">
+              {/* Save button — disabled until config has loaded so a failed or
+                  slow settings:get can't be overwritten with staged defaults */}
+              <div className="flex justify-end items-center gap-3">
+                {generalSaveResult && generalSaveResult !== "saved" && (
+                  <p className="text-sm text-red-600 dark:text-red-400">{generalSaveResult}</p>
+                )}
                 <button
                   onClick={handleSaveGeneral}
-                  disabled={isSavingGeneral}
-                  className="px-6 py-2 bg-blue-600 dark:bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors disabled:opacity-50"
+                  disabled={isSavingGeneral || !generalConfig}
+                  className={`px-6 py-2 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 ${
+                    generalSaveResult === "saved"
+                      ? "bg-green-600 dark:bg-green-500"
+                      : "bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-600"
+                  }`}
                 >
-                  {isSavingGeneral ? "Saving..." : "Save Changes"}
+                  {isSavingGeneral
+                    ? "Saving..."
+                    : generalSaveResult === "saved"
+                      ? "Saved"
+                      : "Save Changes"}
                 </button>
               </div>
             </div>

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -223,7 +223,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
 
   // What the main process will actually launch for background drafts, given
   // the current provider gates — the same resolver prefetch/rerun use, so the
-  // fallback warning in the Agents tab can't drift from real behavior.
+  // fallback warning under the Agent Drafter row can't drift from real behavior.
   const effectiveBackgroundProvider = resolveBackgroundAgentProviderId({
     backgroundAgentProvider,
     opencode: generalConfig?.opencode,
@@ -334,12 +334,17 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
     return cleanup;
   }, []);
 
+  // Refetch config when the General tab is shown so provider gates flipped in
+  // the Extensions tab (OpenCode/Hostler enablement) are reflected in the
+  // Agent Drafter runtime options without reopening Settings.
+  useEffect(() => {
+    if (activeTab !== "general") return;
+    queryClient.invalidateQueries({ queryKey: ["general-config"] });
+  }, [activeTab, queryClient]);
+
   // Check Claude CLI availability and auth status when Agents tab is shown.
-  // Also refetch config so provider gates flipped in the Extensions tab
-  // (OpenCode/Hostler enablement) are reflected without reopening Settings.
   useEffect(() => {
     if (activeTab !== "agents") return;
-    queryClient.invalidateQueries({ queryKey: ["general-config"] });
     setClaudeAuthStatus("checking");
     (
       window.api.agent.claudeAuthStatus() as Promise<{
@@ -441,6 +446,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         syncDraftsToGmail,
         modelConfig,
         featureProviders,
+        backgroundAgentProvider,
         // Only send featureModels here — apiKey and defaultModel are owned by the
         // ExtensionsTab. Spreading the cached ollamaCloud here can carry a stale
         // empty apiKey from before the user saved one in ExtensionsTab; the backend
@@ -1350,7 +1356,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     {
                       key: "agentDrafter" as const,
                       label: "Agent Drafter",
-                      description: "Background auto-draft generation",
+                      description: "Background auto-drafts for new emails and “Regenerate draft”",
                     },
                     {
                       key: "agentChat" as const,
@@ -1359,70 +1365,125 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                     },
                   ].map(({ key, label, description }) => {
                     const provider = featureProviders[key] ?? "anthropic";
+                    // The Agent Drafter row doubles as the background-agent runtime
+                    // picker: OpenCode/Hostler route background drafts to that agent
+                    // provider (backgroundAgentProvider, model configured in the
+                    // Extensions tab), while Anthropic/Ollama keep the built-in
+                    // Claude agent and pick which model it uses.
+                    const isBackgroundAgentRow = key === "agentDrafter";
+                    const externalRuntime =
+                      isBackgroundAgentRow && backgroundAgentProvider !== "claude";
                     return (
                       <div
                         key={key}
-                        className="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700 last:border-0"
+                        className="py-2 border-b border-gray-100 dark:border-gray-700 last:border-0"
                       >
-                        <div className="flex-1 min-w-0 mr-4">
-                          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                            {label}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400">{description}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <select
-                            value={provider}
-                            onChange={(e) => {
-                              const p = e.target.value;
-                              if ((LLM_PROVIDERS as readonly string[]).includes(p)) {
-                                setFeatureProviders((prev) => ({
-                                  ...prev,
-                                  [key]: p as LlmProvider,
-                                }));
-                              }
-                            }}
-                            aria-label={`Provider for ${label}`}
-                            className="px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                          >
-                            <option value="anthropic">Anthropic</option>
-                            {/* For senderLookup, the Ollama option is only honored when
+                        <div className="flex items-center justify-between">
+                          <div className="flex-1 min-w-0 mr-4">
+                            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                              {label}
+                            </p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                              {description}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <select
+                              value={externalRuntime ? backgroundAgentProvider : provider}
+                              onChange={(e) => {
+                                const p = e.target.value;
+                                if (isBackgroundAgentRow && (p === "opencode" || p === "hostler")) {
+                                  setBackgroundAgentProvider(p);
+                                  return;
+                                }
+                                if ((LLM_PROVIDERS as readonly string[]).includes(p)) {
+                                  if (isBackgroundAgentRow) {
+                                    setBackgroundAgentProvider(DEFAULT_BACKGROUND_AGENT_PROVIDER);
+                                  }
+                                  setFeatureProviders((prev) => ({
+                                    ...prev,
+                                    [key]: p as LlmProvider,
+                                  }));
+                                }
+                              }}
+                              aria-label={`Provider for ${label}`}
+                              className="px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                            >
+                              <option value="anthropic">Anthropic</option>
+                              {/* For senderLookup, the Ollama option is only honored when
                                 the search backend is Exa — the Anthropic backend bundles
                                 search + parse into one web_search tool call, which doesn't
                                 exist on Ollama. Hide it on the Anthropic backend to avoid
                                 saving a route that can't be honored at call time. */}
-                            {(key !== "senderLookup" || senderLookupProvider === "exa") && (
-                              <option value="ollama-cloud">Ollama Cloud</option>
-                            )}
-                          </select>
-                          {provider === "anthropic" ? (
-                            <select
-                              value={modelConfig[key]}
-                              onChange={(e) => {
-                                const tier = e.target.value;
-                                if ((MODEL_TIERS as readonly string[]).includes(tier)) {
-                                  setModelConfig((prev) => ({ ...prev, [key]: tier as ModelTier }));
-                                }
-                              }}
-                              aria-label={`Model tier for ${label}`}
-                              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                            >
-                              {MODEL_TIERS.map((tier) => (
-                                <option key={tier} value={tier}>
-                                  {MODEL_TIER_LABELS[tier]}
-                                </option>
-                              ))}
+                              {(key !== "senderLookup" || senderLookupProvider === "exa") && (
+                                <option value="ollama-cloud">Ollama Cloud</option>
+                              )}
+                              {isBackgroundAgentRow && (
+                                <>
+                                  <option
+                                    value="opencode"
+                                    disabled={!generalConfig?.opencode?.enabled}
+                                  >
+                                    OpenCode
+                                  </option>
+                                  <option
+                                    value="hostler"
+                                    disabled={
+                                      !generalConfig?.hostler?.enabled ||
+                                      !generalConfig?.hostler?.apiKey
+                                    }
+                                  >
+                                    Hostler (cloud)
+                                  </option>
+                                </>
+                              )}
                             </select>
-                          ) : (
-                            <OllamaModelSelect
-                              value={ollamaModels[key] ?? DEFAULT_OLLAMA_MODEL}
-                              onChange={(v) => setOllamaModels((prev) => ({ ...prev, [key]: v }))}
-                              ariaLabel={`Ollama model for ${label}`}
-                              selectClassName="w-48 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                              inputClassName="w-48 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                            />
-                          )}
+                            {externalRuntime ? (
+                              <span className="text-xs text-gray-500 dark:text-gray-400">
+                                Model set in Extensions
+                              </span>
+                            ) : provider === "anthropic" ? (
+                              <select
+                                value={modelConfig[key]}
+                                onChange={(e) => {
+                                  const tier = e.target.value;
+                                  if ((MODEL_TIERS as readonly string[]).includes(tier)) {
+                                    setModelConfig((prev) => ({
+                                      ...prev,
+                                      [key]: tier as ModelTier,
+                                    }));
+                                  }
+                                }}
+                                aria-label={`Model tier for ${label}`}
+                                className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                              >
+                                {MODEL_TIERS.map((tier) => (
+                                  <option key={tier} value={tier}>
+                                    {MODEL_TIER_LABELS[tier]}
+                                  </option>
+                                ))}
+                              </select>
+                            ) : (
+                              <OllamaModelSelect
+                                value={ollamaModels[key] ?? DEFAULT_OLLAMA_MODEL}
+                                onChange={(v) => setOllamaModels((prev) => ({ ...prev, [key]: v }))}
+                                ariaLabel={`Ollama model for ${label}`}
+                                selectClassName="w-48 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                inputClassName="w-48 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                              />
+                            )}
+                          </div>
                         </div>
+                        {isBackgroundAgentRow &&
+                          effectiveBackgroundProvider !== backgroundAgentProvider && (
+                            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                              {backgroundAgentProvider === "opencode"
+                                ? "OpenCode is disabled — background drafts fall back to Claude until it's re-enabled."
+                                : backgroundAgentProvider === "hostler"
+                                  ? `Hostler is ${generalConfig?.hostler?.enabled ? "missing an API key" : "disabled"} — background drafts fall back to Claude until it's configured.`
+                                  : `"${backgroundAgentProvider}" isn't available — background drafts fall back to Claude until it's configured.`}
+                            </p>
+                          )}
                       </div>
                     );
                   })}
@@ -2757,52 +2818,6 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
               <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
                 Configure AI agent capabilities including browser automation.
               </p>
-            </div>
-
-            {/* Background agent — which provider runs the automatic new-email drafter */}
-            <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-6">
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <h4 className="text-base font-medium text-gray-900 dark:text-gray-100">
-                    Background Agent
-                  </h4>
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    The agent that automatically drafts replies for new emails (and powers
-                    &quot;Regenerate draft&quot;). Enable OpenCode or Hostler in Settings →
-                    Extensions to select them here.
-                  </p>
-                </div>
-                <select
-                  className="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                  value={backgroundAgentProvider}
-                  onChange={async (e) => {
-                    const value = e.target.value;
-                    setBackgroundAgentProvider(value);
-                    await window.api.settings.set({ backgroundAgentProvider: value });
-                    queryClient.invalidateQueries({ queryKey: ["general-config"] });
-                  }}
-                >
-                  <option value="claude">Claude (Anthropic) — default</option>
-                  <option value="opencode" disabled={!generalConfig?.opencode?.enabled}>
-                    OpenCode
-                  </option>
-                  <option
-                    value="hostler"
-                    disabled={!generalConfig?.hostler?.enabled || !generalConfig?.hostler?.apiKey}
-                  >
-                    Hostler (cloud)
-                  </option>
-                </select>
-              </div>
-              {effectiveBackgroundProvider !== backgroundAgentProvider && (
-                <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
-                  {backgroundAgentProvider === "opencode"
-                    ? "OpenCode is disabled — background drafts fall back to Claude until it's re-enabled."
-                    : backgroundAgentProvider === "hostler"
-                      ? `Hostler is ${generalConfig?.hostler?.enabled ? "missing an API key" : "disabled"} — background drafts fall back to Claude until it's configured.`
-                      : `"${backgroundAgentProvider}" isn't available — background drafts fall back to Claude until it's configured.`}
-                </p>
-              )}
             </div>
 
             {/* Authentication */}

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -212,8 +212,14 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
     },
   });
 
-  // Fetch general config
-  const { data: generalConfig } = useQuery({
+  // Fetch general config. The key is shared with other observers (e.g.
+  // useSignature) whose cached copy can be minutes old — force a fresh fetch
+  // per panel open since the once-only hydration below snapshots what it sees.
+  const {
+    data: generalConfig,
+    isError: generalConfigLoadError,
+    isFetchedAfterMount: generalConfigFresh,
+  } = useQuery({
     queryKey: ["general-config"],
     queryFn: async () => {
       const result = await window.api.settings.get();
@@ -222,6 +228,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       }
       throw new Error(result.error);
     },
+    refetchOnMount: "always",
   });
 
   // What the main process will actually launch for background drafts, given
@@ -275,7 +282,7 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
   // directly, so they stay fresh without this effect re-running.
   const generalInitialized = useRef(false);
   useEffect(() => {
-    if (generalConfig && !generalInitialized.current) {
+    if (generalConfig && generalConfigFresh && !generalInitialized.current) {
       generalInitialized.current = true;
       setEnableSenderLookup(generalConfig.enableSenderLookup ?? true);
       setSenderLookupProvider(generalConfig.senderLookupProvider ?? "anthropic");
@@ -307,7 +314,10 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
         setPosthogEnabled(ph.enabled);
       }
     }
-  }, [generalConfig]);
+    // generalConfigFresh must be a dep: structural sharing can keep the same
+    // data reference across the mount refetch, so the freshness flip is the
+    // only signal that re-runs this effect when cached and fresh data match.
+  }, [generalConfig, generalConfigFresh]);
 
   useEffect(() => {
     if (generalConfig) {
@@ -464,7 +474,8 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
       })) as { success: boolean; error?: string } | undefined;
       if (result?.success) {
         setGeneralSaveResult("saved");
-        setTimeout(() => setGeneralSaveResult(null), 2000);
+        // Functional clear so a later save's error can't be wiped by this timer
+        setTimeout(() => setGeneralSaveResult((v) => (v === "saved" ? null : v)), 2000);
       } else {
         setGeneralSaveResult(result?.error || "Could not save settings.");
       }
@@ -1799,12 +1810,18 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
               {/* Save button — disabled until config has loaded so a failed or
                   slow settings:get can't be overwritten with staged defaults */}
               <div className="flex justify-end items-center gap-3">
+                {generalConfigLoadError && (
+                  <p className="text-sm text-red-600 dark:text-red-400">
+                    Could not load settings — close and reopen Settings to retry. Saving is disabled
+                    so stored settings aren't overwritten.
+                  </p>
+                )}
                 {generalSaveResult && generalSaveResult !== "saved" && (
                   <p className="text-sm text-red-600 dark:text-red-400">{generalSaveResult}</p>
                 )}
                 <button
                   onClick={handleSaveGeneral}
-                  disabled={isSavingGeneral || !generalConfig}
+                  disabled={isSavingGeneral || !generalConfigFresh}
                   className={`px-6 py-2 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 ${
                     generalSaveResult === "saved"
                       ? "bg-green-600 dark:bg-green-500"
@@ -3559,7 +3576,23 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
           </div>
         )}
 
-        {activeTab === "extensions" && <ExtensionsTab />}
+        {activeTab === "extensions" && (
+          <ExtensionsTab
+            onOllamaCloudDisabled={() => {
+              // Mirror the persisted featureProviders reset in the staged copy
+              // (hydrated once per session) so Save Changes can't republish
+              // ollama-cloud routes whose API key was just cleared.
+              setFeatureProviders((prev) =>
+                Object.fromEntries(
+                  Object.entries(prev).map(([feature, provider]) => [
+                    feature,
+                    provider === "ollama-cloud" ? "anthropic" : provider,
+                  ]),
+                ),
+              );
+            }}
+          />
+        )}
 
         {activeTab === "analytics" && (
           <div className="max-w-3xl mx-auto space-y-6">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -626,6 +626,46 @@ export function resolveBackgroundAgentProviderId(
   return requested;
 }
 
+/** Agent runtimes selectable for background drafts besides the built-in Claude agent. */
+export const EXTERNAL_AGENT_RUNTIMES = ["opencode", "hostler"] as const;
+
+/**
+ * Whether selecting `id` as the background agent provider would actually take
+ * effect, derived from the same resolver that routes background drafts — so
+ * UI enablement can't drift from runtime fallback behavior.
+ */
+export function isAgentRuntimeAvailable(
+  id: string,
+  cfg: Pick<Config, "opencode" | "hostler" | "openclaw">,
+): boolean {
+  return resolveBackgroundAgentProviderId({ ...cfg, backgroundAgentProvider: id }) === id;
+}
+
+/**
+ * Interpret a selection from the Agent Drafter provider dropdown, which mixes
+ * agent runtimes (EXTERNAL_AGENT_RUNTIMES) with LLM providers for the built-in
+ * Claude runtime (LLM_PROVIDERS). Picking a runtime routes background drafts
+ * there and leaves the Claude-runtime model choice untouched; picking an LLM
+ * provider returns the runtime to the built-in Claude agent and selects its
+ * model source. Returns null for values that are neither, so unknown option
+ * values are an explicit no-op rather than a silent misroute.
+ */
+export function applyAgentDrafterSelection(
+  selected: string,
+): { backgroundAgentProvider: string; agentDrafterProvider?: LlmProvider } | null {
+  if ((EXTERNAL_AGENT_RUNTIMES as readonly string[]).includes(selected)) {
+    return { backgroundAgentProvider: selected };
+  }
+  const llmParse = LlmProviderSchema.safeParse(selected);
+  if (llmParse.success) {
+    return {
+      backgroundAgentProvider: DEFAULT_BACKGROUND_AGENT_PROVIDER,
+      agentDrafterProvider: llmParse.data,
+    };
+  }
+  return null;
+}
+
 // Dashboard-specific types
 
 // Email with analysis and draft status for the UI

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page, ElectronApplication } from "@playwright/test";
-import { launchElectronApp , closeApp } from "./launch-helpers";
+import { launchElectronApp, closeApp } from "./launch-helpers";
 
 /**
  * E2E Tests for the Settings panel.
@@ -426,5 +426,124 @@ test.describe("Settings Panel - Persistence", () => {
     const defaultButton = page.locator("button:has-text('Default')").first();
     await defaultButton.click();
     await page.waitForTimeout(300);
+  });
+});
+
+test.describe("Settings Panel - Agent Drafter runtime picker", () => {
+  test.describe.configure({ mode: "serial" });
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const result = await launchElectronApp({ workerIndex: testInfo.workerIndex });
+    electronApp = result.app;
+    page = result.page;
+    // Gate state must exist before Settings first mounts — the General tab
+    // reads it from the general-config query fetched on mount.
+    await page.evaluate(() =>
+      window.api.settings.set({
+        backgroundAgentProvider: "claude",
+        hostler: { enabled: true, apiKey: "cpk_test", harness: "opencode" },
+        opencode: { enabled: false },
+      }),
+    );
+  });
+
+  test.afterAll(async () => {
+    if (page) {
+      await page.evaluate(() =>
+        window.api.settings.set({
+          backgroundAgentProvider: "claude",
+          hostler: { enabled: false },
+          opencode: { enabled: false },
+        }),
+      );
+    }
+    if (electronApp) {
+      await closeApp(electronApp);
+    }
+  });
+
+  test("runtime options are gated by Extensions config", async () => {
+    await page.locator("button[title='Settings']").click();
+    await expect(page.locator("h1:has-text('Settings')")).toBeVisible({ timeout: 5000 });
+
+    const select = page.getByLabel("Provider for Agent Drafter");
+    await select.scrollIntoViewIfNeeded();
+    await expect(select.locator("option[value='hostler']")).toBeEnabled();
+    await expect(select.locator("option[value='opencode']")).toBeDisabled();
+  });
+
+  test("selecting an external runtime persists only after Save Changes", async () => {
+    const select = page.getByLabel("Provider for Agent Drafter");
+    await select.selectOption("hostler");
+
+    // The model column is replaced by the Extensions hint while an external
+    // runtime is selected.
+    await expect(page.getByRole("button", { name: "Model set in Extensions" })).toBeVisible();
+
+    // Old UI persisted on change; the consolidated row stages until Save.
+    const before = (await page.evaluate(() => window.api.settings.get())) as {
+      data?: { backgroundAgentProvider?: string };
+    };
+    expect(before.data?.backgroundAgentProvider ?? "claude").toBe("claude");
+
+    await page.getByRole("button", { name: "Save Changes" }).click();
+    await expect
+      .poll(async () => {
+        const cfg = (await page.evaluate(() => window.api.settings.get())) as {
+          data?: { backgroundAgentProvider?: string };
+        };
+        return cfg.data?.backgroundAgentProvider;
+      })
+      .toBe("hostler");
+  });
+
+  test("selecting an LLM provider returns the runtime to Claude and restores the model select", async () => {
+    const select = page.getByLabel("Provider for Agent Drafter");
+    await select.selectOption("anthropic");
+
+    await expect(page.getByLabel("Model tier for Agent Drafter")).toBeVisible();
+
+    await page.getByRole("button", { name: "Save Changes" }).click();
+    await expect
+      .poll(async () => {
+        const cfg = (await page.evaluate(() => window.api.settings.get())) as {
+          data?: { backgroundAgentProvider?: string };
+        };
+        return cfg.data?.backgroundAgentProvider;
+      })
+      .toBe("claude");
+  });
+
+  // Runs in the same serial describe (same worker) as the tests above: all of
+  // these tests write backgroundAgentProvider/opencode/hostler in the SHARED
+  // config store (only the DB is per-worker), so splitting them across
+  // describes lets fullyParallel workers race on those keys.
+  test("shows the fallback warning and keeps the saved runtime selected when gated off", async ({}, testInfo) => {
+    // A saved runtime whose Extensions gates are no longer met — the row must
+    // surface the fallback instead of silently misrepresenting where drafts
+    // run. The state must exist before Settings first mounts, so relaunch.
+    await page.evaluate(() =>
+      window.api.settings.set({
+        backgroundAgentProvider: "opencode",
+        opencode: { enabled: false },
+        hostler: { enabled: false },
+      }),
+    );
+    await closeApp(electronApp);
+    const result = await launchElectronApp({ workerIndex: testInfo.workerIndex });
+    electronApp = result.app;
+    page = result.page;
+
+    await page.locator("button[title='Settings']").click();
+    await expect(page.locator("h1:has-text('Settings')")).toBeVisible({ timeout: 5000 });
+
+    const select = page.getByLabel("Provider for Agent Drafter");
+    await select.scrollIntoViewIfNeeded();
+    await expect(select).toHaveValue("opencode");
+    await expect(
+      page.getByText(/OpenCode is disabled — background drafts fall back to the built-in agent/),
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -429,6 +429,10 @@ test.describe("Settings Panel - Persistence", () => {
   });
 });
 
+// These tests use ONLY the opencode + backgroundAgentProvider config keys.
+// The electron-store config is shared across parallel e2e workers (only the
+// DB is per-worker), and tests/e2e/hostler-settings.spec.ts owns the hostler
+// key — touching it here would let fullyParallel workers race on it.
 test.describe("Settings Panel - Agent Drafter runtime picker", () => {
   test.describe.configure({ mode: "serial" });
   let electronApp: ElectronApplication;
@@ -443,8 +447,7 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
     await page.evaluate(() =>
       window.api.settings.set({
         backgroundAgentProvider: "claude",
-        hostler: { enabled: true, apiKey: "cpk_test", harness: "opencode" },
-        opencode: { enabled: false },
+        opencode: { enabled: true },
       }),
     );
   });
@@ -454,7 +457,6 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
       await page.evaluate(() =>
         window.api.settings.set({
           backgroundAgentProvider: "claude",
-          hostler: { enabled: false },
           opencode: { enabled: false },
         }),
       );
@@ -464,19 +466,18 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
     }
   });
 
-  test("runtime options are gated by Extensions config", async () => {
+  test("an enabled runtime is selectable in the Agent Drafter row", async () => {
     await page.locator("button[title='Settings']").click();
     await expect(page.locator("h1:has-text('Settings')")).toBeVisible({ timeout: 5000 });
 
     const select = page.getByLabel("Provider for Agent Drafter");
     await select.scrollIntoViewIfNeeded();
-    await expect(select.locator("option[value='hostler']")).toBeEnabled();
-    await expect(select.locator("option[value='opencode']")).toBeDisabled();
+    await expect(select.locator("option[value='opencode']")).toBeEnabled();
   });
 
   test("selecting an external runtime persists only after Save Changes", async () => {
     const select = page.getByLabel("Provider for Agent Drafter");
-    await select.selectOption("hostler");
+    await select.selectOption("opencode");
 
     // The model column is replaced by the Extensions hint while an external
     // runtime is selected.
@@ -496,7 +497,7 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
         };
         return cfg.data?.backgroundAgentProvider;
       })
-      .toBe("hostler");
+      .toBe("opencode");
   });
 
   test("selecting an LLM provider returns the runtime to Claude and restores the model select", async () => {
@@ -516,10 +517,8 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
       .toBe("claude");
   });
 
-  // Runs in the same serial describe (same worker) as the tests above: all of
-  // these tests write backgroundAgentProvider/opencode/hostler in the SHARED
-  // config store (only the DB is per-worker), so splitting them across
-  // describes lets fullyParallel workers race on those keys.
+  // Same serial describe (same worker) as the tests above: they all mutate
+  // the shared backgroundAgentProvider/opencode keys.
   test("shows the fallback warning and keeps the saved runtime selected when gated off", async ({}, testInfo) => {
     // A saved runtime whose Extensions gates are no longer met — the row must
     // surface the fallback instead of silently misrepresenting where drafts
@@ -528,7 +527,6 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
       window.api.settings.set({
         backgroundAgentProvider: "opencode",
         opencode: { enabled: false },
-        hostler: { enabled: false },
       }),
     );
     await closeApp(electronApp);
@@ -542,6 +540,7 @@ test.describe("Settings Panel - Agent Drafter runtime picker", () => {
     const select = page.getByLabel("Provider for Agent Drafter");
     await select.scrollIntoViewIfNeeded();
     await expect(select).toHaveValue("opencode");
+    await expect(select.locator("option[value='opencode']")).toBeDisabled();
     await expect(
       page.getByText(/OpenCode is disabled — background drafts fall back to the built-in agent/),
     ).toBeVisible();

--- a/tests/real-gmail/cached-mode.spec.ts
+++ b/tests/real-gmail/cached-mode.spec.ts
@@ -103,7 +103,16 @@ test.describe("Real-Gmail Layer 9a — cached .dev-data", () => {
   test.afterAll(async () => {
     if (app) {
       try {
-        await app.close();
+        // app.close() can also HANG (not throw) when the main process has
+        // stuck handles — seen intermittently with a parallel `npm run dev`
+        // instance sharing .dev-data. Race it so the SIGKILL fallback below
+        // covers hangs too, instead of blowing the 60s hook budget.
+        await Promise.race([
+          app.close(),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error("app.close() timed out")), 15_000),
+          ),
+        ]);
       } catch {
         const proc = app.process();
         if (proc.pid) {

--- a/tests/unit/background-agent-provider.spec.ts
+++ b/tests/unit/background-agent-provider.spec.ts
@@ -9,6 +9,8 @@ import {
   ConfigSchema,
   DEFAULT_BACKGROUND_AGENT_PROVIDER,
   resolveBackgroundAgentProviderId,
+  applyAgentDrafterSelection,
+  isAgentRuntimeAvailable,
 } from "../../src/shared/types";
 import { deriveTraceProviderIds } from "../../src/shared/agent-types";
 import type { ScopedAgentEvent } from "../../src/shared/agent-types";
@@ -185,5 +187,54 @@ test.describe("deriveTraceProviderIds", () => {
 
   test("returns claude for an empty trace", () => {
     expect(deriveTraceProviderIds([])).toEqual(["claude"]);
+  });
+});
+
+test.describe("applyAgentDrafterSelection", () => {
+  test("selecting an external runtime routes background drafts there and leaves the Claude-runtime model untouched", () => {
+    expect(applyAgentDrafterSelection("opencode")).toEqual({
+      backgroundAgentProvider: "opencode",
+    });
+    expect(applyAgentDrafterSelection("hostler")).toEqual({
+      backgroundAgentProvider: "hostler",
+    });
+  });
+
+  test("selecting an LLM provider returns the runtime to the built-in Claude agent", () => {
+    expect(applyAgentDrafterSelection("anthropic")).toEqual({
+      backgroundAgentProvider: DEFAULT_BACKGROUND_AGENT_PROVIDER,
+      agentDrafterProvider: "anthropic",
+    });
+    expect(applyAgentDrafterSelection("ollama-cloud")).toEqual({
+      backgroundAgentProvider: DEFAULT_BACKGROUND_AGENT_PROVIDER,
+      agentDrafterProvider: "ollama-cloud",
+    });
+  });
+
+  test("unknown option values are an explicit no-op, not a misroute", () => {
+    expect(applyAgentDrafterSelection("openclaw-agent")).toBeNull();
+    expect(applyAgentDrafterSelection("")).toBeNull();
+  });
+});
+
+test.describe("isAgentRuntimeAvailable", () => {
+  test("mirrors the resolver gates for opencode", () => {
+    expect(isAgentRuntimeAvailable("opencode", { opencode: { enabled: true } })).toBe(true);
+    expect(isAgentRuntimeAvailable("opencode", { opencode: { enabled: false } })).toBe(false);
+    expect(isAgentRuntimeAvailable("opencode", {})).toBe(false);
+  });
+
+  test("mirrors the resolver gates for hostler (needs enabled AND apiKey)", () => {
+    expect(
+      isAgentRuntimeAvailable("hostler", { hostler: { enabled: true, apiKey: "cpk_x" } }),
+    ).toBe(true);
+    expect(isAgentRuntimeAvailable("hostler", { hostler: { enabled: true } })).toBe(false);
+    expect(
+      isAgentRuntimeAvailable("hostler", { hostler: { enabled: false, apiKey: "cpk_x" } }),
+    ).toBe(false);
+  });
+
+  test("the built-in Claude runtime is always available", () => {
+    expect(isAgentRuntimeAvailable(DEFAULT_BACKGROUND_AGENT_PROVIDER, {})).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The background auto-draft agent was configurable in two places: a **"Background Agent"** card in Settings → Agents (which runtime runs background drafts: Claude / OpenCode / Hostler, added in #185) and the **"Agent Drafter"** row in Settings → General → AI Models (which model the built-in Claude runtime uses). This PR consolidates both into the single Agent Drafter row in the General tab.

The two selectors collapse cleanly because the model choice only matters when the Claude runtime is active — OpenCode and Hostler bring their own model configuration in the Extensions tab.

## Changes

- The Agent Drafter provider dropdown now offers **Anthropic, Ollama Cloud, OpenCode, and Hostler (cloud)**. Option enablement derives from the same `resolveBackgroundAgentProviderId` gates the main process uses (via a new `isAgentRuntimeAvailable` helper), so the UI can't drift from real fallback behavior.
- The runtime/model mutual exclusion lives in a new pure helper `applyAgentDrafterSelection` in `shared/types.ts`: picking OpenCode/Hostler sets `backgroundAgentProvider` and swaps the model select for a "Model set in Extensions" link (which navigates to the Extensions tab); picking Anthropic/Ollama returns the runtime to the built-in Claude agent and selects its model as before. Unknown/hand-edited provider ids render as a disabled option instead of a blank select.
- The fallback warning (selected provider's gates unmet → drafts fall back to the built-in agent) moves under the row, plus a guidance hint (enable OpenCode/Hostler in Extensions) replacing the copy the old card carried.
- Removed the Background Agent card from the Agents tab.
- **State-sync hardening** (from review): General-tab staged state now hydrates once from the first config load — previously any `general-config` refetch (Extensions-tab save, window-focus) rewrote all staged fields, silently reverting unsaved edits. The gate freshness that motivated the old tab-visit refetch now comes from write-site invalidations in ExtensionsTab's OpenCode/Hostler save handlers.
- **Save feedback** (from review): the General tab's Save Changes button now reports success ("Saved") and failure (inline error) instead of swallowing the `settings:set` result, and is disabled until config has loaded so a failed `settings:get` can't be overwritten with staged defaults.

**Behavior change:** the runtime choice used to persist immediately on change (old Agents card); it now persists via the General tab's "Save Changes" button, consistent with the rest of the AI Models section.

**Known residual (intentionally out of scope):** while an external runtime is selected, the hidden `featureProviders.agentDrafter` value still participates in `resolveAgentOllamaConfig`'s both-features gate for the shared agent worker (documented in a code comment); and staged General-tab edits are still discarded when Settings closes without Save, as with every other field in that section.

## Screenshots

Consolidated Agent Drafter row in General → AI Models:

![Consolidated AI Models section with Agent Drafter row](https://raw.githubusercontent.com/ankitvgupta/exo/pr-assets/consolidate-agent-model-setting/ai-models-agent-drafter.png)

OpenCode selected as runtime — "Model set in Extensions" link, fallback warning when OpenCode is disabled in Extensions, and the enablement hint:

![Agent Drafter row with OpenCode selected and fallback warning](https://raw.githubusercontent.com/ankitvgupta/exo/pr-assets/consolidate-agent-model-setting/agent-drafter-fallback-warning.png)

## Validation

- `npm run typecheck`, `npm run lint`, prettier — clean
- `npm run test:unit` — 1490 passed at PR open; 25/25 on the extended resolver/helper spec after review fixes
- New e2e coverage in `tests/e2e/settings.spec.ts` (4 tests, one serial describe since the config store is shared across parallel e2e workers): option gating from Extensions config, staged-save round-trip via Save Changes, runtime reset to Claude, fallback warning + saved-value display when gated off — 31/31 in the file
- Multi-pass review before push: 5 specialist reviewers + fresh-context adversarial pass; all CRITICAL/high findings fixed (state-sync clobber, save-result swallowing), informational findings either fixed (guidance copy, unknown-id select, intro copy, warning copy) or documented as residual above
- Exercised end-to-end in the running app via CDP; screenshots above are from the final state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRE-PR-REPORT-START SHA=736c7d0 mode=full -->
**Pre-PR verdict**: PASS

- mode: `full`
- sha: `736c7d0`
- generated: 2026-07-16T04:26:54.860Z

| Phase | Status | Duration |
|---|---|---|
| eval:analyzer | ✅ exit 0 | 19.2s |
| eval:features | ✅ exit 0 | 38.0s |
| agentic-verify | ✅ exit 0 | 331.2s |
| real-gmail:cached | ✅ exit 0 | 12.9s |

<!-- PRE-PR-REPORT-END -->
