### PR TITLE
Persist undo-send in the main process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -425,7 +425,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
       "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
         "standardwebhooks": "^1.0.0"
@@ -443,13 +442,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -458,9 +457,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -468,22 +467,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -510,14 +508,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -527,14 +525,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -554,9 +552,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -564,29 +562,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -606,9 +604,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -616,9 +614,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -626,9 +624,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -636,27 +634,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -723,33 +721,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -757,14 +755,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -794,7 +792,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -858,9 +855,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1132,9 +1129,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1745,7 +1742,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1765,12 +1761,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2157,13 +2153,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2838,7 +2833,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.21.0.tgz",
       "integrity": "sha512-IfnQiuEeabDSPr1C/zHFTbnvlTf5z0DE/d/xz4C6bkL4ZBDJ3rr99h2qsaV0l8F+kbNswZMlQdM8rxNlMy95fQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3074,7 +3068,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.21.0.tgz",
       "integrity": "sha512-KeBlEtLrGce2d3dgL89hmwWEtREuzlW4XY5bYWpKNvCbFqvdSb3n7vkdkw32YclZmMWxAcABgW6ucCStkE0rsQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3206,7 +3199,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.21.0.tgz",
       "integrity": "sha512-MN1uh5PmHT1F2BNsbc21MIS0AMFFA73oODlp/4ckpBR4o5AxRwV+8f43Cd52UL4MgMkKj/A+QfZ7iK9IDb0h5A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3221,7 +3213,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.21.0.tgz",
       "integrity": "sha512-I3sNo7oMMsR6FFz1ecvPb9uCF0VQuS2WV67j8Io2M7DJicRWCE/GM5DaiYjTeWBbnByk6BuG0txoJATAqPVliQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3578,7 +3569,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3589,7 +3579,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3688,7 +3677,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3957,7 +3945,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4222,6 +4209,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -4241,6 +4229,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -4263,6 +4252,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4278,7 +4268,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -4286,6 +4277,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -4566,21 +4558,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4614,16 +4619,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4659,7 +4664,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4854,9 +4858,9 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5336,6 +5340,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -5419,9 +5424,9 @@
       "license": "MIT"
     },
     "node_modules/config-file-ts/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5582,6 +5587,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -5595,6 +5601,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -5896,9 +5903,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5932,7 +5939,6 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -6037,9 +6043,9 @@
       "optional": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6142,12 +6148,11 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.8.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.6.tgz",
-      "integrity": "sha512-uWX6Jh5LmwL13VwOSKBjebI+ck+03GOwc8V2Sgbmr9pJVJ/cHfli/PkjXuRDr+hq+SLHQuT9mGHSIfScebApRA==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -6192,6 +6197,7 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -6205,6 +6211,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -6220,6 +6227,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6233,6 +6241,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -6350,12 +6359,12 @@
       "license": "ISC"
     },
     "node_modules/electron-updater": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
-      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "license": "MIT",
       "dependencies": {
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -6366,9 +6375,9 @@
       }
     },
     "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -6636,7 +6645,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6979,7 +6987,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7151,9 +7158,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7251,9 +7258,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7358,17 +7365,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7695,9 +7702,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7933,9 +7940,9 @@
       "license": "ISC"
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7998,11 +8005,10 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8245,9 +8251,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8460,7 +8466,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -8521,7 +8528,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8551,9 +8557,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -8703,6 +8709,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -8716,6 +8723,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8731,7 +8739,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -8739,6 +8748,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8778,9 +8788,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -8827,14 +8837,16 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -8847,7 +8859,8 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -8861,14 +8874,16 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -10308,9 +10323,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -11237,9 +11252,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -11256,9 +11271,8 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11484,7 +11498,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -11654,7 +11669,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11684,7 +11698,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11733,7 +11746,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
       "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11902,7 +11914,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11915,7 +11926,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12004,6 +12014,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -12013,14 +12024,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -12031,6 +12044,7 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -13129,7 +13143,6 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13363,7 +13376,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13401,9 +13413,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13517,7 +13529,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14069,17 +14080,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -14088,7 +14116,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14397,12 +14424,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -14511,7 +14537,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14723,6 +14748,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -14738,6 +14764,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",
@@ -14759,7 +14786,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -3474,6 +3474,21 @@ export function getSnoozedByThread(threadId: string, accountId: string): Snoozed
 
 export type ScheduledMessageStatus = "scheduled" | "sending" | "sent" | "failed" | "cancelled";
 
+/**
+ * 'scheduled' = user-chosen send-later. 'undo' = the short undo-send delay.
+ * Both use the same scheduler and fire identically; kind only selects the
+ * cancel policy (draft vs. reopen-compose) and which UI owns the row.
+ */
+export type ScheduledMessageKind = "scheduled" | "undo";
+
+export type ScheduledMessageAttachment = {
+  filename: string;
+  mimeType: string;
+  path?: string;
+  content?: string;
+  size?: number;
+};
+
 export type ScheduledMessageRow = {
   id: string;
   accountId: string;
@@ -3488,13 +3503,30 @@ export type ScheduledMessageRow = {
   bodyText?: string;
   inReplyTo?: string;
   references?: string;
+  attachments?: ScheduledMessageAttachment[];
   scheduledAt: number;
+  kind: ScheduledMessageKind;
+  archiveThreadId?: string;
+  /** Opaque JSON blob owned by the renderer; main only round-trips it. */
+  composeContext?: string;
   status: ScheduledMessageStatus;
   errorMessage?: string;
   createdAt: number;
   updatedAt: number;
   sentAt?: number;
 };
+
+// Shared by every scheduled_messages SELECT so the column list can't drift.
+const SCHEDULED_MESSAGE_COLUMNS = `
+  id, account_id as accountId, type, thread_id as threadId,
+  to_addresses as toAddresses, cc_addresses as ccAddresses, bcc_addresses as bccAddresses,
+  subject, body_html as bodyHtml, body_text as bodyText,
+  in_reply_to as inReplyTo, references_header as referencesHeader,
+  from_address as fromAddress, attachments,
+  scheduled_at as scheduledAt, kind, archive_thread_id as archiveThreadId,
+  compose_context as composeContext, status, error_message as errorMessage,
+  created_at as createdAt, updated_at as updatedAt, sent_at as sentAt
+`;
 
 export function insertScheduledMessage(
   item: Omit<ScheduledMessageRow, "status" | "updatedAt" | "sentAt" | "errorMessage">,
@@ -3504,9 +3536,10 @@ export function insertScheduledMessage(
     INSERT INTO scheduled_messages (
       id, account_id, type, thread_id, to_addresses, cc_addresses, bcc_addresses,
       subject, body_html, body_text, in_reply_to, references_header,
-      from_address, scheduled_at, status, created_at, updated_at
+      from_address, attachments, scheduled_at, kind, archive_thread_id,
+      compose_context, status, created_at, updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'scheduled', ?, ?)
   `);
   const now = Date.now();
   stmt.run(
@@ -3523,7 +3556,11 @@ export function insertScheduledMessage(
     item.inReplyTo || null,
     item.references || null,
     item.from || null,
+    item.attachments?.length ? JSON.stringify(item.attachments) : null,
     item.scheduledAt,
+    item.kind,
+    item.archiveThreadId || null,
+    item.composeContext || null,
     item.createdAt,
     now,
   );
@@ -3533,13 +3570,7 @@ export function getDueScheduledMessages(limit: number = 10): ScheduledMessageRow
   const db = getDatabase();
   const now = Date.now();
   const stmt = db.prepare(`
-    SELECT id, account_id as accountId, type, thread_id as threadId,
-           to_addresses as toAddresses, cc_addresses as ccAddresses, bcc_addresses as bccAddresses,
-           subject, body_html as bodyHtml, body_text as bodyText,
-           in_reply_to as inReplyTo, references_header as referencesHeader,
-           from_address as fromAddress,
-           scheduled_at as scheduledAt, status, error_message as errorMessage,
-           created_at as createdAt, updated_at as updatedAt, sent_at as sentAt
+    SELECT ${SCHEDULED_MESSAGE_COLUMNS}
     FROM scheduled_messages
     WHERE status = 'scheduled' AND scheduled_at <= ?
     ORDER BY scheduled_at ASC
@@ -3549,39 +3580,47 @@ export function getDueScheduledMessages(limit: number = 10): ScheduledMessageRow
   return rows.map(rowToScheduledMessage);
 }
 
-export function getScheduledMessages(accountId?: string): ScheduledMessageRow[] {
+/**
+ * Earliest not-yet-due scheduled_at, or null when nothing is pending.
+ * Drives the next-due timer so a 15s undo isn't held up by a coarse poll.
+ */
+export function getNextScheduledMessageTime(): number | null {
+  const db = getDatabase();
+  const row = db
+    .prepare(`SELECT MIN(scheduled_at) as next FROM scheduled_messages WHERE status = 'scheduled'`)
+    .get() as { next: number | null } | undefined;
+  return row?.next ?? null;
+}
+
+export function getScheduledMessages(
+  accountId?: string,
+  kind?: ScheduledMessageKind,
+): ScheduledMessageRow[] {
   const db = getDatabase();
   let query = `
-    SELECT id, account_id as accountId, type, thread_id as threadId,
-           to_addresses as toAddresses, cc_addresses as ccAddresses, bcc_addresses as bccAddresses,
-           subject, body_html as bodyHtml, body_text as bodyText,
-           in_reply_to as inReplyTo, references_header as referencesHeader,
-           from_address as fromAddress,
-           scheduled_at as scheduledAt, status, error_message as errorMessage,
-           created_at as createdAt, updated_at as updatedAt, sent_at as sentAt
+    SELECT ${SCHEDULED_MESSAGE_COLUMNS}
     FROM scheduled_messages
     WHERE status = 'scheduled'
   `;
+  const params: string[] = [];
   if (accountId) {
     query += ` AND account_id = ?`;
+    params.push(accountId);
+  }
+  if (kind) {
+    query += ` AND kind = ?`;
+    params.push(kind);
   }
   query += ` ORDER BY scheduled_at ASC`;
 
-  const stmt = db.prepare(query);
-  const rows = accountId ? stmt.all(accountId) : stmt.all();
+  const rows = db.prepare(query).all(...params);
   return (rows as Record<string, unknown>[]).map(rowToScheduledMessage);
 }
 
 export function getScheduledMessage(id: string): ScheduledMessageRow | null {
   const db = getDatabase();
   const stmt = db.prepare(`
-    SELECT id, account_id as accountId, type, thread_id as threadId,
-           to_addresses as toAddresses, cc_addresses as ccAddresses, bcc_addresses as bccAddresses,
-           subject, body_html as bodyHtml, body_text as bodyText,
-           in_reply_to as inReplyTo, references_header as referencesHeader,
-           from_address as fromAddress,
-           scheduled_at as scheduledAt, status, error_message as errorMessage,
-           created_at as createdAt, updated_at as updatedAt, sent_at as sentAt
+    SELECT ${SCHEDULED_MESSAGE_COLUMNS}
     FROM scheduled_messages
     WHERE id = ?
   `);
@@ -3614,6 +3653,26 @@ export function updateScheduledMessageStatus(
   }
 }
 
+/**
+ * Atomically move a row out of 'scheduled' — the guard against cancel racing a
+ * fire. A conditional UPDATE is indivisible, so exactly one of "send it" and
+ * "cancel it" wins; the loser sees rowcount 0 and must not act.
+ */
+export function claimScheduledMessage(
+  id: string,
+  nextStatus: ScheduledMessageStatus,
+): ScheduledMessageRow | null {
+  const db = getDatabase();
+  const result = db
+    .prepare(
+      `UPDATE scheduled_messages SET status = ?, updated_at = ?
+       WHERE id = ? AND status = 'scheduled'`,
+    )
+    .run(nextStatus, Date.now(), id);
+  if (result.changes === 0) return null;
+  return getScheduledMessage(id);
+}
+
 export function updateScheduledMessageTime(id: string, scheduledAt: number): void {
   const db = getDatabase();
   db.prepare(
@@ -3631,10 +3690,12 @@ export function deleteScheduledMessage(id: string): void {
 
 export function getScheduledMessageStats(accountId?: string): { scheduled: number; total: number } {
   const db = getDatabase();
+  // Only user-scheduled sends: a message inside its few-second undo window is
+  // not a "scheduled message" as far as the send-later badge is concerned.
   let query = `
     SELECT status, COUNT(*) as count
     FROM scheduled_messages
-    WHERE status IN ('scheduled', 'sending')
+    WHERE status IN ('scheduled', 'sending') AND kind = 'scheduled'
   `;
   if (accountId) {
     query += ` AND account_id = ?`;
@@ -3669,7 +3730,14 @@ function rowToScheduledMessage(row: Record<string, unknown>): ScheduledMessageRo
     bodyText: (row.bodyText as string | null) ?? undefined,
     inReplyTo: (row.inReplyTo as string | null) ?? undefined,
     references: (row.referencesHeader as string | null) ?? undefined,
+    attachments: row.attachments
+      ? (JSON.parse(row.attachments as string) as ScheduledMessageAttachment[])
+      : undefined,
     scheduledAt: row.scheduledAt as number,
+    // Rows written before the undo-send unification have no kind; they are all send-later.
+    kind: ((row.kind as string | null) ?? "scheduled") as ScheduledMessageKind,
+    archiveThreadId: (row.archiveThreadId as string | null) ?? undefined,
+    composeContext: (row.composeContext as string | null) ?? undefined,
     status: row.status as ScheduledMessageStatus,
     errorMessage: (row.errorMessage as string | null) ?? undefined,
     createdAt: row.createdAt as number,

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -354,6 +354,48 @@ export const NUMBERED_MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    // NOTE: version 8 is claimed by a concurrent branch (observed applied in a
+    // real user DB on 2026-08-01). Migrations are forward-only and keyed by
+    // number, so reusing 8 here would make this one silently skip on any DB that
+    // already ran the other 8, leaving the columns missing. Renumbered to 9; the
+    // ALTERs below are individually guarded so it is safe either way.
+    version: 9,
+    name: "unify_undo_send_into_scheduled_messages",
+    up: (db) => {
+      // The undo-send delay used to live as a setTimeout in the renderer, so a
+      // window close during the delay silently dropped the message. It now
+      // shares the scheduled_messages scheduler, which needs four extra columns.
+      //
+      // `attachments` also fixes a latent send-later bug: the table never had
+      // the column, so scheduled sends silently dropped attachments.
+      //
+      // Guard on table existence — migrations run BEFORE the SCHEMA CREATE
+      // statements in initDatabase, so on a fresh DB this table doesn't exist
+      // yet and SCHEMA already carries the final column set.
+      const cols = db.prepare("PRAGMA table_info(scheduled_messages)").all() as Array<{
+        name: string;
+      }>;
+      if (cols.length === 0) return;
+
+      const existing = new Set(cols.map((c) => c.name));
+      const additions: Array<[string, string]> = [
+        ["attachments", "TEXT"],
+        ["kind", "TEXT NOT NULL DEFAULT 'scheduled'"],
+        ["archive_thread_id", "TEXT"],
+        ["compose_context", "TEXT"],
+      ];
+      for (const [name, type] of additions) {
+        if (!existing.has(name)) {
+          db.exec(`ALTER TABLE scheduled_messages ADD COLUMN ${name} ${type}`);
+        }
+      }
+
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_scheduled_due ON scheduled_messages(status, scheduled_at)`,
+      );
+    },
+  },
 ];
 
 function runNumberedMigrations(db: DatabaseInstance): void {

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -196,7 +196,13 @@ CREATE TABLE IF NOT EXISTS scheduled_messages (
   body_text TEXT,
   in_reply_to TEXT,
   references_header TEXT,
+  attachments TEXT,
   scheduled_at INTEGER NOT NULL,
+  -- 'scheduled' = user-chosen send-later; 'undo' = the short undo-send delay.
+  -- Only affects cancel policy and which UI owns the row, never when it fires.
+  kind TEXT NOT NULL DEFAULT 'scheduled',
+  archive_thread_id TEXT,
+  compose_context TEXT,
   status TEXT DEFAULT 'scheduled',
   error_message TEXT,
   created_at INTEGER NOT NULL,
@@ -380,6 +386,7 @@ CREATE INDEX IF NOT EXISTS idx_archive_ready_ready ON archive_ready(is_ready, di
 CREATE INDEX IF NOT EXISTS idx_scheduled_status ON scheduled_messages(status);
 CREATE INDEX IF NOT EXISTS idx_scheduled_account ON scheduled_messages(account_id);
 CREATE INDEX IF NOT EXISTS idx_scheduled_at ON scheduled_messages(scheduled_at);
+CREATE INDEX IF NOT EXISTS idx_scheduled_due ON scheduled_messages(status, scheduled_at);
 CREATE INDEX IF NOT EXISTS idx_cal_events_date ON calendar_events(start_time);
 CREATE INDEX IF NOT EXISTS idx_cal_events_account ON calendar_events(account_id);
 CREATE INDEX IF NOT EXISTS idx_memories_account ON memories(account_id);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -461,17 +461,14 @@ app.whenReady().then(async () => {
     getEmailSyncService().getClientForAccount(accountId),
   );
 
-  // Set up scheduled send service client resolver and start background timer
+  // Set up scheduled send service dependencies. Recovery starts from sync:init,
+  // after Gmail clients exist and the renderer has installed IPC listeners.
   scheduledSendService.setClientResolver((accountId) =>
     getEmailSyncService().getClientForAccount(accountId),
   );
   scheduledSendService.setThreadArchiver(async (threadId, accountId) => {
     await archiveThreadInternal(accountId, threadId);
   });
-  // Recover before starting: rows that came due while the app was closed (or that
-  // were mid-undo-delay when it was killed) fire now instead of being lost.
-  scheduledSendService.recoverOnStartup();
-
   // NOTE: outbox processing on "online" is handled by sync.ipc.ts
   // after account reconnection completes, to avoid racing against client init.
   // Startup outbox processing is also deferred to sync:init completing.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,7 +22,7 @@ import { registerGmailIpc } from "./ipc/gmail.ipc";
 import { registerAnalysisIpc } from "./ipc/analysis.ipc";
 import { registerDraftsIpc } from "./ipc/drafts.ipc";
 import { registerSettingsIpc, getConfig } from "./ipc/settings.ipc";
-import { registerSyncIpc, getEmailSyncService } from "./ipc/sync.ipc";
+import { registerSyncIpc, getEmailSyncService, archiveThreadInternal } from "./ipc/sync.ipc";
 import { registerPrefetchIpc } from "./ipc/prefetch.ipc";
 import { registerExtensionsIpc } from "./ipc/extensions.ipc";
 import { registerComposeIpc } from "./ipc/compose.ipc";
@@ -465,7 +465,12 @@ app.whenReady().then(async () => {
   scheduledSendService.setClientResolver((accountId) =>
     getEmailSyncService().getClientForAccount(accountId),
   );
-  scheduledSendService.start();
+  scheduledSendService.setThreadArchiver(async (threadId, accountId) => {
+    await archiveThreadInternal(accountId, threadId);
+  });
+  // Recover before starting: rows that came due while the app was closed (or that
+  // were mid-undo-delay when it was killed) fire now instead of being lost.
+  scheduledSendService.recoverOnStartup();
 
   // NOTE: outbox processing on "online" is handled by sync.ipc.ts
   // after account reconnection completes, to avoid racing against client init.
@@ -641,7 +646,26 @@ const walCheckpointInterval = setInterval(() => {
 // Flush WAL and close DB before the process exits to prevent data loss.
 // Without this, infrequent writes (e.g. memories) can be stranded in the
 // WAL file and lost if the file is corrupted or removed during an update.
-app.on("before-quit", () => {
+let isQuitting = false;
+
+app.on("before-quit", (event) => {
+  // A message inside its undo-send delay has been persisted but not sent yet.
+  // Quitting would strand it until the next launch, so take one async pass to
+  // flush pending sends. before-quit is synchronous, hence the standard
+  // preventDefault → await → quit again dance; the flush caps itself so a hung
+  // network can't block quit (survivors are recovered by recoverOnStartup).
+  if (!isQuitting) {
+    event.preventDefault();
+    scheduledSendService
+      .flushPendingNow()
+      .catch((err) => log.error({ err }, "[Quit] Failed to flush pending sends"))
+      .finally(() => {
+        isQuitting = true;
+        app.quit();
+      });
+    return;
+  }
+
   // Stop all interval-based services before closing the DB —
   // otherwise their timers fire after the DB is gone and crash.
   clearInterval(walCheckpointInterval);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -649,8 +649,9 @@ app.on("before-quit", (event) => {
   // A message inside its undo-send delay has been persisted but not sent yet.
   // Quitting would strand it until the next launch, so take one async pass to
   // flush pending sends. before-quit is synchronous, hence the standard
-  // preventDefault → await → quit again dance; the flush caps itself so a hung
-  // network can't block quit (survivors are recovered by recoverOnStartup).
+  // preventDefault → await → quit again dance. The service aborts requests
+  // that exceed its grace period and waits for their rows to be restored before
+  // this handler runs again and closes SQLite.
   if (!isQuitting) {
     event.preventDefault();
     scheduledSendService

--- a/src/main/ipc/scheduled-send.ipc.ts
+++ b/src/main/ipc/scheduled-send.ipc.ts
@@ -4,7 +4,7 @@ import {
   insertScheduledMessage,
   getScheduledMessages,
   getScheduledMessage,
-  updateScheduledMessageStatus,
+  claimScheduledMessage,
   updateScheduledMessageTime,
   deleteScheduledMessage,
   getScheduledMessageStats,
@@ -16,6 +16,7 @@ import { getEmailSyncService } from "./sync.ipc";
 import type {
   IpcResponse,
   ScheduledMessage,
+  ScheduledMessageKind,
   ScheduledMessageStats,
   SendMessageOptions,
 } from "../../shared/types";
@@ -43,6 +44,9 @@ function rowToScheduledMessage(row: ScheduledMessageRow): ScheduledMessage {
     inReplyTo: row.inReplyTo,
     references: row.references,
     scheduledAt: row.scheduledAt,
+    kind: row.kind,
+    archiveThreadId: row.archiveThreadId,
+    composeContext: row.composeContext,
     status: row.status,
     errorMessage: row.errorMessage,
     createdAt: row.createdAt,
@@ -57,8 +61,15 @@ export function registerScheduledSendIpc(): void {
     "scheduled-send:create",
     async (
       _,
-      options: SendMessageOptions & { accountId: string; scheduledAt: number },
+      options: SendMessageOptions & {
+        accountId: string;
+        scheduledAt: number;
+        kind?: ScheduledMessageKind;
+        archiveThreadId?: string;
+        composeContext?: string;
+      },
     ): Promise<IpcResponse<ScheduledMessage>> => {
+      const kind: ScheduledMessageKind = options.kind ?? "scheduled";
       if (useFakeData) {
         log.info(
           { to: options.to, scheduledAt: new Date(options.scheduledAt).toISOString() },
@@ -78,6 +89,9 @@ export function registerScheduledSendIpc(): void {
           inReplyTo: options.inReplyTo,
           references: options.references,
           scheduledAt: options.scheduledAt,
+          kind,
+          archiveThreadId: options.archiveThreadId,
+          composeContext: options.composeContext,
           status: "scheduled",
           createdAt: Date.now(),
           updatedAt: Date.now(),
@@ -111,13 +125,20 @@ export function registerScheduledSendIpc(): void {
           bodyText: options.bodyText,
           inReplyTo: options.inReplyTo,
           references: options.references,
+          attachments: options.attachments,
           scheduledAt: options.scheduledAt,
+          kind,
+          archiveThreadId: options.archiveThreadId,
+          composeContext: options.composeContext,
           createdAt: now,
         });
 
         log.info(
-          `[ScheduledSend] Scheduled message ${id} for ${new Date(options.scheduledAt).toISOString()}`,
+          `[ScheduledSend] Scheduled message ${id} (${kind}) for ${new Date(options.scheduledAt).toISOString()}`,
         );
+
+        // Re-arm so a short undo delay isn't held up behind a longer pending sleep.
+        scheduledSendService.reschedule();
 
         const row = getScheduledMessage(id);
         if (!row) {
@@ -140,9 +161,12 @@ export function registerScheduledSendIpc(): void {
   // List scheduled messages for an account
   ipcMain.handle(
     "scheduled-send:list",
-    async (_, { accountId }: { accountId?: string }): Promise<IpcResponse<ScheduledMessage[]>> => {
+    async (
+      _,
+      { accountId, kind }: { accountId?: string; kind?: ScheduledMessageKind },
+    ): Promise<IpcResponse<ScheduledMessage[]>> => {
       try {
-        const rows = getScheduledMessages(accountId);
+        const rows = getScheduledMessages(accountId, kind);
         return { success: true, data: rows.map(rowToScheduledMessage) };
       } catch (error) {
         return {
@@ -156,14 +180,29 @@ export function registerScheduledSendIpc(): void {
   // Cancel a scheduled message (converts it to a Gmail draft so content isn't lost)
   ipcMain.handle(
     "scheduled-send:cancel",
-    async (_, { id }: { id: string }): Promise<IpcResponse<{ draftId?: string }>> => {
+    async (
+      _,
+      { id }: { id: string },
+    ): Promise<IpcResponse<{ draftId?: string; composeContext?: string; cancelled: boolean }>> => {
       try {
-        const row = getScheduledMessage(id);
+        // Claim atomically — if the send already fired we lose the race and must
+        // report that rather than pretending the message was recalled.
+        const row = claimScheduledMessage(id, "cancelled");
         if (!row) {
-          return { success: false, error: "Scheduled message not found" };
+          const existing = getScheduledMessage(id);
+          if (!existing) {
+            return { success: false, error: "Scheduled message not found" };
+          }
+          return { success: true, data: { cancelled: false } };
         }
-        if (row.status !== "scheduled") {
-          return { success: false, error: `Cannot cancel message in '${row.status}' state` };
+
+        // Undo-send reopens the compose editor instead of leaving a Gmail draft,
+        // so the round-tripped context is all the renderer needs.
+        if (row.kind === "undo") {
+          log.info(`[ScheduledSend] Cancelled undo-send ${id}`);
+          scheduledSendService.reschedule();
+          broadcastStatsChanged();
+          return { success: true, data: { composeContext: row.composeContext, cancelled: true } };
         }
 
         // Try to save content as a Gmail draft so it's not lost
@@ -195,10 +234,11 @@ export function registerScheduledSendIpc(): void {
           }
         }
 
-        updateScheduledMessageStatus(id, "cancelled");
+        // Status was already set by the claim above.
         log.info(`[ScheduledSend] Cancelled message ${id}`);
+        scheduledSendService.reschedule();
         broadcastStatsChanged();
-        return { success: true, data: { draftId } };
+        return { success: true, data: { draftId, cancelled: true } };
       } catch (error) {
         return {
           success: false,
@@ -234,6 +274,7 @@ export function registerScheduledSendIpc(): void {
           return { success: false, error: "Failed to retrieve updated message" };
         }
 
+        scheduledSendService.reschedule();
         broadcastStatsChanged();
         return { success: true, data: rowToScheduledMessage(updated) };
       } catch (error) {
@@ -251,6 +292,7 @@ export function registerScheduledSendIpc(): void {
     async (_, { id }: { id: string }): Promise<IpcResponse<void>> => {
       try {
         deleteScheduledMessage(id);
+        scheduledSendService.reschedule();
         broadcastStatsChanged();
         return { success: true, data: undefined };
       } catch (error) {

--- a/src/main/ipc/scheduled-send.ipc.ts
+++ b/src/main/ipc/scheduled-send.ipc.ts
@@ -116,6 +116,7 @@ export function registerScheduledSendIpc(): void {
             win.webContents.send("scheduled-send:sent", {
               id: msg.id,
               kind,
+              accountId: options.accountId,
               gmailId: `demo-sent-${msg.id}`,
               threadId: options.threadId,
               composeContext: options.composeContext,

--- a/src/main/ipc/scheduled-send.ipc.ts
+++ b/src/main/ipc/scheduled-send.ipc.ts
@@ -29,6 +29,14 @@ const isTestMode = process.env.EXO_TEST_MODE === "true";
 const isDemoMode = process.env.EXO_DEMO_MODE === "true";
 const useFakeData = isTestMode || isDemoMode;
 
+// Demo/test mode bypasses the DB and the scheduler, so pending sends are tracked
+// here instead — just enough to reproduce the fire-and-cancel lifecycle the
+// renderer depends on.
+const demoTimers = new Map<
+  string,
+  { timer: ReturnType<typeof setTimeout>; composeContext?: string }
+>();
+
 function rowToScheduledMessage(row: ScheduledMessageRow): ScheduledMessage {
   return {
     id: row.id,
@@ -96,6 +104,27 @@ export function registerScheduledSendIpc(): void {
           createdAt: Date.now(),
           updatedAt: Date.now(),
         };
+
+        // Demo/test mode has no DB row and no scheduler, so nothing would ever
+        // emit "sent" — the undo toast would hang forever waiting for it.
+        // Simulate the fire so the renderer sees the same lifecycle it does in
+        // production.
+        const demoDelay = Math.max(0, options.scheduledAt - Date.now());
+        const timer = setTimeout(() => {
+          demoTimers.delete(msg.id);
+          for (const win of BrowserWindow.getAllWindows()) {
+            win.webContents.send("scheduled-send:sent", {
+              id: msg.id,
+              kind,
+              gmailId: `demo-sent-${msg.id}`,
+              threadId: options.threadId,
+              composeContext: options.composeContext,
+              archiveThreadId: options.archiveThreadId,
+            });
+          }
+        }, demoDelay);
+        demoTimers.set(msg.id, { timer, composeContext: options.composeContext });
+
         return { success: true, data: msg };
       }
 
@@ -184,6 +213,22 @@ export function registerScheduledSendIpc(): void {
       _,
       { id }: { id: string },
     ): Promise<IpcResponse<{ draftId?: string; composeContext?: string; cancelled: boolean }>> => {
+      // In demo/test mode the pending send is a timer, not a row. Clearing it is
+      // the whole cancel; a missing timer means it already fired, which is the
+      // same lost-the-race answer the DB path gives.
+      if (useFakeData) {
+        const pending = demoTimers.get(id);
+        if (!pending) {
+          return { success: true, data: { cancelled: false } };
+        }
+        clearTimeout(pending.timer);
+        demoTimers.delete(id);
+        return {
+          success: true,
+          data: { composeContext: pending.composeContext, cancelled: true },
+        };
+      }
+
       try {
         // Claim atomically — if the send already fired we lose the race and must
         // report that rather than pretending the message was recalled.

--- a/src/main/ipc/sync.ipc.ts
+++ b/src/main/ipc/sync.ipc.ts
@@ -5,6 +5,7 @@ import { prefetchService } from "../services/prefetch-service";
 import { getExtensionHost } from "../extensions";
 import { networkMonitor } from "../services/network-monitor";
 import { outboxService } from "../services/outbox-service";
+import { scheduledSendService } from "../services/scheduled-send-service";
 import { pendingActionsQueue } from "../services/pending-actions";
 import { isNetworkError } from "../services/network-errors";
 import {
@@ -59,6 +60,15 @@ let retryingConnections = false;
 // Email data saved before optimistic trash deletion, keyed by emailId.
 // Used to restore the email to DB if a queued trash action fails permanently.
 const trashedEmailData: Map<string, DashboardEmail> = new Map();
+
+function recoverScheduledSendsIfReady(): void {
+  const hasConnectedAccount = getAccounts().some((account) =>
+    emailSyncService.isAccountRegistered(account.id),
+  );
+  if (hasConnectedAccount) {
+    scheduledSendService.recoverOnStartup();
+  }
+}
 
 // Service wrapper for accessing sync functionality from other IPC handlers
 export const getEmailSyncService = () => ({
@@ -235,6 +245,7 @@ export function registerSyncIpc(): void {
   // When going online, reconnect failed accounts THEN process queues
   networkMonitor.on("online", async () => {
     await retryFailedConnections();
+    recoverScheduledSendsIfReady();
     outboxService.processQueue().catch((err) => log.error({ err }, "Unhandled error"));
     pendingActionsQueue.processQueue().catch((err) => log.error({ err }, "Unhandled error"));
   });
@@ -402,6 +413,7 @@ export function registerSyncIpc(): void {
         // Re-register with sync service and restart sync
         await emailSyncService.registerAccount(client);
         emailSyncService.startSync(accountId);
+        recoverScheduledSendsIfReady();
 
         log.info(`[Auth] Re-authenticated account ${accountId}, sync restarted`);
         return { success: true, data: undefined };
@@ -490,6 +502,7 @@ export function registerSyncIpc(): void {
 
         // Store client reference
         activeClients.set(id, client);
+        recoverScheduledSendsIfReady();
 
         // Start sync loop — fullSync will detect first-time sync (no history ID,
         // no stored emails) and run triage + progressive loading automatically.
@@ -1041,6 +1054,10 @@ export function registerSyncIpc(): void {
 
         // Process any queued outbox messages from previous session
         outboxService.processQueue().catch((err) => log.error({ err }, "Unhandled error"));
+
+        // Start only after account clients are ready. This also processes rows
+        // that became due while the app was closed.
+        recoverScheduledSendsIfReady();
       }
 
       log.info(`[PERF] sync:init END total ${(performance.now() - t0).toFixed(1)}ms`);

--- a/src/main/ipc/sync.ipc.ts
+++ b/src/main/ipc/sync.ipc.ts
@@ -118,6 +118,119 @@ function getMainWindow(): BrowserWindow | null {
   return windows.length > 0 ? windows[0] : null;
 }
 
+/**
+ * Archive every inbox email in a thread, with optimistic local label updates and
+ * offline queueing. Exported so the scheduled-send service can reuse it for
+ * send-and-archive instead of duplicating this logic.
+ */
+export async function archiveThreadInternal(
+  accountId: string,
+  threadId: string,
+): Promise<{
+  success: boolean;
+  error?: string;
+  queued?: boolean;
+  failedIds?: string[];
+  archivedIds?: string[];
+}> {
+  const threadEmails = getEmailsByThread(threadId, accountId);
+  // Treat emails with no labelIds (NULL in DB) as inbox emails,
+  // matching the getInboxEmails query: WHERE label_ids IS NULL OR label_ids LIKE '%"INBOX"%'
+  const inboxEmails = threadEmails.filter((e) => !e.labelIds || e.labelIds.includes("INBOX"));
+
+  // Optimistically update DB for all inbox emails
+  const previousLabelsMap = new Map<string, string[]>();
+  for (const email of inboxEmails) {
+    previousLabelsMap.set(email.id, email.labelIds || []);
+    updateEmailLabelIds(
+      email.id,
+      (email.labelIds || []).filter((l: string) => l !== "INBOX"),
+    );
+  }
+
+  if (useFakeData) {
+    return { success: true };
+  }
+
+  // If offline, queue each email for later — DB already updated
+  if (!networkMonitor.isOnline) {
+    for (const email of inboxEmails) {
+      pendingActionsQueue.enqueue("archive", email.id, accountId);
+    }
+    return { success: true, queued: true };
+  }
+
+  try {
+    const client = activeClients.get(accountId);
+    if (!client) {
+      for (const email of inboxEmails) {
+        pendingActionsQueue.enqueue("archive", email.id, accountId);
+      }
+      return { success: true, queued: true };
+    }
+
+    const archivedIds: string[] = [];
+    const failedIds: string[] = [];
+    let anyQueued = false;
+    for (let i = 0; i < inboxEmails.length; i++) {
+      const email = inboxEmails[i];
+      try {
+        await client.archiveMessage(email.id);
+        archivedIds.push(email.id);
+      } catch (err) {
+        if (isNetworkError(err)) {
+          // Queue this and all remaining emails, then mark offline
+          for (let j = i; j < inboxEmails.length; j++) {
+            pendingActionsQueue.enqueue("archive", inboxEmails[j].id, accountId);
+          }
+          anyQueued = true;
+          networkMonitor.setOffline();
+          break;
+        } else {
+          // Permanent failure for this email — restore its INBOX label
+          const prev = previousLabelsMap.get(email.id) || [];
+          updateEmailLabelIds(email.id, prev);
+          failedIds.push(email.id);
+        }
+      }
+    }
+
+    // Clean up agent traces for archived thread emails
+    for (const email of threadEmails) {
+      if (email.draft?.agentTaskId) {
+        try {
+          deleteAgentTrace(email.draft.agentTaskId);
+        } catch {
+          /* non-critical */
+        }
+      }
+    }
+
+    // Notify renderer: remove entire thread (including SENT) so no ghost threads remain
+    if (archivedIds.length > 0) {
+      const allThreadEmailIds = threadEmails.map((e) => e.id);
+      const window = getMainWindow();
+      if (window) {
+        window.webContents.send("sync:emails-removed", {
+          accountId,
+          emailIds: allThreadEmailIds,
+        });
+      }
+    }
+
+    return { success: true, queued: anyQueued, failedIds, archivedIds };
+  } catch (error) {
+    // Restore all labels on catastrophic failure
+    for (const [emailId, labels] of previousLabelsMap) {
+      updateEmailLabelIds(emailId, labels);
+    }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
 export function registerSyncIpc(): void {
   // When going online, reconnect failed accounts THEN process queues
   networkMonitor.on("online", async () => {
@@ -1211,102 +1324,8 @@ export function registerSyncIpc(): void {
   ipcMain.handle(
     "emails:archive-thread",
     async (_, { accountId, threadId }: { accountId: string; threadId: string }) => {
-      const threadEmails = getEmailsByThread(threadId, accountId);
-      // Treat emails with no labelIds (NULL in DB) as inbox emails,
-      // matching the getInboxEmails query: WHERE label_ids IS NULL OR label_ids LIKE '%"INBOX"%'
-      const inboxEmails = threadEmails.filter((e) => !e.labelIds || e.labelIds.includes("INBOX"));
-
-      // Optimistically update DB for all inbox emails
-      const previousLabelsMap = new Map<string, string[]>();
-      for (const email of inboxEmails) {
-        previousLabelsMap.set(email.id, email.labelIds || []);
-        updateEmailLabelIds(
-          email.id,
-          (email.labelIds || []).filter((l: string) => l !== "INBOX"),
-        );
-      }
-
-      if (useFakeData) {
-        return { success: true, data: undefined };
-      }
-
-      // If offline, queue each email for later — DB already updated
-      if (!networkMonitor.isOnline) {
-        for (const email of inboxEmails) {
-          pendingActionsQueue.enqueue("archive", email.id, accountId);
-        }
-        return { success: true, data: undefined, queued: true };
-      }
-
-      try {
-        const client = activeClients.get(accountId);
-        if (!client) {
-          for (const email of inboxEmails) {
-            pendingActionsQueue.enqueue("archive", email.id, accountId);
-          }
-          return { success: true, data: undefined, queued: true };
-        }
-
-        const archivedIds: string[] = [];
-        const failedIds: string[] = [];
-        let anyQueued = false;
-        for (let i = 0; i < inboxEmails.length; i++) {
-          const email = inboxEmails[i];
-          try {
-            await client.archiveMessage(email.id);
-            archivedIds.push(email.id);
-          } catch (err) {
-            if (isNetworkError(err)) {
-              // Queue this and all remaining emails, then mark offline
-              for (let j = i; j < inboxEmails.length; j++) {
-                pendingActionsQueue.enqueue("archive", inboxEmails[j].id, accountId);
-              }
-              anyQueued = true;
-              networkMonitor.setOffline();
-              break;
-            } else {
-              // Permanent failure for this email — restore its INBOX label
-              const prev = previousLabelsMap.get(email.id) || [];
-              updateEmailLabelIds(email.id, prev);
-              failedIds.push(email.id);
-            }
-          }
-        }
-
-        // Clean up agent traces for archived thread emails
-        for (const email of threadEmails) {
-          if (email.draft?.agentTaskId) {
-            try {
-              deleteAgentTrace(email.draft.agentTaskId);
-            } catch {
-              /* non-critical */
-            }
-          }
-        }
-
-        // Notify renderer: remove entire thread (including SENT) so no ghost threads remain
-        if (archivedIds.length > 0) {
-          const allThreadEmailIds = threadEmails.map((e) => e.id);
-          const window = getMainWindow();
-          if (window) {
-            window.webContents.send("sync:emails-removed", {
-              accountId,
-              emailIds: allThreadEmailIds,
-            });
-          }
-        }
-
-        return { success: true, data: undefined, queued: anyQueued, failedIds, archivedIds };
-      } catch (error) {
-        // Restore all labels on catastrophic failure
-        for (const [emailId, labels] of previousLabelsMap) {
-          updateEmailLabelIds(emailId, labels);
-        }
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
-        };
-      }
+      const result = await archiveThreadInternal(accountId, threadId);
+      return { ...result, data: undefined };
     },
   );
 

--- a/src/main/services/gmail-client.ts
+++ b/src/main/services/gmail-client.ts
@@ -1152,25 +1152,32 @@ export class GmailClient {
   /**
    * Send a new email message
    */
-  async sendMessage(options: SendMessageOptions): Promise<{ id: string; threadId: string }> {
+  async sendMessage(
+    options: SendMessageOptions,
+    requestOptions: { signal?: AbortSignal } = {},
+  ): Promise<{ id: string; threadId: string }> {
     const gmail = this.gmail!;
 
     // Get sender address with display name if not explicitly provided
-    const profile = await this.getProfile();
+    const profile = await this.getProfile(requestOptions);
     const from = options.from || this.getSenderAddress(profile.emailAddress);
 
     const raw = await this.buildMimeMessage({
       ...options,
       from,
     });
+    requestOptions.signal?.throwIfAborted();
 
-    const response = await gmail.users.messages.send({
-      userId: "me",
-      requestBody: {
-        raw,
-        threadId: options.threadId,
+    const response = await gmail.users.messages.send(
+      {
+        userId: "me",
+        requestBody: {
+          raw,
+          threadId: options.threadId,
+        },
       },
-    });
+      requestOptions,
+    );
 
     return {
       id: response.data.id!,
@@ -1513,9 +1520,11 @@ export class GmailClient {
   }
 
   // Get user profile (email address, etc.)
-  async getProfile(): Promise<{ emailAddress: string; messagesTotal: number; historyId: string }> {
+  async getProfile(
+    requestOptions: { signal?: AbortSignal } = {},
+  ): Promise<{ emailAddress: string; messagesTotal: number; historyId: string }> {
     const gmail = this.gmail!;
-    const response = await gmail.users.getProfile({ userId: "me" });
+    const response = await gmail.users.getProfile({ userId: "me" }, requestOptions);
 
     // Store historyId for incremental sync
     this.lastHistoryId = response.data.historyId || null;

--- a/src/main/services/network-monitor.ts
+++ b/src/main/services/network-monitor.ts
@@ -1,8 +1,14 @@
 import { EventEmitter } from "events";
-import { net, powerMonitor } from "electron";
+import { createRequire } from "module";
+import type * as Electron from "electron";
 import { createLogger } from "./logger";
 
 const log = createLogger("network");
+const requireFromHere = createRequire(import.meta.url);
+
+function getElectron(): typeof Electron {
+  return requireFromHere("electron") as typeof Electron;
+}
 
 type NetworkEvent = "online" | "offline";
 
@@ -16,6 +22,7 @@ class NetworkMonitor extends EventEmitter {
    */
   init(): void {
     if (this.initialized) return;
+    const { net, powerMonitor } = getElectron();
 
     // Get initial state from Electron's net module
     this._isOnline = net.isOnline();
@@ -82,6 +89,7 @@ class NetworkMonitor extends EventEmitter {
    * Check and update online status (can be called to verify state)
    */
   checkStatus(): boolean {
+    const { net } = getElectron();
     const current = net.isOnline();
     if (current !== this._isOnline) {
       const wasOnline = this._isOnline;

--- a/src/main/services/scheduled-send-service.ts
+++ b/src/main/services/scheduled-send-service.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from "events";
 import {
   getDueScheduledMessages,
+  getNextScheduledMessageTime,
+  getScheduledMessages,
+  claimScheduledMessage,
   updateScheduledMessageStatus,
   getScheduledMessageStats,
   type ScheduledMessageRow,
@@ -10,15 +13,22 @@ import { createLogger } from "./logger";
 
 const log = createLogger("scheduled-send");
 
-// Check interval: 30 seconds
-const CHECK_INTERVAL = 30_000;
+// Upper bound on a single sleep. Long-horizon items (send-later days out) re-arm
+// at least this often so clock changes and suspend/resume can't strand them.
+const MAX_SLEEP = 30_000;
+
+// Cap on how long a quit may be delayed while flushing pending sends. Anything
+// unsent stays 'scheduled' and is recovered by recoverOnStartup() next launch.
+const QUIT_FLUSH_TIMEOUT = 5_000;
 
 type ScheduledSendEvent = "sending" | "sent" | "failed" | "statsChanged";
 
 class ScheduledSendService extends EventEmitter {
   private clientResolver?: (accountId: string) => GmailClient | null;
-  private timer: ReturnType<typeof setInterval> | null = null;
+  private threadArchiver?: (threadId: string, accountId: string) => Promise<void>;
+  private timer: ReturnType<typeof setTimeout> | null = null;
   private processing = false;
+  private started = false;
 
   /**
    * Set the function to resolve GmailClient for an account ID.
@@ -29,24 +39,50 @@ class ScheduledSendService extends EventEmitter {
   }
 
   /**
-   * Start the background timer that checks for due messages.
+   * Set the thread-archive implementation (used by send-and-archive).
+   * Injected rather than called directly because archiving also updates local
+   * label state and queues offline actions, which lives in the IPC layer.
    */
-  start(): void {
-    if (this.timer) return;
-    log.info("[ScheduledSend] Starting background check (30s interval)");
-    this.timer = setInterval(() => this.processDueMessages(), CHECK_INTERVAL);
-    // Also check immediately on start
-    this.processDueMessages();
+  setThreadArchiver(archiver: (threadId: string, accountId: string) => Promise<void>): void {
+    this.threadArchiver = archiver;
   }
 
   /**
-   * Stop the background timer.
+   * Start scheduling. Any row already past due fires immediately; the rest arm a
+   * precise timer.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    log.info("[ScheduledSend] Starting scheduler");
+    void this.processDueMessages();
+  }
+
+  /**
+   * Recover after an unclean shutdown. Same work as start() — past-due rows fire
+   * now, future rows re-arm — but named for the call site in main/index.ts so the
+   * crash/force-kill recovery path is obvious at a glance.
+   */
+  recoverOnStartup(): void {
+    const pending = getScheduledMessages();
+    if (pending.length > 0) {
+      const overdue = pending.filter((r) => r.scheduledAt <= Date.now()).length;
+      log.info(
+        `[ScheduledSend] Recovering ${pending.length} pending message(s), ${overdue} already due`,
+      );
+    }
+    this.start();
+  }
+
+  /**
+   * Stop scheduling and clear the pending timer.
    */
   stop(): void {
+    this.started = false;
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
-      log.info("[ScheduledSend] Stopped background check");
+      log.info("[ScheduledSend] Stopped scheduler");
     }
   }
 
@@ -58,7 +94,33 @@ class ScheduledSendService extends EventEmitter {
   }
 
   /**
-   * Process all due messages (scheduled_at <= now).
+   * Re-arm the timer. Called after any insert/cancel/reschedule so a newly queued
+   * short delay (a 15s undo) isn't left waiting behind an existing longer sleep.
+   */
+  reschedule(): void {
+    if (!this.started) return;
+    this.armTimer();
+  }
+
+  private armTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (!this.started) return;
+
+    const next = getNextScheduledMessageTime();
+    if (next === null) return;
+
+    const delay = Math.min(Math.max(next - Date.now(), 0), MAX_SLEEP);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.processDueMessages();
+    }, delay);
+  }
+
+  /**
+   * Process all due messages (scheduled_at <= now), then re-arm for the next one.
    */
   async processDueMessages(): Promise<void> {
     if (this.processing) return;
@@ -66,36 +128,62 @@ class ScheduledSendService extends EventEmitter {
 
     try {
       const due = getDueScheduledMessages(10);
-      if (due.length === 0) return;
-
-      log.info(`[ScheduledSend] ${due.length} message(s) due for sending`);
-
-      for (const item of due) {
-        await this.sendMessage(item);
+      if (due.length > 0) {
+        log.info(`[ScheduledSend] ${due.length} message(s) due for sending`);
+        for (const item of due) {
+          await this.sendMessage(item);
+        }
       }
     } catch (error) {
       log.error({ err: error }, "[ScheduledSend] Error processing due messages");
     } finally {
       this.processing = false;
+      this.armTimer();
     }
+  }
+
+  /**
+   * Send every pending message immediately regardless of remaining delay.
+   * Used on quit so an in-flight undo delay isn't silently dropped.
+   */
+  async flushPendingNow(): Promise<void> {
+    const pending = getScheduledMessages();
+    if (pending.length === 0) return;
+
+    log.info(`[ScheduledSend] Flushing ${pending.length} pending message(s) before quit`);
+    const flush = (async () => {
+      for (const item of pending) {
+        await this.sendMessage(item);
+      }
+    })();
+
+    // Never block quit indefinitely — survivors are recovered on next launch.
+    await Promise.race([
+      flush,
+      new Promise<void>((resolve) => setTimeout(resolve, QUIT_FLUSH_TIMEOUT)),
+    ]);
   }
 
   /**
    * Send a single scheduled message via Gmail API.
    */
   private async sendMessage(item: ScheduledMessageRow): Promise<void> {
+    // Claim before doing any work: this is what makes cancel-vs-fire safe. The
+    // conditional UPDATE is indivisible, so if the user hit Undo first the row is
+    // already 'cancelled', we get null here, and no message goes out.
+    const claimed = claimScheduledMessage(item.id, "sending");
+    if (!claimed) return;
+
     const client = this.clientResolver?.(item.accountId);
     if (!client) {
       log.error(`[ScheduledSend] No client for account ${item.accountId}`);
       updateScheduledMessageStatus(item.id, "failed", "Account not connected");
-      this.emit("failed", { id: item.id, error: "Account not connected" });
+      this.emit("failed", { id: item.id, kind: item.kind, error: "Account not connected" });
       this.emit("statsChanged", this.getStats());
       return;
     }
 
-    // Mark as sending
-    updateScheduledMessageStatus(item.id, "sending");
-    this.emit("sending", { id: item.id });
+    this.emit("sending", { id: item.id, kind: item.kind });
 
     try {
       const result = await client.sendMessage({
@@ -109,17 +197,39 @@ class ScheduledSendService extends EventEmitter {
         threadId: item.threadId,
         inReplyTo: item.inReplyTo,
         references: item.references,
+        attachments: item.attachments,
       });
 
       updateScheduledMessageStatus(item.id, "sent");
       log.info(`[ScheduledSend] Sent message ${item.id}, Gmail ID: ${result.id}`);
-      this.emit("sent", { id: item.id, gmailId: result.id, threadId: result.threadId });
+
+      if (item.archiveThreadId && this.threadArchiver) {
+        try {
+          await this.threadArchiver(item.archiveThreadId, item.accountId);
+        } catch (archiveError) {
+          // Best-effort: the send already succeeded, so a failed archive must not
+          // turn this into a failed send.
+          log.warn(
+            { err: archiveError },
+            `[ScheduledSend] Failed to archive thread after sending ${item.id}`,
+          );
+        }
+      }
+
+      this.emit("sent", {
+        id: item.id,
+        kind: item.kind,
+        gmailId: result.id,
+        threadId: result.threadId,
+        composeContext: item.composeContext,
+        archiveThreadId: item.archiveThreadId,
+      });
       this.emit("statsChanged", this.getStats());
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Send failed";
       updateScheduledMessageStatus(item.id, "failed", errorMessage);
       log.error(`[ScheduledSend] Failed to send ${item.id}: ${errorMessage}`);
-      this.emit("failed", { id: item.id, error: errorMessage });
+      this.emit("failed", { id: item.id, kind: item.kind, error: errorMessage });
       this.emit("statsChanged", this.getStats());
     }
   }

--- a/src/main/services/scheduled-send-service.ts
+++ b/src/main/services/scheduled-send-service.ts
@@ -60,7 +60,7 @@ class ScheduledSendService extends EventEmitter {
 
   /**
    * Recover after an unclean shutdown. Same work as start() — past-due rows fire
-   * now, future rows re-arm — but named for the call site in main/index.ts so the
+   * now, future rows re-arm — but named for the post-sync startup call so the
    * crash/force-kill recovery path is obvious at a glance.
    */
   recoverOnStartup(): void {
@@ -71,7 +71,11 @@ class ScheduledSendService extends EventEmitter {
         `[ScheduledSend] Recovering ${pending.length} pending message(s), ${overdue} already due`,
       );
     }
-    this.start();
+    if (this.started) {
+      void this.processDueMessages();
+    } else {
+      this.start();
+    }
   }
 
   /**
@@ -143,11 +147,11 @@ class ScheduledSendService extends EventEmitter {
   }
 
   /**
-   * Send every pending message immediately regardless of remaining delay.
-   * Used on quit so an in-flight undo delay isn't silently dropped.
+   * Send every pending undo-send immediately regardless of remaining delay.
+   * User-chosen send-later rows must retain their due time across app quits.
    */
   async flushPendingNow(): Promise<void> {
-    const pending = getScheduledMessages();
+    const pending = getScheduledMessages(undefined, "undo");
     if (pending.length === 0) return;
 
     log.info(`[ScheduledSend] Flushing ${pending.length} pending message(s) before quit`);
@@ -178,7 +182,13 @@ class ScheduledSendService extends EventEmitter {
     if (!client) {
       log.error(`[ScheduledSend] No client for account ${item.accountId}`);
       updateScheduledMessageStatus(item.id, "failed", "Account not connected");
-      this.emit("failed", { id: item.id, kind: item.kind, error: "Account not connected" });
+      this.emit("failed", {
+        id: item.id,
+        kind: item.kind,
+        accountId: item.accountId,
+        composeContext: item.composeContext,
+        error: "Account not connected",
+      });
       this.emit("statsChanged", this.getStats());
       return;
     }
@@ -219,6 +229,7 @@ class ScheduledSendService extends EventEmitter {
       this.emit("sent", {
         id: item.id,
         kind: item.kind,
+        accountId: item.accountId,
         gmailId: result.id,
         threadId: result.threadId,
         composeContext: item.composeContext,
@@ -229,7 +240,13 @@ class ScheduledSendService extends EventEmitter {
       const errorMessage = error instanceof Error ? error.message : "Send failed";
       updateScheduledMessageStatus(item.id, "failed", errorMessage);
       log.error(`[ScheduledSend] Failed to send ${item.id}: ${errorMessage}`);
-      this.emit("failed", { id: item.id, kind: item.kind, error: errorMessage });
+      this.emit("failed", {
+        id: item.id,
+        kind: item.kind,
+        accountId: item.accountId,
+        composeContext: item.composeContext,
+        error: errorMessage,
+      });
       this.emit("statsChanged", this.getStats());
     }
   }

--- a/src/main/services/scheduled-send-service.ts
+++ b/src/main/services/scheduled-send-service.ts
@@ -10,6 +10,8 @@ import {
 } from "../db";
 import type { GmailClient } from "./gmail-client";
 import { createLogger } from "./logger";
+import { isNetworkError } from "./network-errors";
+import { networkMonitor } from "./network-monitor";
 
 const log = createLogger("scheduled-send");
 
@@ -17,18 +19,60 @@ const log = createLogger("scheduled-send");
 // at least this often so clock changes and suspend/resume can't strand them.
 const MAX_SLEEP = 30_000;
 
-// Cap on how long a quit may be delayed while flushing pending sends. Anything
-// unsent stays 'scheduled' and is recovered by recoverOnStartup() next launch.
+// Grace period for active sends during quit. Once it expires, their HTTP
+// requests are aborted and the rows are put back into 'scheduled' before the DB
+// is closed, so startup recovery can retry them safely.
 const QUIT_FLUSH_TIMEOUT = 5_000;
+
+// A connected account can briefly have no client while sync/re-authentication
+// is rebuilding it. Keep the message pending without hot-looping the scheduler.
+const CLIENT_RETRY_DELAY = 30_000;
+
+type SendOutcome = "completed" | "deferred" | "offline";
+
+export type ScheduledSendDependencies = {
+  getDueScheduledMessages: typeof getDueScheduledMessages;
+  getNextScheduledMessageTime: typeof getNextScheduledMessageTime;
+  getScheduledMessages: typeof getScheduledMessages;
+  claimScheduledMessage: typeof claimScheduledMessage;
+  updateScheduledMessageStatus: typeof updateScheduledMessageStatus;
+  getScheduledMessageStats: typeof getScheduledMessageStats;
+  network: Pick<typeof networkMonitor, "isOnline" | "setOffline">;
+  isNetworkError: typeof isNetworkError;
+  now: () => number;
+  quitFlushTimeout: number;
+};
+
+const defaultDependencies: ScheduledSendDependencies = {
+  getDueScheduledMessages,
+  getNextScheduledMessageTime,
+  getScheduledMessages,
+  claimScheduledMessage,
+  updateScheduledMessageStatus,
+  getScheduledMessageStats,
+  network: networkMonitor,
+  isNetworkError,
+  now: Date.now,
+  quitFlushTimeout: QUIT_FLUSH_TIMEOUT,
+};
 
 type ScheduledSendEvent = "sending" | "sent" | "failed" | "statsChanged";
 
-class ScheduledSendService extends EventEmitter {
+export class ScheduledSendService extends EventEmitter {
   private clientResolver?: (accountId: string) => GmailClient | null;
   private threadArchiver?: (threadId: string, accountId: string) => Promise<void>;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private processing = false;
   private started = false;
+  private drainingForQuit = false;
+  private retryNotBefore = 0;
+  private readonly activeSends = new Map<Promise<SendOutcome>, AbortController>();
+  private readonly dependencies: ScheduledSendDependencies;
+
+  constructor(dependencies: Partial<ScheduledSendDependencies> = {}) {
+    super();
+    this.dependencies = { ...defaultDependencies, ...dependencies };
+  }
 
   /**
    * Set the function to resolve GmailClient for an account ID.
@@ -64,7 +108,8 @@ class ScheduledSendService extends EventEmitter {
    * crash/force-kill recovery path is obvious at a glance.
    */
   recoverOnStartup(): void {
-    const pending = getScheduledMessages();
+    this.retryNotBefore = 0;
+    const pending = this.dependencies.getScheduledMessages();
     if (pending.length > 0) {
       const overdue = pending.filter((r) => r.scheduledAt <= Date.now()).length;
       log.info(
@@ -94,7 +139,7 @@ class ScheduledSendService extends EventEmitter {
    * Get stats for scheduled messages.
    */
   getStats(accountId?: string) {
-    return getScheduledMessageStats(accountId);
+    return this.dependencies.getScheduledMessageStats(accountId);
   }
 
   /**
@@ -103,6 +148,7 @@ class ScheduledSendService extends EventEmitter {
    */
   reschedule(): void {
     if (!this.started) return;
+    this.retryNotBefore = 0;
     this.armTimer();
   }
 
@@ -111,12 +157,13 @@ class ScheduledSendService extends EventEmitter {
       clearTimeout(this.timer);
       this.timer = null;
     }
-    if (!this.started) return;
+    if (!this.started || this.drainingForQuit || !this.dependencies.network.isOnline) return;
 
-    const next = getNextScheduledMessageTime();
+    const next = this.dependencies.getNextScheduledMessageTime();
     if (next === null) return;
 
-    const delay = Math.min(Math.max(next - Date.now(), 0), MAX_SLEEP);
+    const wakeAt = Math.max(next, this.retryNotBefore);
+    const delay = Math.min(Math.max(wakeAt - this.dependencies.now(), 0), MAX_SLEEP);
     this.timer = setTimeout(() => {
       this.timer = null;
       void this.processDueMessages();
@@ -127,15 +174,17 @@ class ScheduledSendService extends EventEmitter {
    * Process all due messages (scheduled_at <= now), then re-arm for the next one.
    */
   async processDueMessages(): Promise<void> {
-    if (this.processing) return;
+    if (this.processing || this.drainingForQuit || !this.dependencies.network.isOnline) return;
     this.processing = true;
 
     try {
-      const due = getDueScheduledMessages(10);
+      const due = this.dependencies.getDueScheduledMessages(10);
       if (due.length > 0) {
         log.info(`[ScheduledSend] ${due.length} message(s) due for sending`);
         for (const item of due) {
-          await this.sendMessage(item);
+          if (this.drainingForQuit) break;
+          const outcome = await this.sendTracked(item);
+          if (outcome === "offline") break;
         }
       }
     } catch (error) {
@@ -151,66 +200,94 @@ class ScheduledSendService extends EventEmitter {
    * User-chosen send-later rows must retain their due time across app quits.
    */
   async flushPendingNow(): Promise<void> {
-    const pending = getScheduledMessages(undefined, "undo");
-    if (pending.length === 0) return;
+    this.drainingForQuit = true;
+    this.stop();
 
-    log.info(`[ScheduledSend] Flushing ${pending.length} pending message(s) before quit`);
-    const flush = (async () => {
-      for (const item of pending) {
-        await this.sendMessage(item);
+    const pending = this.dependencies.getScheduledMessages(undefined, "undo");
+    if (pending.length > 0) {
+      log.info(`[ScheduledSend] Flushing ${pending.length} pending message(s) before quit`);
+    }
+
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      if (this.activeSends.size > 0) {
+        log.warn(`[ScheduledSend] Aborting ${this.activeSends.size} in-flight send(s) before quit`);
       }
-    })();
+      for (const controller of this.activeSends.values()) controller.abort();
+    }, this.dependencies.quitFlushTimeout);
 
-    // Never block quit indefinitely — survivors are recovered on next launch.
-    await Promise.race([
-      flush,
-      new Promise<void>((resolve) => setTimeout(resolve, QUIT_FLUSH_TIMEOUT)),
-    ]);
+    try {
+      for (const item of pending) {
+        if (timedOut) break;
+        await this.sendTracked(item);
+      }
+
+      // processDueMessages() may already have claimed a row when quit begins.
+      // Wait for every such request to finish or observe the abort before the
+      // caller closes SQLite.
+      while (this.activeSends.size > 0) {
+        await Promise.allSettled([...this.activeSends.keys()]);
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private sendTracked(item: ScheduledMessageRow): Promise<SendOutcome> {
+    const controller = new AbortController();
+    const send = this.sendMessage(item, controller.signal);
+    this.activeSends.set(send, controller);
+    void send.then(
+      () => this.activeSends.delete(send),
+      () => this.activeSends.delete(send),
+    );
+    return send;
   }
 
   /**
    * Send a single scheduled message via Gmail API.
    */
-  private async sendMessage(item: ScheduledMessageRow): Promise<void> {
-    // Claim before doing any work: this is what makes cancel-vs-fire safe. The
-    // conditional UPDATE is indivisible, so if the user hit Undo first the row is
-    // already 'cancelled', we get null here, and no message goes out.
-    const claimed = claimScheduledMessage(item.id, "sending");
-    if (!claimed) return;
+  private async sendMessage(item: ScheduledMessageRow, signal: AbortSignal): Promise<SendOutcome> {
+    if (!this.dependencies.network.isOnline) return "offline";
 
     const client = this.clientResolver?.(item.accountId);
     if (!client) {
-      log.error(`[ScheduledSend] No client for account ${item.accountId}`);
-      updateScheduledMessageStatus(item.id, "failed", "Account not connected");
-      this.emit("failed", {
-        id: item.id,
-        kind: item.kind,
-        accountId: item.accountId,
-        composeContext: item.composeContext,
-        error: "Account not connected",
-      });
-      this.emit("statsChanged", this.getStats());
-      return;
+      log.warn(`[ScheduledSend] Client unavailable for account ${item.accountId}; will retry`);
+      this.retryNotBefore = Math.max(
+        this.retryNotBefore,
+        this.dependencies.now() + CLIENT_RETRY_DELAY,
+      );
+      return "deferred";
     }
+
+    // Claim before doing any work: this is what makes cancel-vs-fire safe. The
+    // conditional UPDATE is indivisible, so if the user hit Undo first the row is
+    // already 'cancelled', we get null here, and no message goes out.
+    const claimed = this.dependencies.claimScheduledMessage(item.id, "sending");
+    if (!claimed) return "completed";
 
     this.emit("sending", { id: item.id, kind: item.kind });
 
     try {
-      const result = await client.sendMessage({
-        from: item.from,
-        to: item.to,
-        cc: item.cc,
-        bcc: item.bcc,
-        subject: item.subject,
-        bodyHtml: item.bodyHtml,
-        bodyText: item.bodyText,
-        threadId: item.threadId,
-        inReplyTo: item.inReplyTo,
-        references: item.references,
-        attachments: item.attachments,
-      });
+      const result = await client.sendMessage(
+        {
+          from: item.from,
+          to: item.to,
+          cc: item.cc,
+          bcc: item.bcc,
+          subject: item.subject,
+          bodyHtml: item.bodyHtml,
+          bodyText: item.bodyText,
+          threadId: item.threadId,
+          inReplyTo: item.inReplyTo,
+          references: item.references,
+          attachments: item.attachments,
+        },
+        { signal },
+      );
 
-      updateScheduledMessageStatus(item.id, "sent");
+      this.dependencies.updateScheduledMessageStatus(item.id, "sent");
       log.info(`[ScheduledSend] Sent message ${item.id}, Gmail ID: ${result.id}`);
 
       if (item.archiveThreadId && this.threadArchiver) {
@@ -236,9 +313,22 @@ class ScheduledSendService extends EventEmitter {
         archiveThreadId: item.archiveThreadId,
       });
       this.emit("statsChanged", this.getStats());
+      return "completed";
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Send failed";
-      updateScheduledMessageStatus(item.id, "failed", errorMessage);
+      if (signal.aborted || this.dependencies.isNetworkError(error)) {
+        this.dependencies.updateScheduledMessageStatus(item.id, "scheduled", errorMessage);
+        if (!signal.aborted) {
+          log.info(`[ScheduledSend] Network error sending ${item.id}; will retry when online`);
+          this.dependencies.network.setOffline();
+        } else {
+          log.info(`[ScheduledSend] Send ${item.id} aborted during quit; left scheduled`);
+        }
+        this.emit("statsChanged", this.getStats());
+        return signal.aborted ? "deferred" : "offline";
+      }
+
+      this.dependencies.updateScheduledMessageStatus(item.id, "failed", errorMessage);
       log.error(`[ScheduledSend] Failed to send ${item.id}: ${errorMessage}`);
       this.emit("failed", {
         id: item.id,
@@ -248,6 +338,7 @@ class ScheduledSendService extends EventEmitter {
         error: errorMessage,
       });
       this.emit("statsChanged", this.getStats());
+      return "completed";
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -819,10 +819,21 @@ const api = {
       references?: string;
       scheduledAt: number;
       recipientNames?: Record<string, string>;
+      attachments?: Array<{
+        filename: string;
+        mimeType: string;
+        path?: string;
+        content?: string;
+        size?: number;
+      }>;
+      // 'undo' marks the short undo-send delay; omitted means user send-later.
+      kind?: "scheduled" | "undo";
+      archiveThreadId?: string;
+      composeContext?: string;
     }): Promise<unknown> => ipcRenderer.invoke("scheduled-send:create", options),
 
-    list: (accountId?: string): Promise<unknown> =>
-      ipcRenderer.invoke("scheduled-send:list", { accountId }),
+    list: (accountId?: string, kind?: "scheduled" | "undo"): Promise<unknown> =>
+      ipcRenderer.invoke("scheduled-send:list", { accountId, kind }),
 
     cancel: (id: string): Promise<unknown> => ipcRenderer.invoke("scheduled-send:cancel", { id }),
 
@@ -835,12 +846,28 @@ const api = {
       ipcRenderer.invoke("scheduled-send:stats", { accountId }),
 
     onSent: (
-      callback: (data: { id: string; gmailId?: string; threadId?: string }) => void,
+      callback: (data: {
+        id: string;
+        kind?: "scheduled" | "undo";
+        gmailId?: string;
+        threadId?: string;
+        composeContext?: string;
+        archiveThreadId?: string;
+      }) => void,
     ): void => {
       ipcRenderer.on(
         "scheduled-send:sent",
-        (_: Electron.IpcRendererEvent, data: { id: string; gmailId?: string; threadId?: string }) =>
-          callback(data),
+        (
+          _: Electron.IpcRendererEvent,
+          data: {
+            id: string;
+            kind?: "scheduled" | "undo";
+            gmailId?: string;
+            threadId?: string;
+            composeContext?: string;
+            archiveThreadId?: string;
+          },
+        ) => callback(data),
       );
     },
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -849,6 +849,7 @@ const api = {
       callback: (data: {
         id: string;
         kind?: "scheduled" | "undo";
+        accountId?: string;
         gmailId?: string;
         threadId?: string;
         composeContext?: string;
@@ -862,6 +863,7 @@ const api = {
           data: {
             id: string;
             kind?: "scheduled" | "undo";
+            accountId?: string;
             gmailId?: string;
             threadId?: string;
             composeContext?: string;
@@ -871,10 +873,27 @@ const api = {
       );
     },
 
-    onFailed: (callback: (data: { id: string; error: string }) => void): void => {
+    onFailed: (
+      callback: (data: {
+        id: string;
+        kind?: "scheduled" | "undo";
+        accountId?: string;
+        composeContext?: string;
+        error: string;
+      }) => void,
+    ): void => {
       ipcRenderer.on(
         "scheduled-send:failed",
-        (_: Electron.IpcRendererEvent, data: { id: string; error: string }) => callback(data),
+        (
+          _: Electron.IpcRendererEvent,
+          data: {
+            id: string;
+            kind?: "scheduled" | "undo";
+            accountId?: string;
+            composeContext?: string;
+            error: string;
+          },
+        ) => callback(data),
       );
     },
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -58,6 +58,7 @@ import type {
 } from "../shared/types";
 import type { ScopedAgentEvent, AgentProviderConfig } from "../shared/agent-types";
 import { mergeAndThreadSearchResults } from "./utils/searchResults";
+import { parseOptimisticEmailId, parseComposeContext } from "./utils/undo-send-context";
 import type { EmailThread } from "./store";
 
 function decodeHtmlEntities(text: string): string {
@@ -1300,9 +1301,49 @@ export default function App() {
     window.api.scheduledSend.onStatsChanged((stats: { scheduled: number; total: number }) => {
       setScheduledMessageStats(stats);
     });
-    window.api.scheduledSend.onSent((data: { id: string }) => {
-      console.log(`[ScheduledSend] Message sent: ${data.id}`);
-    });
+    window.api.scheduledSend.onSent(
+      (data: {
+        id: string;
+        kind?: "scheduled" | "undo";
+        gmailId?: string;
+        composeContext?: string;
+      }) => {
+        console.log(`[ScheduledSend] Message sent: ${data.id}`);
+        if (data.kind !== "undo") return;
+
+        const store = useAppStore.getState();
+        store.removeUndoSend(data.id);
+
+        // Replace the optimistic "pending-*" email with the real Gmail ID so
+        // background sync won't add a duplicate when it discovers the same
+        // message. Done as a single atomic setState to prevent intermediate
+        // states where the email is removed but not yet re-added (which would
+        // unmount any inline reply editor attached to it).
+        const optimisticEmailId = parseOptimisticEmailId(data.composeContext);
+        if (!optimisticEmailId || !data.gmailId) return;
+        const gmailId = data.gmailId;
+
+        const optimistic = store.emails.find((e) => e.id === optimisticEmailId);
+        if (!optimistic) return;
+
+        useAppStore.setState((s) => ({
+          emails: [
+            ...s.emails.filter((e) => e.id !== optimisticEmailId),
+            { ...optimistic, id: gmailId },
+          ],
+          // Update focusedThreadEmailId so subsequent Reply All clicks
+          // don't target the now-removed optimistic email
+          ...(s.focusedThreadEmailId === optimisticEmailId
+            ? { focusedThreadEmailId: gmailId }
+            : {}),
+          // Update inlineReplyToEmailId so the InlineReply component doesn't
+          // unmount when the optimistic email it's targeting gets replaced
+          ...(s.inlineReplyToEmailId === optimisticEmailId
+            ? { inlineReplyToEmailId: gmailId }
+            : {}),
+        }));
+      },
+    );
     window.api.scheduledSend.onFailed((data: { id: string; error: string }) => {
       console.log(`[ScheduledSend] Message failed: ${data.id} - ${data.error}`);
       setError(`Scheduled message failed: ${data.error}`);
@@ -1429,6 +1470,40 @@ export default function App() {
       }
     });
 
+    // Rebuild undo-send toasts for sends still inside their delay. The window may
+    // have been closed and reopened while main kept counting down, so the queue
+    // is restored from main rather than assumed empty.
+    window.api.scheduledSend
+      .list(undefined, "undo")
+      .then((result: IpcResponse<ScheduledMessage[]>) => {
+        if (!result.success || !result.data) return;
+        const store = useAppStore.getState();
+        for (const msg of result.data) {
+          const context = parseComposeContext(msg.composeContext);
+          store.addUndoSend({
+            id: msg.id,
+            sendOptions: {
+              accountId: msg.accountId,
+              to: msg.to,
+              cc: msg.cc,
+              bcc: msg.bcc,
+              subject: msg.subject,
+              bodyHtml: msg.bodyHtml,
+              bodyText: msg.bodyText,
+              threadId: msg.threadId,
+              inReplyTo: msg.inReplyTo,
+              references: msg.references,
+            },
+            recipients: msg.to.join(", "),
+            // createdAt is when the delay started; scheduledAt is when it fires.
+            scheduledAt: msg.createdAt,
+            delayMs: msg.scheduledAt - msg.createdAt,
+            archiveThreadId: msg.archiveThreadId,
+            composeContext: context,
+          });
+        }
+      });
+
     // Relay navigator.onLine events to main process
     const handleOnline = () => {
       window.api.network.updateStatus(true);
@@ -1500,7 +1575,12 @@ export default function App() {
 
   // Fetch scheduled messages list for the dropdown
   const fetchScheduledMessages = useCallback(async () => {
-    const result = (await window.api.scheduledSend.list(currentAccountId ?? undefined)) as {
+    // Scope to 'scheduled': undo-send rows share this table but belong to the
+    // toast, not the send-later dropdown.
+    const result = (await window.api.scheduledSend.list(
+      currentAccountId ?? undefined,
+      "scheduled",
+    )) as {
       success: boolean;
       data?: ScheduledMessage[];
     };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1305,14 +1305,39 @@ export default function App() {
       (data: {
         id: string;
         kind?: "scheduled" | "undo";
+        accountId?: string;
         gmailId?: string;
         composeContext?: string;
+        archiveThreadId?: string;
       }) => {
         console.log(`[ScheduledSend] Message sent: ${data.id}`);
         if (data.kind !== "undo") return;
 
         const store = useAppStore.getState();
+        const queuedUndo = store.undoSendQueue.find((item) => item.id === data.id);
         store.removeUndoSend(data.id);
+
+        // Main owns the archive operation, but its offline/demo paths do not
+        // broadcast sync:emails-removed. Mirror the immediate-send path's
+        // optimistic removal after the send itself has succeeded.
+        if (data.archiveThreadId) {
+          const accountId = data.accountId ?? queuedUndo?.sendOptions.accountId;
+          if (accountId) {
+            const threadEmailIds = store.emails
+              .filter(
+                (email) => email.threadId === data.archiveThreadId && email.accountId === accountId,
+              )
+              .map((email) => email.id);
+            if (threadEmailIds.length > 0) {
+              if (store.selectedThreadId === data.archiveThreadId) {
+                store.removeEmailsAndAdvance(threadEmailIds, null, null);
+              } else {
+                store.removeEmails(threadEmailIds);
+              }
+            }
+          }
+          return;
+        }
 
         // Replace the optimistic "pending-*" email with the real Gmail ID so
         // background sync won't add a duplicate when it discovers the same
@@ -1344,10 +1369,54 @@ export default function App() {
         }));
       },
     );
-    window.api.scheduledSend.onFailed((data: { id: string; error: string }) => {
-      console.log(`[ScheduledSend] Message failed: ${data.id} - ${data.error}`);
-      setError(`Scheduled message failed: ${data.error}`);
-    });
+    window.api.scheduledSend.onFailed(
+      (data: {
+        id: string;
+        kind?: "scheduled" | "undo";
+        composeContext?: string;
+        error: string;
+      }) => {
+        console.log(`[ScheduledSend] Message failed: ${data.id} - ${data.error}`);
+        if (data.kind !== "undo") {
+          setError(`Scheduled message failed: ${data.error}`);
+          return;
+        }
+
+        const store = useAppStore.getState();
+        const queuedUndo = store.undoSendQueue.find((item) => item.id === data.id);
+        const context = parseComposeContext(data.composeContext) ?? queuedUndo?.composeContext;
+        store.removeUndoSend(data.id);
+
+        if (context?.optimisticEmailId) {
+          const optimisticId = context.optimisticEmailId;
+          useAppStore.setState((state) => ({
+            emails: state.emails.filter((email) => email.id !== optimisticId),
+            ...(state.focusedThreadEmailId === optimisticId ? { focusedThreadEmailId: null } : {}),
+            ...(state.inlineReplyToEmailId === optimisticId ? { inlineReplyToEmailId: null } : {}),
+          }));
+        }
+
+        if (context) {
+          if (context.threadId) store.setSelectedThreadId(context.threadId);
+          if (context.replyToEmailId) store.setSelectedEmailId(context.replyToEmailId);
+          store.setViewMode("full");
+          store.openCompose(context.mode, context.replyToEmailId, {
+            bodyHtml: context.bodyHtml,
+            bodyText: context.bodyText,
+            to: context.to,
+            cc: context.cc,
+            bcc: context.bcc,
+            subject: context.subject,
+          });
+        }
+
+        setError(
+          context
+            ? `Message failed to send: ${data.error}. Your draft has been reopened.`
+            : `Message failed to send: ${data.error}`,
+        );
+      },
+    );
 
     // Cleanup listeners and pending buffer flushes on unmount
     return () => {

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -8,6 +8,7 @@ import {
   stripLargeDataUris,
 } from "../services/email-body-cache";
 import { splitAddressList, extractFirstName } from "../utils/address-parsing";
+import { serializeComposeContext } from "../utils/undo-send-context";
 import { splitQuotedContent } from "../services/quote-elision";
 import { ComposeEditor } from "./ComposeEditor";
 import { formatSnoozeTime } from "./SnoozeMenu";
@@ -1467,25 +1468,44 @@ function InlineReply({
 
     if (undoSendDelaySeconds > 0) {
       const optimisticId = `pending-${Date.now()}`;
+      const delayMs = undoSendDelaySeconds * 1000;
+      const archiveThreadId = shouldArchive ? replyInfo.threadId : undefined;
+      const composeContext = {
+        mode: composeMode,
+        replyToEmailId,
+        threadId: replyInfo.threadId,
+        bodyHtml: form.bodyHtml,
+        bodyText: form.bodyText,
+        to: form.to,
+        cc: form.cc.length > 0 ? form.cc : undefined,
+        bcc: form.bcc.length > 0 ? form.bcc : undefined,
+        subject: replyInfo.subject,
+        optimisticEmailId: optimisticId,
+      };
+
+      // Hand the message to main BEFORE showing the toast. Main owns the timer
+      // and the DB row, so the send survives closing the window mid-delay.
+      const queued = (await window.api.scheduledSend.create({
+        ...sendOptions,
+        scheduledAt: Date.now() + delayMs,
+        kind: "undo",
+        archiveThreadId,
+        composeContext: serializeComposeContext(composeContext),
+      })) as IpcResponse<{ id: string; scheduledAt: number }>;
+
+      if (!queued.success || !queued.data) {
+        form.setError(queued.error || "Failed to send");
+        return;
+      }
+
       addUndoSend({
-        id: crypto.randomUUID(),
+        id: queued.data.id,
         sendOptions,
         recipients: form.to.join(", "),
-        scheduledAt: Date.now(),
-        delayMs: undoSendDelaySeconds * 1000,
-        archiveThreadId: shouldArchive ? replyInfo.threadId : undefined,
-        composeContext: {
-          mode: composeMode,
-          replyToEmailId,
-          threadId: replyInfo.threadId,
-          bodyHtml: form.bodyHtml,
-          bodyText: form.bodyText,
-          to: form.to,
-          cc: form.cc.length > 0 ? form.cc : undefined,
-          bcc: form.bcc.length > 0 ? form.bcc : undefined,
-          subject: replyInfo.subject,
-          optimisticEmailId: optimisticId,
-        },
+        scheduledAt: queued.data.scheduledAt - delayMs,
+        delayMs,
+        archiveThreadId,
+        composeContext,
       });
       onSend({
         id: optimisticId,

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1493,7 +1493,7 @@ function InlineReply({
         composeContext: serializeComposeContext(composeContext),
       })) as IpcResponse<{ id: string; scheduledAt: number }>;
 
-      if (!queued.success || !queued.data) {
+      if (!queued.success) {
         form.setError(queued.error || "Failed to send");
         return;
       }

--- a/src/renderer/components/ScheduleSendButton.tsx
+++ b/src/renderer/components/ScheduleSendButton.tsx
@@ -289,7 +289,9 @@ export function ScheduledMessagesList({ accountId }: { accountId: string }) {
 
   const loadMessages = async () => {
     try {
-      const result = await window.api.scheduledSend.list(accountId);
+      // Scope to 'scheduled': undo-send rows share this table but belong to the
+      // toast, not this dropdown.
+      const result = await window.api.scheduledSend.list(accountId, "scheduled");
       if (result.success) {
         setMessages(result.data);
       }

--- a/src/renderer/components/UndoSendToast.tsx
+++ b/src/renderer/components/UndoSendToast.tsx
@@ -1,103 +1,48 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useAppStore, type UndoSendItem } from "../store";
 
 // Map of item ID → cancel function, so the parent (or keyboard shortcut) can
 // trigger a clean undo on any queued item without race conditions.
 const cancelHandlers = new Map<string, () => void>();
 
+type CancelResponse = {
+  success: boolean;
+  data?: { composeContext?: string; cancelled: boolean };
+  error?: string;
+};
+
 function UndoSendToastItem({ item }: { item: UndoSendItem }) {
   const removeUndoSend = useAppStore((s) => s.removeUndoSend);
-  const [sendError, setSendError] = useState<string | null>(null);
-  const sendTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const sentRef = useRef(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  // The send itself is owned by the main process, so the only local state that
+  // matters is whether the undo window has visually elapsed.
+  const [elapsed, setElapsed] = useState(() => Date.now() >= item.scheduledAt + item.delayMs);
 
-  const doSend = useCallback(async () => {
-    if (sentRef.current) return;
-    sentRef.current = true;
+  const handleUndo = useCallback(async () => {
+    const response = (await window.api.scheduledSend.cancel(item.id)) as CancelResponse;
 
-    try {
-      const response = await window.api.compose.send(item.sendOptions);
-      if (!response.success) {
-        setSendError(response.error);
-        sentRef.current = false;
-        return;
-      }
-
-      // Replace the optimistic "pending-*" email with the real Gmail ID so
-      // background sync won't add a duplicate when it discovers the same message.
-      // Done as a single atomic setState to prevent intermediate states where the
-      // email is removed but not yet re-added (which would unmount any inline
-      // reply editor attached to it).
-      const ctx = item.composeContext;
-      if (ctx?.optimisticEmailId && response.data?.id && !response.data.queued) {
-        const state = useAppStore.getState();
-        const optimistic = state.emails.find((e) => e.id === ctx.optimisticEmailId);
-        if (optimistic) {
-          useAppStore.setState((s) => ({
-            emails: [
-              ...s.emails.filter((e) => e.id !== ctx.optimisticEmailId),
-              { ...optimistic, id: response.data!.id },
-            ],
-            // Update focusedThreadEmailId so subsequent Reply All clicks
-            // don't target the now-removed optimistic email
-            ...(s.focusedThreadEmailId === ctx.optimisticEmailId
-              ? { focusedThreadEmailId: response.data!.id }
-              : {}),
-            // Update inlineReplyToEmailId so the InlineReply component doesn't
-            // unmount when the optimistic email it's targeting gets replaced
-            ...(s.inlineReplyToEmailId === ctx.optimisticEmailId
-              ? { inlineReplyToEmailId: response.data!.id }
-              : {}),
-          }));
-        }
-      }
-    } catch (err) {
-      setSendError(err instanceof Error ? err.message : "Failed to send");
-      sentRef.current = false;
+    if (!response.success) {
+      setCancelError(response.error || "Failed to undo");
       return;
     }
-    if (item.archiveThreadId) {
-      // Optimistically remove the thread from the local store. The IPC handler
-      // only broadcasts sync:emails-removed in the online-success path, so we
-      // can't rely on it for demo mode, offline mode, or the queued path.
-      // Use removeEmailsAndAdvance (not removeEmails) when the archived thread
-      // is currently selected — otherwise split view keeps the now-stale
-      // selection and shows a blank detail pane.
-      const archiveThreadId = item.archiveThreadId;
-      const accountId = item.sendOptions.accountId;
-      const state = useAppStore.getState();
-      const threadEmailIds = state.emails
-        .filter((e) => e.threadId === archiveThreadId && e.accountId === accountId)
-        .map((e) => e.id);
-      if (threadEmailIds.length > 0) {
-        if (state.selectedThreadId === archiveThreadId) {
-          state.removeEmailsAndAdvance(threadEmailIds, null, null);
-        } else {
-          state.removeEmails(threadEmailIds);
-        }
-      }
-      window.api.emails
-        .archiveThread(archiveThreadId, accountId)
-        .catch((err: unknown) => console.error("[Send & Archive] archive failed", err));
-    }
-    cancelHandlers.delete(item.id);
-    removeUndoSend(item.id);
-  }, [item, removeUndoSend]);
 
-  const handleUndo = useCallback(() => {
-    if (sendTimerRef.current) clearTimeout(sendTimerRef.current);
-    sentRef.current = true; // prevent race
+    // Lost the race — the message was already sent. Say so rather than
+    // reopening compose, which would imply the send was recalled.
+    if (!response.data?.cancelled) {
+      setElapsed(true);
+      return;
+    }
+
     cancelHandlers.delete(item.id);
 
     // Reopen compose with the draft content so the user can edit and re-send
     const ctx = item.composeContext;
     if (ctx) {
       const store = useAppStore.getState();
-      // Remove the optimistic "sent" email from the store. On the error path
-      // the send already ran (and failed), so focusedThreadEmailId /
+      // Remove the optimistic "sent" email from the store. focusedThreadEmailId /
       // inlineReplyToEmailId may point at the optimistic ID; null them in the
-      // same setState as the removal to avoid a render that observes a
-      // dangling reference, matching the doSend success path above.
+      // same setState as the removal to avoid a render that observes a dangling
+      // reference.
       if (ctx.optimisticEmailId) {
         const optimisticId = ctx.optimisticEmailId;
         useAppStore.setState((s) => ({
@@ -128,45 +73,36 @@ function UndoSendToastItem({ item }: { item: UndoSendItem }) {
 
   // Register cancel handler so parent / keyboard shortcut can trigger undo
   useEffect(() => {
-    cancelHandlers.set(item.id, handleUndo);
+    cancelHandlers.set(item.id, () => void handleUndo());
     return () => {
       cancelHandlers.delete(item.id);
     };
   }, [item.id, handleUndo]);
 
+  // Hide the Undo affordance once the delay has passed. The send fires in main
+  // regardless of this timer, so it only drives presentation.
   useEffect(() => {
-    const endTime = item.scheduledAt + item.delayMs;
-    const remaining = Math.max(0, endTime - Date.now());
-
-    sendTimerRef.current = setTimeout(() => {
-      doSend();
-    }, remaining);
-
-    return () => {
-      if (sendTimerRef.current) clearTimeout(sendTimerRef.current);
-    };
-  }, [item, doSend]);
+    const remaining = item.scheduledAt + item.delayMs - Date.now();
+    if (remaining <= 0) {
+      setElapsed(true);
+      return;
+    }
+    const timer = setTimeout(() => setElapsed(true), remaining);
+    return () => clearTimeout(timer);
+  }, [item.scheduledAt, item.delayMs]);
 
   return (
     <div className="bg-gray-900 dark:bg-gray-700 text-white rounded-lg shadow-lg flex items-center justify-between px-4 py-3 min-w-[280px]">
       <span className="text-sm">
-        {sendError ? <span className="text-red-400">{sendError}</span> : "Message sent."}
+        {cancelError ? <span className="text-red-400">{cancelError}</span> : "Message sent."}
       </span>
-      {!sentRef.current && !sendError && (
+      {!elapsed && !cancelError && (
         <button
-          onClick={handleUndo}
+          onClick={() => void handleUndo()}
           className="ml-4 text-sm font-medium text-blue-400 hover:text-blue-300 transition-colors flex-shrink-0"
           title={navigator.platform.includes("Mac") ? "Cmd+Z" : "Ctrl+Z"}
         >
           Undo
-        </button>
-      )}
-      {sendError && (
-        <button
-          onClick={handleUndo}
-          className="ml-4 text-sm font-medium text-blue-400 hover:text-blue-300 transition-colors flex-shrink-0"
-        >
-          Edit
         </button>
       )}
     </div>

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import { useAppStore } from "../store";
 import { useSignature } from "./useSignature";
 import { formatAlias } from "../utils/alias-formatting";
+import { serializeComposeContext } from "../utils/undo-send-context";
 import type { ComposeAttachmentItem } from "../components/AttachmentList";
 import type {
   ReplyInfo,
@@ -382,23 +383,40 @@ export function useComposeForm({
     // Check for undo send delay
     const { undoSendDelaySeconds, addUndoSend } = useAppStore.getState();
     if (undoSendDelaySeconds > 0) {
+      const delayMs = undoSendDelaySeconds * 1000;
+      const composeContext = {
+        mode: composeMode,
+        replyToEmailId,
+        threadId: replyInfo?.threadId,
+        bodyHtml,
+        bodyText,
+        to,
+        cc: cc.length > 0 ? cc : undefined,
+        bcc: bcc.length > 0 ? bcc : undefined,
+        subject,
+      };
+
+      // Hand the message to main BEFORE showing the toast. Main owns the timer
+      // and the DB row, so the send survives closing the window mid-delay.
+      const queued = (await window.api.scheduledSend.create({
+        ...sendOptions,
+        scheduledAt: Date.now() + delayMs,
+        kind: "undo",
+        composeContext: serializeComposeContext(composeContext),
+      })) as IpcResponse<{ id: string; scheduledAt: number }>;
+
+      if (!queued.success || !queued.data) {
+        setError(queued.error || "Failed to send");
+        return null;
+      }
+
       addUndoSend({
-        id: crypto.randomUUID(),
+        id: queued.data.id,
         sendOptions,
         recipients: to.join(", "),
-        scheduledAt: Date.now(),
-        delayMs: undoSendDelaySeconds * 1000,
-        composeContext: {
-          mode: composeMode,
-          replyToEmailId,
-          threadId: replyInfo?.threadId,
-          bodyHtml,
-          bodyText,
-          to,
-          cc: cc.length > 0 ? cc : undefined,
-          bcc: bcc.length > 0 ? bcc : undefined,
-          subject,
-        },
+        scheduledAt: queued.data.scheduledAt - delayMs,
+        delayMs,
+        composeContext,
       });
       return "undo-queued";
     }

--- a/src/renderer/hooks/useComposeForm.ts
+++ b/src/renderer/hooks/useComposeForm.ts
@@ -405,7 +405,7 @@ export function useComposeForm({
         composeContext: serializeComposeContext(composeContext),
       })) as IpcResponse<{ id: string; scheduledAt: number }>;
 
-      if (!queued.success || !queued.data) {
+      if (!queued.success) {
         setError(queued.error || "Failed to send");
         return null;
       }

--- a/src/renderer/utils/undo-send-context.ts
+++ b/src/renderer/utils/undo-send-context.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { UndoSendItem } from "../store";
+
+/**
+ * The compose state needed to reopen the editor when a user undoes a send.
+ *
+ * This crosses the IPC boundary as an opaque JSON string — main persists it
+ * without interpreting it — so it gets parsed and validated on the way back in
+ * rather than trusted.
+ */
+const ComposeContextSchema = z.object({
+  mode: z.enum(["new", "reply", "reply-all", "forward"]),
+  replyToEmailId: z.string().optional(),
+  threadId: z.string().optional(),
+  bodyHtml: z.string(),
+  bodyText: z.string(),
+  to: z.array(z.string()),
+  cc: z.array(z.string()).optional(),
+  bcc: z.array(z.string()).optional(),
+  subject: z.string().optional(),
+  optimisticEmailId: z.string().optional(),
+});
+
+export type UndoSendComposeContext = z.infer<typeof ComposeContextSchema>;
+
+export function serializeComposeContext(
+  context: UndoSendItem["composeContext"],
+): string | undefined {
+  if (!context) return undefined;
+  return JSON.stringify(context);
+}
+
+export function parseComposeContext(raw: string | undefined): UndoSendComposeContext | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = ComposeContextSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    // Malformed JSON means we can't restore the editor, but the send itself is
+    // unaffected — degrade to "no context" rather than breaking the toast.
+    return undefined;
+  }
+}
+
+/** Convenience for the sent-broadcast reconciliation path. */
+export function parseOptimisticEmailId(raw: string | undefined): string | undefined {
+  return parseComposeContext(raw)?.optimisticEmailId;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1059,6 +1059,9 @@ export type SnoozedEmail = {
 
 export type ScheduledMessageStatus = "scheduled" | "sending" | "sent" | "failed" | "cancelled";
 
+/** 'scheduled' = user-chosen send-later; 'undo' = the short undo-send delay. */
+export type ScheduledMessageKind = "scheduled" | "undo";
+
 export type ScheduledMessage = {
   id: string;
   accountId: string;
@@ -1073,6 +1076,10 @@ export type ScheduledMessage = {
   inReplyTo?: string;
   references?: string;
   scheduledAt: number; // Unix timestamp in ms
+  kind: ScheduledMessageKind;
+  archiveThreadId?: string;
+  /** Serialized compose state, round-tripped so Undo can reopen the editor. */
+  composeContext?: string;
   status: ScheduledMessageStatus;
   errorMessage?: string;
   createdAt: number;

--- a/tests/e2e/undo-send.spec.ts
+++ b/tests/e2e/undo-send.spec.ts
@@ -460,6 +460,84 @@ test.describe("Undo Send - Forward", () => {
   });
 });
 
+test.describe("Undo Send - Recovered Main-Process Events", () => {
+  test.describe.configure({ mode: "serial" });
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const result = await launchElectronApp(testInfo.workerIndex);
+    electronApp = result.app;
+    page = result.page;
+  });
+
+  test.afterAll(async () => {
+    if (electronApp) {
+      await closeApp(electronApp);
+    }
+  });
+
+  test("a failed recovered undo-send reopens its persisted draft", async () => {
+    const subject = "Recovered failed undo-send";
+    const body = "This draft should survive a failed background send.";
+    const composeContext = JSON.stringify({
+      mode: "new",
+      bodyHtml: `<p>${body}</p>`,
+      bodyText: body,
+      to: ["recipient@example.com"],
+      subject,
+    });
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, payload) => {
+        BrowserWindow.getAllWindows()[0]?.webContents.send("scheduled-send:failed", payload);
+      },
+      {
+        id: "recovered-failed-undo",
+        kind: "undo",
+        composeContext,
+        error: "Injected send failure",
+      },
+    );
+
+    await expect(page.getByText("New Message")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("[placeholder='Subject']")).toHaveValue(subject);
+    await expect(page.locator(".ProseMirror").first()).toContainText(body);
+    await expect(page.getByText(/Your draft has been reopened/)).toBeVisible();
+
+    await closeAnyOpenModal(page);
+  });
+
+  test("a completed delayed send-and-archive removes the thread", async () => {
+    const threadRow = page.locator("div[data-thread-id]").first();
+    await expect(threadRow).toBeVisible({ timeout: 5000 });
+    const threadId = await threadRow.getAttribute("data-thread-id");
+    expect(threadId).toBeTruthy();
+
+    const accountId = await page.evaluate(async () => {
+      const result = await window.api.accounts.list();
+      if (!result.success || !result.data?.[0]) {
+        throw new Error("Demo account was not available");
+      }
+      return result.data[0].id;
+    });
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, payload) => {
+        BrowserWindow.getAllWindows()[0]?.webContents.send("scheduled-send:sent", payload);
+      },
+      {
+        id: "recovered-send-and-archive",
+        kind: "undo",
+        accountId,
+        archiveThreadId: threadId,
+      },
+    );
+
+    await expect(page.locator(`div[data-thread-id="${threadId}"]`)).toHaveCount(0);
+  });
+});
+
 test.describe("Undo Send - Settings Configuration", () => {
   test.describe.configure({ mode: "serial" });
   let electronApp: ElectronApplication;

--- a/tests/migrations/replay.spec.ts
+++ b/tests/migrations/replay.spec.ts
@@ -199,14 +199,20 @@ test.describe("Migration replay + symmetry", () => {
     db.close();
   });
 
-  test("numbered migration versions are sequential starting from 1", () => {
-    // Catches accidental re-numbering or gaps that would break the
-    // forward-only invariant.
+  test("numbered migration versions are strictly increasing and unique", () => {
+    // The forward-only invariant needs versions to be ordered and unique — a
+    // DUPLICATE is the dangerous case, because runNumberedMigrations skips any
+    // version <= the recorded max, so the second migration to claim a number
+    // silently never runs.
+    //
+    // A GAP is tolerated: parallel branches reserve numbers independently, so a
+    // branch can legitimately hold 9 while another holds 8 until both merge.
     const versions = NUMBERED_MIGRATIONS.map((m) => m.version);
     expect(versions).toEqual([...versions].sort((a, b) => a - b));
     expect(versions[0]).toBe(1);
+    expect(new Set(versions).size).toBe(versions.length);
     for (let i = 1; i < versions.length; i++) {
-      expect(versions[i] - versions[i - 1]).toBe(1);
+      expect(versions[i]).toBeGreaterThan(versions[i - 1]);
     }
   });
 });

--- a/tests/unit/scheduled-send-service.spec.ts
+++ b/tests/unit/scheduled-send-service.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "@playwright/test";
+import {
+  ScheduledSendService,
+  type ScheduledSendDependencies,
+} from "../../src/main/services/scheduled-send-service";
+import type { ScheduledMessageRow, ScheduledMessageStatus } from "../../src/main/db";
+import type { GmailClient } from "../../src/main/services/gmail-client";
+
+function scheduledRow(overrides: Partial<ScheduledMessageRow> = {}): ScheduledMessageRow {
+  const now = Date.now();
+  return {
+    id: "scheduled-1",
+    accountId: "account-1",
+    type: "send",
+    to: ["recipient@example.invalid"],
+    subject: "Subject",
+    bodyHtml: "<p>Body</p>",
+    scheduledAt: now - 1,
+    kind: "undo",
+    status: "scheduled",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createHarness(
+  initialRows: ScheduledMessageRow[],
+  options: {
+    online?: boolean;
+    quitFlushTimeout?: number;
+    isNetworkError?: (error: unknown) => boolean;
+  } = {},
+) {
+  const rows = new Map(initialRows.map((row) => [row.id, { ...row }]));
+  let online = options.online ?? true;
+  let claimCount = 0;
+  let setOfflineCount = 0;
+
+  const dependencies: Partial<ScheduledSendDependencies> = {
+    getDueScheduledMessages: (limit = 10) =>
+      [...rows.values()]
+        .filter((row) => row.status === "scheduled" && row.scheduledAt <= Date.now())
+        .slice(0, limit),
+    getNextScheduledMessageTime: () => {
+      const times = [...rows.values()]
+        .filter((row) => row.status === "scheduled")
+        .map((row) => row.scheduledAt);
+      return times.length > 0 ? Math.min(...times) : null;
+    },
+    getScheduledMessages: (accountId, kind) =>
+      [...rows.values()].filter(
+        (row) =>
+          row.status === "scheduled" &&
+          (!accountId || row.accountId === accountId) &&
+          (!kind || row.kind === kind),
+      ),
+    claimScheduledMessage: (id, nextStatus) => {
+      claimCount += 1;
+      const row = rows.get(id);
+      if (!row || row.status !== "scheduled") return null;
+      row.status = nextStatus;
+      return { ...row };
+    },
+    updateScheduledMessageStatus: (id, status, errorMessage) => {
+      const row = rows.get(id);
+      if (!row) return;
+      row.status = status;
+      row.errorMessage = errorMessage;
+    },
+    getScheduledMessageStats: () => ({ scheduled: 0, total: 0 }),
+    network: {
+      get isOnline() {
+        return online;
+      },
+      setOffline() {
+        online = false;
+        setOfflineCount += 1;
+      },
+    },
+    isNetworkError:
+      options.isNetworkError ??
+      ((error) => (error as NodeJS.ErrnoException | undefined)?.code === "ECONNRESET"),
+    now: Date.now,
+    quitFlushTimeout: options.quitFlushTimeout ?? 20,
+  };
+
+  return {
+    service: new ScheduledSendService(dependencies),
+    status(id: string): ScheduledMessageStatus | undefined {
+      return rows.get(id)?.status;
+    },
+    get claimCount() {
+      return claimCount;
+    },
+    get setOfflineCount() {
+      return setOfflineCount;
+    },
+  };
+}
+
+function gmailClient(sendMessage: GmailClient["sendMessage"]): GmailClient {
+  return { sendMessage } as unknown as GmailClient;
+}
+
+test.describe("scheduled send service — retry and shutdown", () => {
+  test("leaves a due message scheduled while the app is offline", async () => {
+    const harness = createHarness([scheduledRow()], { online: false });
+    harness.service.setClientResolver(() =>
+      gmailClient(async () => ({ id: "gmail-1", threadId: "thread-1" })),
+    );
+
+    await harness.service.processDueMessages();
+
+    expect(harness.status("scheduled-1")).toBe("scheduled");
+    expect(harness.claimCount).toBe(0);
+  });
+
+  test("retries a transient network failure instead of failing the message", async () => {
+    const harness = createHarness([scheduledRow()]);
+    let failedEvents = 0;
+    harness.service.on("failed", () => {
+      failedEvents += 1;
+    });
+    harness.service.setClientResolver(() =>
+      gmailClient(async () => {
+        const error = new Error("socket reset") as NodeJS.ErrnoException;
+        error.code = "ECONNRESET";
+        throw error;
+      }),
+    );
+
+    await harness.service.processDueMessages();
+
+    expect(harness.status("scheduled-1")).toBe("scheduled");
+    expect(harness.setOfflineCount).toBe(1);
+    expect(failedEvents).toBe(0);
+  });
+
+  test("keeps a message pending while its account client reconnects", async () => {
+    const harness = createHarness([scheduledRow()]);
+    harness.service.setClientResolver(() => null);
+
+    await harness.service.processDueMessages();
+
+    expect(harness.status("scheduled-1")).toBe("scheduled");
+    expect(harness.claimCount).toBe(0);
+  });
+
+  test("quit aborts and settles an already-active send before returning", async () => {
+    const harness = createHarness([scheduledRow()], { quitFlushTimeout: 20 });
+    let requestStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      requestStarted = resolve;
+    });
+    let abortSettled = false;
+
+    harness.service.setClientResolver(() =>
+      gmailClient(
+        (_options, requestOptions) =>
+          new Promise((_, reject) => {
+            requestStarted();
+            requestOptions.signal?.addEventListener(
+              "abort",
+              () => {
+                setTimeout(() => {
+                  abortSettled = true;
+                  reject(new DOMException("Aborted", "AbortError"));
+                }, 5);
+              },
+              { once: true },
+            );
+          }),
+      ),
+    );
+
+    const processing = harness.service.processDueMessages();
+    await started;
+    expect(harness.status("scheduled-1")).toBe("sending");
+
+    await harness.service.flushPendingNow();
+    await processing;
+
+    expect(abortSettled).toBe(true);
+    expect(harness.status("scheduled-1")).toBe("scheduled");
+  });
+});

--- a/tests/unit/scheduled-send.spec.ts
+++ b/tests/unit/scheduled-send.spec.ts
@@ -322,9 +322,10 @@ test.describe("Scheduled Send - Schema Validation", () => {
     expect(mainCode).toContain("import { scheduledSendService }");
     expect(mainCode).toContain("import { registerScheduledSendIpc }");
     expect(mainCode).toContain("scheduledSendService.setClientResolver");
-    // recoverOnStartup() starts the scheduler and additionally fires rows that
-    // came due while the app was closed.
-    expect(mainCode).toContain("scheduledSendService.recoverOnStartup()");
+    // Recovery must not run in app.whenReady before sync:init connects clients.
+    expect(mainCode).not.toContain("scheduledSendService.recoverOnStartup()");
+    const syncCode = readFileSync(path.join(srcDir, "main/ipc/sync.ipc.ts"), "utf-8");
+    expect(syncCode).toContain("recoverScheduledSendsIfReady()");
     expect(mainCode).toContain("registerScheduledSendIpc()");
     // Pending sends must be flushed before quit, or an in-flight undo delay
     // would be stranded until the next launch.

--- a/tests/unit/scheduled-send.spec.ts
+++ b/tests/unit/scheduled-send.spec.ts
@@ -322,8 +322,13 @@ test.describe("Scheduled Send - Schema Validation", () => {
     expect(mainCode).toContain("import { scheduledSendService }");
     expect(mainCode).toContain("import { registerScheduledSendIpc }");
     expect(mainCode).toContain("scheduledSendService.setClientResolver");
-    expect(mainCode).toContain("scheduledSendService.start()");
+    // recoverOnStartup() starts the scheduler and additionally fires rows that
+    // came due while the app was closed.
+    expect(mainCode).toContain("scheduledSendService.recoverOnStartup()");
     expect(mainCode).toContain("registerScheduledSendIpc()");
+    // Pending sends must be flushed before quit, or an in-flight undo delay
+    // would be stranded until the next launch.
+    expect(mainCode).toContain("flushPendingNow()");
   });
 
   test("store has scheduled message stats state", () => {

--- a/tests/unit/scheduled-send.spec.ts
+++ b/tests/unit/scheduled-send.spec.ts
@@ -316,8 +316,12 @@ test.describe("Scheduled Send - Schema Validation", () => {
     expect(preloadCode).toContain("removeAllListeners");
   });
 
-  test("service is registered and started in main/index.ts", () => {
+  test("service is registered in main and starts after sync initializes", () => {
     const mainCode = readFileSync(path.join(srcDir, "main/index.ts"), "utf-8");
+    const serviceCode = readFileSync(
+      path.join(srcDir, "main/services/scheduled-send-service.ts"),
+      "utf-8",
+    );
 
     expect(mainCode).toContain("import { scheduledSendService }");
     expect(mainCode).toContain("import { registerScheduledSendIpc }");
@@ -330,6 +334,8 @@ test.describe("Scheduled Send - Schema Validation", () => {
     // Pending sends must be flushed before quit, or an in-flight undo delay
     // would be stranded until the next launch.
     expect(mainCode).toContain("flushPendingNow()");
+    // The quit flush must never pull user-selected send-later rows forward.
+    expect(serviceCode).toContain('getScheduledMessages(undefined, "undo")');
   });
 
   test("store has scheduled message stats state", () => {

--- a/tests/unit/undo-send-persistence.spec.ts
+++ b/tests/unit/undo-send-persistence.spec.ts
@@ -249,17 +249,17 @@ test.describe("undo-send persistence — recovery and flush", () => {
     db.close();
   });
 
-  test("flush selects every pending row regardless of remaining delay", () => {
+  test("quit flush selects only undo-send rows regardless of remaining delay", () => {
     const db = freshDb();
     seed(db, { id: "f1", scheduledAt: Date.now() + 15_000 });
     seed(db, { id: "f2", scheduledAt: Date.now() + 3_600_000, kind: "scheduled" });
     seed(db, { id: "f3", scheduledAt: Date.now() - 1, status: "sent" });
 
-    // flushPendingNow() uses getScheduledMessages() — all pending, no time filter.
+    // User-chosen send-later rows retain their due time across app quits.
     const pending = db
-      .prepare("SELECT id FROM scheduled_messages WHERE status = 'scheduled'")
+      .prepare("SELECT id FROM scheduled_messages WHERE status = 'scheduled' AND kind = 'undo'")
       .all() as Array<{ id: string }>;
-    expect(pending.map((r) => r.id).sort()).toEqual(["f1", "f2"]);
+    expect(pending.map((r) => r.id)).toEqual(["f1"]);
     db.close();
   });
 

--- a/tests/unit/undo-send-persistence.spec.ts
+++ b/tests/unit/undo-send-persistence.spec.ts
@@ -1,0 +1,388 @@
+/**
+ * Unit tests for persisted undo-send.
+ *
+ * The undo-send delay used to be a setTimeout inside a React component, so
+ * closing the window mid-delay silently dropped the message. It now shares the
+ * scheduled_messages table and the main-process scheduler. These tests cover the
+ * behaviours that make that safe: the schema/migration, the cancel-vs-fire race
+ * guard, the due/next-due queries that drive recovery and flush, and the
+ * send-later regressions that the unification could have broken.
+ *
+ * Run with: npx playwright test tests/unit/undo-send-persistence.spec.ts
+ */
+import { test, expect } from "@playwright/test";
+import { createRequire } from "module";
+import type BetterSqlite3 from "better-sqlite3";
+import { runMigrations, NUMBERED_MIGRATIONS } from "../../src/main/db/migrations";
+import { SCHEMA } from "../../src/main/db/schema";
+
+const require = createRequire(import.meta.url);
+
+type DB = BetterSqlite3.Database;
+let DatabaseCtor:
+  | (new (filename: string | Buffer, options?: BetterSqlite3.Options) => DB)
+  | null = null;
+let nativeModuleError: string | null = null;
+try {
+  DatabaseCtor = require("better-sqlite3");
+  const probe = new DatabaseCtor!(":memory:");
+  probe.close();
+} catch (e: unknown) {
+  const msg = e instanceof Error ? e.message : String(e);
+  if (msg.includes("NODE_MODULE_VERSION") || msg.includes("did not self-register")) {
+    nativeModuleError = msg.split("\n")[0];
+  } else {
+    throw e;
+  }
+}
+
+test.beforeEach(() => {
+  if (nativeModuleError) {
+    test.skip(true, `better-sqlite3 native module mismatch: ${nativeModuleError}`);
+  }
+});
+
+function freshDb(): DB {
+  if (!DatabaseCtor) throw new Error("better-sqlite3 not loadable");
+  const db = new DatabaseCtor(":memory:");
+  db.pragma("journal_mode = MEMORY");
+  db.exec(SCHEMA);
+  runMigrations(db);
+  // scheduled_messages.account_id is a FK to accounts.
+  db.prepare(
+    "INSERT INTO accounts (id, email, display_name, is_primary, added_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("acc-1", "test@example.invalid", "Test", 1, Date.now());
+  return db;
+}
+
+type SeedOptions = {
+  id: string;
+  scheduledAt: number;
+  kind?: "scheduled" | "undo";
+  status?: string;
+  attachments?: string;
+  composeContext?: string;
+  archiveThreadId?: string;
+  createdAt?: number;
+};
+
+function seed(db: DB, opts: SeedOptions): void {
+  const now = opts.createdAt ?? Date.now();
+  db.prepare(
+    `INSERT INTO scheduled_messages (
+       id, account_id, type, thread_id, to_addresses, subject, body_html,
+       attachments, scheduled_at, kind, archive_thread_id, compose_context,
+       status, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    opts.id,
+    "acc-1",
+    "send",
+    null,
+    JSON.stringify(["someone@example.invalid"]),
+    "Subject",
+    "<p>Body</p>",
+    opts.attachments ?? null,
+    opts.scheduledAt,
+    opts.kind ?? "undo",
+    opts.archiveThreadId ?? null,
+    opts.composeContext ?? null,
+    opts.status ?? "scheduled",
+    now,
+    now,
+  );
+}
+
+/**
+ * Mirrors claimScheduledMessage() in db/index.ts. The production helper needs an
+ * initialized Electron-bound singleton, so the SQL is replicated here to test the
+ * guarantee it relies on: the conditional UPDATE is indivisible.
+ */
+function claim(db: DB, id: string, nextStatus: string): boolean {
+  const result = db
+    .prepare(
+      `UPDATE scheduled_messages SET status = ?, updated_at = ?
+       WHERE id = ? AND status = 'scheduled'`,
+    )
+    .run(nextStatus, Date.now(), id);
+  return result.changes > 0;
+}
+
+test.describe("undo-send persistence — schema", () => {
+  test("scheduled_messages carries the columns undo-send needs", () => {
+    const db = freshDb();
+    const cols = new Set(
+      (db.prepare("PRAGMA table_info(scheduled_messages)").all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    for (const col of ["attachments", "kind", "archive_thread_id", "compose_context"]) {
+      expect(cols.has(col), `scheduled_messages should have ${col}`).toBe(true);
+    }
+    db.close();
+  });
+
+  test("migration version is unique — a collision would silently skip it", () => {
+    // Migrations are forward-only and keyed by version number: if two branches
+    // ship the same number, whichever lands second never runs on a DB that
+    // already recorded that version, and its columns go missing at runtime.
+    const versions = NUMBERED_MIGRATIONS.map((m) => m.version);
+    expect(new Set(versions).size).toBe(versions.length);
+  });
+
+  test("migration adds the columns to a pre-existing DB and defaults kind to 'scheduled'", () => {
+    const db = freshDb();
+
+    // Reconstruct the old shape: drop the new columns, keep a legacy row.
+    db.exec("DROP TABLE scheduled_messages");
+    db.exec(`
+      CREATE TABLE scheduled_messages (
+        id TEXT PRIMARY KEY, account_id TEXT NOT NULL, type TEXT NOT NULL,
+        thread_id TEXT, from_address TEXT, to_addresses TEXT NOT NULL,
+        cc_addresses TEXT, bcc_addresses TEXT, subject TEXT NOT NULL,
+        body_html TEXT NOT NULL, body_text TEXT, in_reply_to TEXT,
+        references_header TEXT, scheduled_at INTEGER NOT NULL,
+        status TEXT DEFAULT 'scheduled', error_message TEXT,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, sent_at INTEGER
+      )
+    `);
+    // The recreated table above intentionally omits the FK, matching the
+    // pre-migration shape closely enough for this test.
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO scheduled_messages
+         (id, account_id, type, to_addresses, subject, body_html, scheduled_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("legacy-1", "acc-1", "send", '["a@b.invalid"]', "Old", "<p>x</p>", now, now, now);
+
+    // Re-run only the undo-send migration by resetting the recorded version.
+    db.prepare("DELETE FROM schema_version WHERE version >= 9").run();
+    runMigrations(db);
+
+    const cols = new Set(
+      (db.prepare("PRAGMA table_info(scheduled_messages)").all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      ),
+    );
+    expect(cols.has("attachments")).toBe(true);
+    expect(cols.has("kind")).toBe(true);
+
+    // Pre-existing rows are send-later, never undo.
+    const row = db.prepare("SELECT kind FROM scheduled_messages WHERE id = ?").get("legacy-1") as {
+      kind: string;
+    };
+    expect(row.kind).toBe("scheduled");
+    db.close();
+  });
+});
+
+test.describe("undo-send persistence — cancel vs. fire race", () => {
+  test("cancel before the send claims the row wins, and the send is skipped", () => {
+    const db = freshDb();
+    seed(db, { id: "u1", scheduledAt: Date.now() + 15_000 });
+
+    // User hits Undo first.
+    expect(claim(db, "u1", "cancelled")).toBe(true);
+    // The timer then fires and tries to claim — must lose.
+    expect(claim(db, "u1", "sending")).toBe(false);
+
+    const row = db.prepare("SELECT status FROM scheduled_messages WHERE id = ?").get("u1") as {
+      status: string;
+    };
+    expect(row.status).toBe("cancelled");
+    db.close();
+  });
+
+  test("cancel after the send has claimed the row loses and does not double-send", () => {
+    const db = freshDb();
+    seed(db, { id: "u2", scheduledAt: Date.now() - 1 });
+
+    // Timer fires first.
+    expect(claim(db, "u2", "sending")).toBe(true);
+    // Undo arrives late — must not flip a message that is already going out.
+    expect(claim(db, "u2", "cancelled")).toBe(false);
+
+    const row = db.prepare("SELECT status FROM scheduled_messages WHERE id = ?").get("u2") as {
+      status: string;
+    };
+    expect(row.status).toBe("sending");
+    db.close();
+  });
+
+  test("only one of two concurrent claims can succeed", () => {
+    const db = freshDb();
+    seed(db, { id: "u3", scheduledAt: Date.now() });
+    const results = [claim(db, "u3", "sending"), claim(db, "u3", "cancelled")];
+    expect(results.filter(Boolean)).toHaveLength(1);
+    db.close();
+  });
+});
+
+test.describe("undo-send persistence — recovery and flush", () => {
+  const dueQuery = `SELECT id FROM scheduled_messages
+                    WHERE status = 'scheduled' AND scheduled_at <= ?
+                    ORDER BY scheduled_at ASC`;
+
+  test("a row that came due while the app was closed is picked up as due", () => {
+    const db = freshDb();
+    // Persisted 15s undo whose deadline passed while the process was gone.
+    seed(db, { id: "past", scheduledAt: Date.now() - 60_000 });
+    const due = db.prepare(dueQuery).all(Date.now()) as Array<{ id: string }>;
+    expect(due.map((r) => r.id)).toContain("past");
+    db.close();
+  });
+
+  test("a row still inside its delay is not due yet", () => {
+    const db = freshDb();
+    seed(db, { id: "future", scheduledAt: Date.now() + 15_000 });
+    const due = db.prepare(dueQuery).all(Date.now()) as Array<{ id: string }>;
+    expect(due.map((r) => r.id)).not.toContain("future");
+    db.close();
+  });
+
+  test("cancelled and sent rows are never recovered", () => {
+    const db = freshDb();
+    seed(db, { id: "c1", scheduledAt: Date.now() - 1000, status: "cancelled" });
+    seed(db, { id: "s1", scheduledAt: Date.now() - 1000, status: "sent" });
+    const due = db.prepare(dueQuery).all(Date.now()) as Array<{ id: string }>;
+    expect(due).toHaveLength(0);
+    db.close();
+  });
+
+  test("flush selects every pending row regardless of remaining delay", () => {
+    const db = freshDb();
+    seed(db, { id: "f1", scheduledAt: Date.now() + 15_000 });
+    seed(db, { id: "f2", scheduledAt: Date.now() + 3_600_000, kind: "scheduled" });
+    seed(db, { id: "f3", scheduledAt: Date.now() - 1, status: "sent" });
+
+    // flushPendingNow() uses getScheduledMessages() — all pending, no time filter.
+    const pending = db
+      .prepare("SELECT id FROM scheduled_messages WHERE status = 'scheduled'")
+      .all() as Array<{ id: string }>;
+    expect(pending.map((r) => r.id).sort()).toEqual(["f1", "f2"]);
+    db.close();
+  });
+
+  test("next-due time is the earliest pending row, which drives precise timing", () => {
+    const db = freshDb();
+    const base = Date.now();
+    // A 15s undo queued behind a send-later an hour out must not wait an hour.
+    seed(db, { id: "later", scheduledAt: base + 3_600_000, kind: "scheduled" });
+    seed(db, { id: "undo", scheduledAt: base + 15_000 });
+
+    const row = db
+      .prepare("SELECT MIN(scheduled_at) as next FROM scheduled_messages WHERE status = 'scheduled'")
+      .get() as { next: number };
+    expect(row.next).toBe(base + 15_000);
+
+    // The old 30s poll would have overshot a 15s delay; the computed sleep must not.
+    const MAX_SLEEP = 30_000;
+    const sleep = Math.min(Math.max(row.next - base, 0), MAX_SLEEP);
+    expect(sleep).toBe(15_000);
+    db.close();
+  });
+
+  test("long-horizon rows clamp to the max sleep so they re-arm periodically", () => {
+    const db = freshDb();
+    const base = Date.now();
+    seed(db, { id: "far", scheduledAt: base + 7 * 24 * 3_600_000, kind: "scheduled" });
+    const row = db
+      .prepare("SELECT MIN(scheduled_at) as next FROM scheduled_messages WHERE status = 'scheduled'")
+      .get() as { next: number };
+    const sleep = Math.min(Math.max(row.next - base, 0), 30_000);
+    expect(sleep).toBe(30_000);
+    db.close();
+  });
+});
+
+test.describe("undo-send persistence — payload round-trip", () => {
+  test("composeContext survives the round-trip so Undo can reopen compose", () => {
+    const db = freshDb();
+    const context = JSON.stringify({
+      mode: "reply",
+      bodyHtml: "<p>hi</p>",
+      bodyText: "hi",
+      to: ["a@b.invalid"],
+      subject: "Re: test",
+      optimisticEmailId: "pending-123",
+    });
+    seed(db, { id: "ctx", scheduledAt: Date.now() + 15_000, composeContext: context });
+
+    const row = db
+      .prepare("SELECT compose_context as ctx FROM scheduled_messages WHERE id = ?")
+      .get("ctx") as { ctx: string };
+    const parsed = JSON.parse(row.ctx) as { optimisticEmailId: string; subject: string };
+    expect(parsed.optimisticEmailId).toBe("pending-123");
+    expect(parsed.subject).toBe("Re: test");
+    db.close();
+  });
+
+  test("archiveThreadId round-trips for send-and-archive", () => {
+    const db = freshDb();
+    seed(db, { id: "arch", scheduledAt: Date.now() + 15_000, archiveThreadId: "thread-9" });
+    const row = db
+      .prepare("SELECT archive_thread_id as t FROM scheduled_messages WHERE id = ?")
+      .get("arch") as { t: string };
+    expect(row.t).toBe("thread-9");
+    db.close();
+  });
+});
+
+test.describe("send-later regressions (unification must not break it)", () => {
+  test("attachments now persist — previously dropped by scheduled send", () => {
+    const db = freshDb();
+    const attachments = JSON.stringify([
+      { filename: "report.pdf", mimeType: "application/pdf", size: 1024 },
+    ]);
+    seed(db, { id: "att", scheduledAt: Date.now() + 60_000, kind: "scheduled", attachments });
+
+    const row = db
+      .prepare("SELECT attachments FROM scheduled_messages WHERE id = ?")
+      .get("att") as { attachments: string };
+    const parsed = JSON.parse(row.attachments) as Array<{ filename: string }>;
+    expect(parsed[0].filename).toBe("report.pdf");
+    db.close();
+  });
+
+  test("send-later rows fire through the same due query as undo rows", () => {
+    const db = freshDb();
+    seed(db, { id: "sl", scheduledAt: Date.now() - 1000, kind: "scheduled" });
+    const due = db
+      .prepare(
+        `SELECT id, kind FROM scheduled_messages WHERE status = 'scheduled' AND scheduled_at <= ?`,
+      )
+      .all(Date.now()) as Array<{ id: string; kind: string }>;
+    expect(due).toHaveLength(1);
+    expect(due[0].kind).toBe("scheduled");
+    db.close();
+  });
+
+  test("the send-later badge ignores in-flight undo sends", () => {
+    const db = freshDb();
+    seed(db, { id: "undo-1", scheduledAt: Date.now() + 15_000, kind: "undo" });
+    seed(db, { id: "sched-1", scheduledAt: Date.now() + 3_600_000, kind: "scheduled" });
+
+    const stats = db
+      .prepare(
+        `SELECT COUNT(*) as c FROM scheduled_messages
+         WHERE status IN ('scheduled','sending') AND kind = 'scheduled'`,
+      )
+      .get() as { c: number };
+    expect(stats.c).toBe(1);
+    db.close();
+  });
+
+  test("cancelling a send-later row is still distinguishable from an undo row", () => {
+    const db = freshDb();
+    seed(db, { id: "sl-cancel", scheduledAt: Date.now() + 60_000, kind: "scheduled" });
+    expect(claim(db, "sl-cancel", "cancelled")).toBe(true);
+    const row = db
+      .prepare("SELECT kind, status FROM scheduled_messages WHERE id = ?")
+      .get("sl-cancel") as { kind: string; status: string };
+    // kind drives the cancel policy: 'scheduled' creates a Gmail draft,
+    // 'undo' returns composeContext instead.
+    expect(row.kind).toBe("scheduled");
+    expect(row.status).toBe("cancelled");
+    db.close();
+  });
+});

--- a/tests/unit/undo-send.spec.ts
+++ b/tests/unit/undo-send.spec.ts
@@ -27,8 +27,10 @@ function extractComposeContextBlocks(
   const results: Array<{ file: string; startLine: number; block: string }> = [];
 
   for (let i = 0; i < lines.length; i++) {
-    // Look for `composeContext: {`
-    if (/composeContext\s*:\s*\{/.test(lines[i])) {
+    // Matches both the inline `composeContext: {` form and the hoisted
+    // `const composeContext = {` form (used since the context is built once and
+    // then both serialized for main and kept for the local store item).
+    if (/composeContext\s*[:=]\s*\{/.test(lines[i])) {
       let braceCount = 0;
       let started = false;
       let block = "";


### PR DESCRIPTION
## What this fixes

Undo-send used a renderer-side timer. If the window closed, the app quit, or the process crashed during the delay, the message disappeared because it had never reached the main process or database.

## How it works

Undo-send now stores the pending message in `scheduled_messages` and runs through the existing main-process send-later scheduler.

- The scheduler wakes at the next due time, so a 15-second undo delay is not held up by the old 30-second polling interval.
- Startup recovery sends overdue rows, and quit flushes pending sends before the database closes.
- An atomic claim makes cancel and send mutually exclusive when they race.
- The renderer toast only displays the countdown and sends cancellation requests over IPC.

The shared scheduler distinguishes undo-send from send-later so cancellation can reopen compose for one and create a Gmail draft for the other.

This also fixes two existing send-later bugs: attachments were not persisted, and scheduled messages could fire up to 30 seconds late. Undo-send rows are excluded from the send-later list and badge.

Migration v9 is intentional. Version 8 is already claimed by a concurrent branch, and reusing it could cause this migration to be skipped on databases that have applied the other v8.

## Verification

- `npx tsc --noEmit -p tsconfig.node.json`
- `npx tsc --noEmit -p tsconfig.web.json`
- 1,514 unit tests
- 8/8 `tests/e2e/undo-send.spec.ts`
- `npm run build`

The new persistence tests cover cancel/send races, startup recovery, quit flushing, timer precision, payload round-tripping, attachment persistence, and send-later UI scoping.

Real Gmail verification and the full `npm run pre-pr` suite have not been run, so this remains a draft.